### PR TITLE
Implements client API for export and download of artifacts

### DIFF
--- a/vdb-bench-assembly/bower.json
+++ b/vdb-bench-assembly/bower.json
@@ -33,7 +33,8 @@
     "angularUtils-pagination": "angular-utils-pagination#~0.9.2",
     "angular-dashboard-framework": "^0.11.0",
     "adf-structures-base": "^0.1.1",
-    "d3pie": "^0.1.9"
+    "d3pie": "^0.1.9",
+    "angular-file-saver": "^1.1.1"
   },
   "devDependencies": {
     "bootstrap": "~3.3.5",

--- a/vdb-bench-assembly/index.html
+++ b/vdb-bench-assembly/index.html
@@ -93,6 +93,7 @@
     <script src="libs/angular-animate/angular-animate.js"></script>
     <script src="libs/angularUtils-pagination/dirPagination.js"></script>
     <script src="libs/d3pie/d3pie/d3pie.js"></script>
+    <script src="libs/angular-file-saver/dist/angular-file-saver.bundle.js"></script>
 
     <!-- dependencies for angular-dashboard-framework -->
     <script src="libs/Sortable/Sortable.js"></script>

--- a/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
@@ -149,6 +149,38 @@
         };
 
         /**
+         * Service: Export the given artifact
+         * Returns: promise object for the exported item
+         */
+        service.export = function(artifact, storageType) {
+            if (!artifact || !storageType)
+                return null;
+
+            var url = REST_URI.IMPORT_EXPORT + REST_URI.EXPORT;
+
+            return getRestService().then(function (restService) {
+                var payload = {
+                    "dataPath": artifact[VDB_KEYS.DATA_PATH],
+                    "storageType": storageType
+                };
+
+                // Posts should always be made on collection (all) not elements (one)
+                return restService.all(url).post(payload);
+            });
+        };
+
+        /**
+         * Service: Download the given artifact. Uses the file storage connector.
+         * Returns: promise object for the downloaded item
+         */
+        service.download = function(artifact) {
+            if (!artifact)
+                return null;
+
+            return service.export(artifact, 'file');
+        };
+
+        /**
          * Service: return the list of translators.
                          If serviceType is wksp then 'vdbName' is required.
          * Returns: promise object for the translator collection

--- a/vdb-bench-assembly/plugins/vdb-bench-core/constants.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/constants.js
@@ -57,6 +57,8 @@
             DATA_KOMODO: 'tko:komodo',
             DATA_WORKSPACE: 'tko:workspace',
             STATUS: '/status',
+            IMPORT_EXPORT: '/importexport',
+            EXPORT: '/export',
             //
             // Types used for whether a teiid vdb
             // is being requested or a workspace
@@ -69,6 +71,7 @@
         .constant('VDB_KEYS', {
             VDBS: 'vdbs',
             ID: 'keng__id',
+            DATA_PATH: 'keng__dataPath',
             DESCRIPTION: 'keng__description',
             TYPE: 'keng__kType',
             LINKS: {

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/vdb-bench.widgets.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/vdb-bench.widgets.js
@@ -15,6 +15,7 @@
         'angularUtils.directives.dirPagination',
         'ui.codemirror',
         'prettyXml',
+        'ngFileSaver',
 
         /*
          * Everybody has access to these.

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/vdbList.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/vdbList.html
@@ -6,6 +6,7 @@
             <div class="pull-right" uib-dropdown ng-show="vm.hasButtons()">
                 <button type="button" class="glyphicon glyphicon-plus vdb-heading-btn" uib-dropdown-toggle ng-click="vm.onAddClicked($event)"></button>
                 <button type="button" class="glyphicon glyphicon-minus vdb-heading-btn" uib-dropdown-toggle ng-click="vm.onRemoveClicked($event)"></button>
+                <button type="button" class="glyphicon glyphicon-export vdb-heading-btn" uib-dropdown-toggle ng-click="vm.onExportClicked($event)"></button>
             </div>
         </uib-accordion-heading>
         <div ng-show="vm.init">


### PR DESCRIPTION
- RepositoryRestService
  - Export and Download functions that allow for downloading of an
    Exportable artefact from the server to the client
- Uses ngFileSaver for converting a json blob into a saveable file that
  triggers the browser SaveAs dialog
- Added to vdbList for test/demo purposes
