### PR TITLE
Fixes base64 decoding issues by including a full DownloadService

### DIFF
--- a/vdb-bench-assembly/bower.json
+++ b/vdb-bench-assembly/bower.json
@@ -34,7 +34,8 @@
     "angular-dashboard-framework": "^0.11.0",
     "adf-structures-base": "^0.1.1",
     "d3pie": "^0.1.9",
-    "angular-file-saver": "^1.1.1"
+    "angular-file-saver": "^1.1.1",
+    "angular-base64": "^2.0.5"
   },
   "devDependencies": {
     "bootstrap": "~3.3.5",

--- a/vdb-bench-assembly/index.html
+++ b/vdb-bench-assembly/index.html
@@ -94,6 +94,7 @@
     <script src="libs/angularUtils-pagination/dirPagination.js"></script>
     <script src="libs/d3pie/d3pie/d3pie.js"></script>
     <script src="libs/angular-file-saver/dist/angular-file-saver.bundle.js"></script>
+    <script src="libs/angular-base64/angular-base64.js"></script>
 
     <!-- dependencies for angular-dashboard-framework -->
     <script src="libs/Sortable/Sortable.js"></script>
@@ -115,6 +116,7 @@
     <script src="plugins/vdb-bench-core/RepositoryRestService.js"></script>
     <script src="plugins/vdb-bench-core/RepositorySelectionService.js"></script>
     <script src="plugins/vdb-bench-core/VdbSelectionService.js"></script>
+    <script src="plugins/vdb-bench-core/DownloadService.js"></script>
     <!-- endinject -->
 
     <!-- vdb-bench-widgets -->

--- a/vdb-bench-assembly/plugins/vdb-bench-core/DownloadService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/DownloadService.js
@@ -1,0 +1,112 @@
+/**
+ * Download (Export) Service
+ *
+ * Provides simple API for downloading content from the engine
+ * and inviting the user to save it to their client filesystem.
+ */
+(function () {
+
+    'use strict';
+
+    angular
+        .module('vdb-bench.core')
+        .factory('DownloadService', DownloadService);
+
+    DownloadService.$inject = ['SYNTAX', 'REST_URI', 'VDB_SCHEMA', 'VDB_KEYS',
+                                              'RepoRestService', 'FileSaver', 'Blob', '$base64'];
+
+    function DownloadService(SYNTAX, REST_URI, VDB_SCHEMA, VDB_KEYS,
+                                            RepoRestService, FileSaver, Blob, $base64) {
+
+        /*
+         * Service instance to be returned
+         */
+        var service = {};
+
+        /*
+         * Converts a base64 data string into a blob for use with the FileSaver library
+         * Acknowledgement to
+         * http://stackoverflow.com/questions/16245767/creating-a-blob-from-a-base64-string-in-javascript
+         */
+        function b64toBlob(b64Data, contentType, sliceSize) {
+            contentType = contentType || '';
+            sliceSize = sliceSize || 512;
+
+            //
+            // Decodes the base64 string back into binary data byte characters
+            //
+            var byteCharacters = $base64.decode(b64Data);
+            var byteArrays = [];
+
+            //
+            // Each character's code point (charCode) will be the value of the byte.
+            // Can create an array of byte values by applying this using the .charCodeAt
+            // method for each character in the string.
+            //
+            // The performance can be improved a little by processing the byteCharacters
+            // in smaller slices, rather than all at once. Rough testing indicates 512 bytes
+            // seems to be a good slice size.
+            //
+            for (var offset = 0; offset < byteCharacters.length; offset += sliceSize) {
+                var slice = byteCharacters.slice(offset, offset + sliceSize);
+
+                var byteNumbers = new Array(slice.length);
+                for (var i = 0; i < slice.length; i++) {
+                    byteNumbers[i] = slice.charCodeAt(i);
+                }
+
+                //
+                // Convert the array of byte values into a real typed byte array
+                // by passing it to the Uint8Array constructor.
+                //
+                var byteArray = new Uint8Array(byteNumbers);
+
+                byteArrays.push(byteArray);
+            }
+
+            //
+            // Convert to a Blob by wrapping it in an array passing it to the Blob constructor.
+            //
+            var blob = new Blob(byteArrays, {
+                type: contentType
+            });
+            return blob;
+        }
+
+        /**
+         * Service: download the given content from the rest service
+         *              and offer it as a file to be saved.
+         */
+        service.download = function (dwnldableObj) {
+            if (! dwnldableObj)
+                return;
+
+            try {
+                RepoRestService.download(dwnldableObj).then(
+                    function (exportStatus) {
+                        if (! exportStatus.downloadable)
+                            return;
+
+                        if (! exportStatus.content)
+                            return;
+
+                        var name = exportStatus.name || dwnldableObj.keng__id;
+                        var fileType = exportStatus.type || 'data';
+                        var enc = exportStatus.content;
+
+                        var contentType = fileType === "zip" ? 'application/zip' : 'text/plain;charset=utf-8';                        
+                        var dataBlob = b64toBlob(enc, contentType);
+
+                        FileSaver.saveAs(dataBlob, name + SYNTAX.DOT + fileType);
+                    },
+                    function (response) {
+                        throw new RepoRestService.newRestException("Failed to export the artifact ");
+                    });
+            } catch (error) {} finally {
+            }            
+        };
+
+        return service;
+    }
+
+})();

--- a/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
@@ -13,9 +13,9 @@
 
     RepoRestService.$inject = ['SYNTAX', 'REST_URI', 'VDB_SCHEMA',
                                              'VDB_KEYS', 'RepoSelectionService', 'Restangular',
-                                             '$http', '$q'];
+                                             '$http', '$q', '$base64'];
 
-    function RepoRestService(SYNTAX, REST_URI, VDB_SCHEMA, VDB_KEYS, RepoSelectionService, Restangular, $http, $q) {
+    function RepoRestService(SYNTAX, REST_URI, VDB_SCHEMA, VDB_KEYS, RepoSelectionService, Restangular, $http, $q, $base64) {
 
         /*
          * Service instance to be returned
@@ -165,7 +165,7 @@
                     "storageType": storageType,
                     "documentType": documentType,
                     "parameters" : parameters,
-                    "content" : btoa(data)
+                    "content" : $base64.encode(data)
                 };
 
                 // Posts should always be made on collection (all) not elements (one)

--- a/vdb-bench-assembly/plugins/vdb-bench-core/vdb-bench.core.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/vdb-bench.core.js
@@ -5,7 +5,8 @@
         /*
          * Angular modules
          */
-        'restangular'
+        'restangular',
+        'base64'
 
         /*
          * Our reusable cross app code modules

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/fileImportControl.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/fileImportControl.js
@@ -9,7 +9,7 @@
         .directive('fileImportControl', FileImportControl);
 
     FileImportControl.$inject = ['CONFIG', 'SYNTAX'];
-    FileImportController.$inject = ['$scope', 'SYNTAX', 'RepoRestService', 'FileSaver', 'Blob', '$window'];
+    FileImportController.$inject = ['$scope', 'SYNTAX', 'RepoRestService', '$window'];
 
     function FileImportControl(config, syntax) {
         var directive = {
@@ -30,7 +30,7 @@
         return directive;
     }
 
-    function FileImportController($scope, SYNTAX, RepoRestService, FileSaver, Blob, $window) {
+    function FileImportController($scope, SYNTAX, RepoRestService, $window) {
         var vm = this;
 
         vm.showProgress = function(display) {

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/vdbList.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/vdbList.js
@@ -11,7 +11,7 @@
     VdbList.$inject = ['CONFIG', 'SYNTAX'];
     VdbListController.$inject = ['VdbSelectionService', 'RepoRestService',
                                                 'REST_URI', 'SYNTAX', 'VDB_KEYS',
-                                                'FileSaver', 'Blob', '$window', '$scope'];
+                                                'DownloadService', '$scope'];
 
     function VdbList(config, syntax) {
         var directive = {
@@ -34,7 +34,7 @@
 
     function VdbListController(VdbSelectionService, RepoRestService,
                                             REST_URI, SYNTAX, VDB_KEYS,
-                                            FileSaver, Blob, $window, $scope) {
+                                            DownloadService, $scope) {
         var vm = this;
 
         vm.vdbs = [];
@@ -171,31 +171,7 @@
         vm.onExportClicked = function(event) {
             var selected = VdbSelectionService.selected();
             try {
-                RepoRestService.download(selected).then(
-                    function (exportStatus) {
-                        if (! exportStatus.downloadable)
-                            return;
-
-                        if (! exportStatus.content)
-                            return;
-
-                        var enc = exportStatus.content;
-                        var content = atob(enc);
-                        var data = new Blob([content], { type: 'text/plain;charset=utf-8' });
-
-                        var name = exportStatus.name;
-                        if (_.isEmpty(name))
-                            name = 'export';
-
-                        var type = exportStatus.type;
-                        if (_.isEmpty(type))
-                            type = 'txt';
-
-                        FileSaver.saveAs(data, name + SYNTAX.DOT + type);
-                    },
-                    function (response) {
-                        throw new RepoRestService.newRestException("Failed to export the artifact " + selected[VDB_KEYS.ID] + " from the host services.\n" + response.data.error);
-                    });
+                DownloadService.download(selected);
             } catch (error) {} finally {
                 // Essential to stop the accordion closing
                 event.stopPropagation();


### PR DESCRIPTION
- base64 strings need to be properly converted to binary byte arrays prior
  to being wrapped by a Blob object. The b64toBlob function in the
  DownloadService is responsible for this.
- bower.json
  - Advised by internet not to rely on atob and btoa
- DownloadService
  - Encapsulates the functionality of downloading a komodo object using the
    rest service to save as a file
  - Provides a converter for getting a base64 string into a Blob object
- dataserviceController
- vdbList
  - Defers downloading of objects to the DownloadService
