### PR TITLE
Fixes pfToolbar testing

### DIFF
--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/pftoolbar.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/pftoolbar.html
@@ -10,18 +10,18 @@
         <div pf-list-view config="vm.listConfig" items="vm.items">
           <div class="list-view-pf-description">
             <div class="list-group-item-heading">
-              {{vm.item.name}}
+              {{item.name}}
             </div>
             <div class="list-group-item-text">
-              {{vm.item.address}}
+              {{item.address}}
             </div>
           </div>
           <div class="list-view-pf-additional-info">
             <div class="list-view-pf-additional-info-item">
-              {{vm.item.age}}
+              {{item.age}}
             </div>
             <div class="list-view-pf-additional-info-item">
-              {{vm.item.birthMonth}}
+              {{item.birthMonth}}
             </div>
           </div>
         </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/pftoolbar.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/pftoolbar.js
@@ -8,9 +8,9 @@
         .module(pluginName)
         .controller('PfViewController', PfViewController);
 
-    PfViewController.$inject = ['RepoRestService', 'REST_URI'];
+    PfViewController.$inject = ['RepoRestService', 'REST_URI', 'pfViewUtils'];
 
-    function PfViewController(RepoRestService, REST_URI) {
+    function PfViewController(RepoRestService, REST_URI, pfViewUtils) {
         var vm = this;
         vm.filtersText = '';
      

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/vdb-bench.dataservice.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/vdb-bench.dataservice.js
@@ -10,6 +10,7 @@
         'prettyXml',
         'angularUtils.directives.dirPagination',
         'patternfly.views',
+        'patternfly.toolbars',
 
         /*
          * Our reusable cross app code modules


### PR DESCRIPTION
- Allows the test toolbar to be displayed correctly
- vdb-bench.dataservice
  - Even though the angular-patternfly.js is included, the module still
    needs to be imported for the pf-toolbar tag to be interpreted as the
    directive.
- pftoolbar.js
  - pfViewUtils is a constant within angular-patternfly so it must be
    imported in the same way as REST_URI
- pftoolbar.html
  - The pf-list-view is a directive and as such provides an internal scope
    where each row is stored under item. Thus, vm should not be prepended
    to the vars.
