### PR TITLE
Implements contents for the DS Home page

### DIFF
--- a/vdb-bench-assembly/bower.json
+++ b/vdb-bench-assembly/bower.json
@@ -40,7 +40,8 @@
     "angular-ui-grid": "^3.2.1",
     "angular-patternfly": "^3.6.0",
     "angular-wizard": "^0.6.1",
-    "hawtio-extension-service": "^2.0.3"
+    "hawtio-extension-service": "^2.0.3",
+    "d3": "^4.2.7"
   },
   "devDependencies": {
     "bootstrap": "~3.3.5",
@@ -62,6 +63,7 @@
     "bootstrap-touchspin": "~3.1.1",
     "datatables-colreorder": "~1.3.2",
     "moment": ">=2.9.0",
-    "jquery-ui": ">=1.9"
+    "jquery-ui": ">=1.9",
+    "d3": "^3.4"
   }
 }

--- a/vdb-bench-assembly/index.html
+++ b/vdb-bench-assembly/index.html
@@ -87,6 +87,7 @@
     <script src="libs/angular-pretty-xml/src/angular-pretty-xml.js"></script>
     <script src="libs/angular-animate/angular-animate.js"></script>
     <script src="libs/angularUtils-pagination/dirPagination.js"></script>
+    <script src="libs/d3/d3.min.js"></script>
     <script src="libs/d3pie/d3pie/d3pie.js"></script>
     <script src="libs/angular-file-saver/dist/angular-file-saver.bundle.js"></script>
     <script src="libs/angular-base64/angular-base64.js"></script>
@@ -150,6 +151,7 @@
     <!-- endinject -->
 
     <!-- vdb-bench-teiid -->
+<!--
     <script src="plugins/vdb-bench-teiid/vdb-bench-teiid.js"></script>
     <script src="plugins/vdb-bench-teiid/config.js"></script>
     <script src="plugins/vdb-bench-teiid/teiidController.js"></script>
@@ -158,11 +160,14 @@
     <script src="plugins/vdb-bench-teiid/translatorsController.js"></script>
     <script src="plugins/vdb-bench-teiid/queryController.js"></script>
     <script src="plugins/vdb-bench-teiid/dataSourcesController.js"></script>
+-->
     <script src="plugins/vdb-bench-teiid/widgets/connected/connected.js"></script>
     <script src="plugins/vdb-bench-teiid/widgets/datasources/datasources.js"></script>
+<!--
     <script src="plugins/vdb-bench-teiid/widgets/translators/translators.js"></script>
     <script src="plugins/vdb-bench-teiid/widgets/vdbs/vdbs.js"></script>
     <script src="plugins/vdb-bench-teiid/widgets/vdb-states/vdb-states.js"></script>
+-->
     <!-- endinject -->
 
     <!-- vdb-bench-teiid-prefs -->
@@ -178,7 +183,9 @@
 
     <!-- vdb-bench-dataservice -->
     <script src="plugins/vdb-bench-dataservice/vdb-bench.dataservice.js"></script>
+    <script src="plugins/vdb-bench-dataservice/dsPageService.js"></script>
     <script src="plugins/vdb-bench-dataservice/dataservicePageController.js"></script>
+    <script src="plugins/vdb-bench-dataservice/dsHomeController.js"></script>
     <script src="plugins/vdb-bench-dataservice/dsSummaryController.js"></script>
     <script src="plugins/vdb-bench-dataservice/dsCloneController.js"></script>
     <script src="plugins/vdb-bench-dataservice/dsEditController.js"></script>
@@ -201,6 +208,9 @@
     <script src="plugins/vdb-bench-dataservice/export/dsExportGitWizard.js"></script>
     <script src="plugins/vdb-bench-dataservice/import/dsImportFileWizard.js"></script>
     <script src="plugins/vdb-bench-dataservice/import/dsImportGitWizard.js"></script>
+    <script src="plugins/vdb-bench-dataservice/widgets/welcome/welcome.js"></script>
+    <script src="plugins/vdb-bench-dataservice/widgets/dataservices/dataservices.js"></script>
+    <script src="plugins/vdb-bench-dataservice/widgets/service-sources/svcsources.js"></script>
     <!-- endinject -->
     <!-- endbuild -->
 

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-home.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-home.html
@@ -1,0 +1,6 @@
+<div ng-controller="DSHomeController as vm">
+    <adf-dashboard name="dv-home-dashboard"
+                            collapsible="true"
+                            structure="6-6"
+                            adf-model="vm.model" />
+</div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-navbar.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-navbar.html
@@ -2,16 +2,16 @@
 </div>
 
 <div id="dsb-vertical-nav">
-    <div id="dsb-nav-item-dashboard" class="dsb-nav-item active" ng-click="vmmain.selectNavItem('dv-home')" body-click="vmmain.selectNavItem(null);">
-        <span class="fa fa-fw fa-dashboard"></span>
-        <div>DV Home</div>
+    <div id="dsb-nav-item-dashboard" class="dsb-nav-item active" ng-click="vmmain.selectNavItem('dataservice-home')" body-click="vmmain.selectNavItem(null);">
+        <span class="fa fa-fw {{vmmain.page('dataservice-home').icon}}"></span>
+        <div>DS Home</div>
     </div>
     <div id="dsb-nav-item-dataservices" class="dsb-nav-item" ng-click="vmmain.selectNavItem('dataservice-summary')" body-click="vmmain.selectNavItem(null);">
-        <span class="fa fa-fw fa-cubes"></span>
+        <span class="fa fa-fw {{vmmain.page('dataservice-summary').icon}}"></span>
         <div>Data Services</div>
     </div>
     <div id="ds-nav-item-sources" class="dsb-nav-item" ng-click="vmmain.selectNavItem('datasource-summary')" body-click="vmmain.selectNavItem(null);">
-        <span class="fa fa-fw fa-database"></span>
+        <span class="fa fa-fw {{vmmain.page('datasource-summary').icon}}"></span>
         <div>Sources</div>
     </div>
     <div class="dsb-nav-item-filler">
@@ -19,12 +19,12 @@
 
     <!-- detail menus -->
     <div id="dsb-vertical-nav-details" ng-switch="vmmain.selectedNavItem" ng-show="vmmain.navItemSelected()">
-        <div id="dsb-nav-detail-dashboard" class="dsb-nav-detail-item" ng-switch-when="dv-home">
-            <h3>DV Home</h3>
+        <div id="dsb-nav-detail-dashboard" class="dsb-nav-detail-item" ng-switch-when="dataservice-home">
+            <h3>DS Home</h3>
             <p>Click below to navigate back to the default Data Service dashboard.</p>
-            <ul>
-                <li><a href="dashboard.html">Back to DV Home</a></li>
-            </ul>
+            <div class="action">
+                <a ng-click="vmmain.selectPage('dataservice-home')"><span class="fa fa-fw {{vmmain.page('dataservice-home').icon}}"></span><span>Back to DS Home</span></a>
+            </div>
         </div>
         <div id="dsb-nav-detail-dataservices" class="dsb-nav-detail-item" ng-switch-when="dataservice-summary">
             <h3>Data Services</h3>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservicePageController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservicePageController.js
@@ -10,7 +10,8 @@
         .controller('DataServicePageController', DataServicePageController);
 
     BodyClickDirective.$inject = ['$parse', '$document'];
-    DataServicePageController.$inject = ['$scope', 'SYNTAX', 'CONFIG', 'RepoRestService', 'DSSelectionService', 'ConnectionSelectionService', 'SvcSourceSelectionService'];
+    DataServicePageController.$inject = ['$scope', 'SYNTAX', 'CONFIG', 'RepoRestService', 'DSSelectionService',
+                                                            'ConnectionSelectionService', 'SvcSourceSelectionService', 'DSPageService'];
 
     /**
      * Designed to bind a click handler to body element which,
@@ -52,7 +53,8 @@
         return directive;
     }
     
-    function DataServicePageController($scope, syntax, config, RepoRestService, DSSelectionService, ConnectionSelectionService, SvcSourceSelectionService) {
+    function DataServicePageController($scope, syntax, config, RepoRestService, DSSelectionService,
+                                                            ConnectionSelectionService, SvcSourceSelectionService, DSPageService) {
         var vm = this;
 
         /*
@@ -62,251 +64,42 @@
             vm.selectPage(pageId);
         });
 
-        var DV_HOME_PAGE = 'dv-home';
-        var DATASERVICE_SUMMARY_PAGE = 'dataservice-summary';
-        var NEW_DATASERVICE_PAGE = 'dataservice-new';
-        var IMPORT_DATASERVICE_PAGE = 'dataservice-import';
-        var EXPORT_DATASERVICE_PAGE = 'dataservice-export';
-        var EDIT_DATASERVICE_PAGE = 'dataservice-edit';
-        var CLONE_DATASERVICE_PAGE = 'dataservice-clone';
-        var TEST_DATASERVICE_PAGE = 'dataservice-test';
-        var CONNECTION_SUMMARY_PAGE = 'connection-summary';
-        var NEW_CONNECTION_PAGE = 'connection-new';
-        var IMPORT_CONNECTION_PAGE = 'connection-import';
-        var EDIT_CONNECTION_PAGE = 'connection-edit';
-        var CLONE_CONNECTION_PAGE = 'connection-clone';
-        var SERVICESOURCE_SUMMARY_PAGE = 'datasource-summary';
-        var SERVICESOURCE_NEW_PAGE = 'svcsource-new';
-        var SERVICESOURCE_IMPORT_PAGE = 'svcsource-import';
-        var SERVICESOURCE_EDIT_PAGE = 'svcsource-edit';
-        var SERVICESOURCE_CLONE_PAGE = 'svcsource-clone';
-        var IMPORT_DRIVER_PAGE = 'driver-import';
-
         vm.selectNavItem = function(navItemId) {
             vm.selectedNavItem = navItemId;
         };
 
         vm.navItemSelected = function() {
-            if (angular.isUndefined(vm.selectedNavItem) || vm.selectedNavItem === null)
+            if (_.isEmpty(vm.selectedNavItem))
                 return false;
 
             return true;
         };
 
-        var pages = {};
-        pages[DV_HOME_PAGE] = {
-            id: DV_HOME_PAGE,
-            title: 'DV Home',
-            icon: 'fa-dashboard',
-            parent: null,
-            template: config.pluginDir + syntax.FORWARD_SLASH +
-                            pluginDirName + syntax.FORWARD_SLASH +
-                            DV_HOME_PAGE + syntax.DOT + syntax.HTML
-        };
-        pages[DATASERVICE_SUMMARY_PAGE] = {
-            id: DATASERVICE_SUMMARY_PAGE,
-            title: 'Data Services',
-            icon: 'fa-search',
-            parent: DV_HOME_PAGE,
-            template: config.pluginDir + syntax.FORWARD_SLASH +
-                            pluginDirName + syntax.FORWARD_SLASH +
-                            DATASERVICE_SUMMARY_PAGE + syntax.DOT + syntax.HTML
-        };
-        pages[NEW_DATASERVICE_PAGE] = {
-            id: NEW_DATASERVICE_PAGE,
-            title: 'New Data Service',
-            icon: 'fa-plus',
-            parent: DATASERVICE_SUMMARY_PAGE,
-            template: config.pluginDir + syntax.FORWARD_SLASH +
-                    pluginDirName + syntax.FORWARD_SLASH +
-                    NEW_DATASERVICE_PAGE + syntax.DOT + syntax.HTML
-        };
-        pages[IMPORT_DATASERVICE_PAGE] = {
-            id: IMPORT_DATASERVICE_PAGE,
-            title: 'Import Data Service',
-            icon: 'pficon-import',
-            parent: DATASERVICE_SUMMARY_PAGE,
-            template: config.pluginDir + syntax.FORWARD_SLASH +
-                            pluginDirName + syntax.FORWARD_SLASH +
-                            IMPORT_DATASERVICE_PAGE + syntax.DOT + syntax.HTML
-        };
-        pages[EXPORT_DATASERVICE_PAGE] = {
-            id: EXPORT_DATASERVICE_PAGE,
-            title: 'Export Data Service',
-            icon: 'pficon-export',
-            parent: DATASERVICE_SUMMARY_PAGE,
-            template: config.pluginDir + syntax.FORWARD_SLASH +
-                            pluginDirName + syntax.FORWARD_SLASH +
-                            EXPORT_DATASERVICE_PAGE + syntax.DOT + syntax.HTML
-        };
-        pages[EDIT_DATASERVICE_PAGE] = {
-            id: EDIT_DATASERVICE_PAGE,
-            title: 'Edit Data Service',
-            icon: 'pficon-edit',
-            parent: DATASERVICE_SUMMARY_PAGE,
-            template: config.pluginDir + syntax.FORWARD_SLASH +
-                            pluginDirName + syntax.FORWARD_SLASH +
-                            EDIT_DATASERVICE_PAGE + syntax.DOT + syntax.HTML
-        };
-        pages[CLONE_DATASERVICE_PAGE] = {
-            id: CLONE_DATASERVICE_PAGE,
-            title: 'Copy Data Service',
-            icon: 'pficon-replicator',
-            parent: DATASERVICE_SUMMARY_PAGE,
-            template: config.pluginDir + syntax.FORWARD_SLASH +
-                            pluginDirName + syntax.FORWARD_SLASH +
-                            CLONE_DATASERVICE_PAGE + syntax.DOT + syntax.HTML
-        };
-        pages[TEST_DATASERVICE_PAGE] = {
-            id: TEST_DATASERVICE_PAGE,
-            title: 'Test Data Service',
-            icon: 'pficon-running',
-            parent: DATASERVICE_SUMMARY_PAGE,
-            template: config.pluginDir + syntax.FORWARD_SLASH +
-                            pluginDirName + syntax.FORWARD_SLASH +
-                            TEST_DATASERVICE_PAGE + syntax.DOT + syntax.HTML
-        };
-        pages[CONNECTION_SUMMARY_PAGE] = {
-            id: CONNECTION_SUMMARY_PAGE,
-            title: 'Connection Summary',
-            template: config.pluginDir + syntax.FORWARD_SLASH +
-                            pluginDirName + syntax.FORWARD_SLASH +
-                            'connections' + syntax.FORWARD_SLASH + CONNECTION_SUMMARY_PAGE + syntax.DOT + syntax.HTML
-        };
-        pages[NEW_CONNECTION_PAGE] = {
-            id: NEW_CONNECTION_PAGE,
-            title: 'New Connection',
-            template: config.pluginDir + syntax.FORWARD_SLASH +
-                    pluginDirName + syntax.FORWARD_SLASH +
-                    'connections' + syntax.FORWARD_SLASH + NEW_CONNECTION_PAGE + syntax.DOT + syntax.HTML
-        };
-        pages[IMPORT_CONNECTION_PAGE] = {
-            id: IMPORT_CONNECTION_PAGE,
-            title: 'Import Connection',
-            template: config.pluginDir + syntax.FORWARD_SLASH +
-                            pluginDirName + syntax.FORWARD_SLASH +
-                            'connections' + syntax.FORWARD_SLASH + IMPORT_CONNECTION_PAGE + syntax.DOT + syntax.HTML
-        };
-        pages[EDIT_CONNECTION_PAGE] = {
-            id: EDIT_CONNECTION_PAGE,
-            title: 'Edit Connection',
-            template: config.pluginDir + syntax.FORWARD_SLASH +
-                            pluginDirName + syntax.FORWARD_SLASH +
-                            'connections' + syntax.FORWARD_SLASH + EDIT_CONNECTION_PAGE + syntax.DOT + syntax.HTML
-        };
-        pages[CLONE_CONNECTION_PAGE] = {
-            id: CLONE_CONNECTION_PAGE,
-            title: 'Clone Connection',
-            template: config.pluginDir + syntax.FORWARD_SLASH +
-                            pluginDirName + syntax.FORWARD_SLASH +
-                            'connections' + syntax.FORWARD_SLASH + CLONE_CONNECTION_PAGE + syntax.DOT + syntax.HTML
-        };
-        pages[SERVICESOURCE_SUMMARY_PAGE] = {
-            id: SERVICESOURCE_SUMMARY_PAGE,
-            title: 'Service-source Summary',
-            icon: 'pficon-storage-domain',
-            parent: DV_HOME_PAGE,
-            template: config.pluginDir + syntax.FORWARD_SLASH +
-                            pluginDirName + syntax.FORWARD_SLASH +
-                            'datasources' + syntax.FORWARD_SLASH + SERVICESOURCE_SUMMARY_PAGE + syntax.DOT + syntax.HTML
-        };
-        pages[SERVICESOURCE_NEW_PAGE] = {
-            id: SERVICESOURCE_NEW_PAGE,
-            title: 'New Service-source',
-            icon: 'fa-plus',
-            parent: SERVICESOURCE_SUMMARY_PAGE,
-            template: config.pluginDir + syntax.FORWARD_SLASH +
-                            pluginDirName + syntax.FORWARD_SLASH +
-                            'datasources' + syntax.FORWARD_SLASH + SERVICESOURCE_NEW_PAGE + syntax.DOT + syntax.HTML
-        };
-        pages[SERVICESOURCE_EDIT_PAGE] = {
-            id: SERVICESOURCE_EDIT_PAGE,
-            title: 'Edit Service-source',
-            icon: 'pficon-edit',
-            parent: SERVICESOURCE_SUMMARY_PAGE,
-            template: config.pluginDir + syntax.FORWARD_SLASH +
-                            pluginDirName + syntax.FORWARD_SLASH +
-                            'datasources' + syntax.FORWARD_SLASH + SERVICESOURCE_EDIT_PAGE + syntax.DOT + syntax.HTML
-        };
-        pages[SERVICESOURCE_CLONE_PAGE] = {
-            id: SERVICESOURCE_CLONE_PAGE,
-            title: 'Clone Service-source',
-            icon: 'pficon-replicator',
-            parent: SERVICESOURCE_SUMMARY_PAGE,
-            template: config.pluginDir + syntax.FORWARD_SLASH +
-                            pluginDirName + syntax.FORWARD_SLASH +
-                            'datasources' + syntax.FORWARD_SLASH + SERVICESOURCE_CLONE_PAGE + syntax.DOT + syntax.HTML
-        };
-        pages[SERVICESOURCE_IMPORT_PAGE] = {
-            id: SERVICESOURCE_IMPORT_PAGE,
-            title: 'Import Service-source',
-            icon: 'pficon-import',
-            parent: SERVICESOURCE_SUMMARY_PAGE,
-            template: config.pluginDir + syntax.FORWARD_SLASH +
-                            pluginDirName + syntax.FORWARD_SLASH +
-                            'datasources' + syntax.FORWARD_SLASH + SERVICESOURCE_IMPORT_PAGE + syntax.DOT + syntax.HTML
-        };
-        pages[IMPORT_DRIVER_PAGE] = {
-            id: IMPORT_DRIVER_PAGE,
-            title: 'Import Driver',
-            template: config.pluginDir + syntax.FORWARD_SLASH +
-                            pluginDirName + syntax.FORWARD_SLASH +
-                            'connections' + syntax.FORWARD_SLASH + IMPORT_DRIVER_PAGE + syntax.DOT + syntax.HTML
-        };
-
         vm.page = function(pageId) {
-            if (angular.isUndefined(pageId))
-                return null;
-
-            return pages[pageId];
+            return DSPageService.page(pageId);
         };
 
         vm.pages = function(pageIds) {
-            var selectedPages = [];
-            if (angular.isUndefined(pageIds) || pageIds === null)
-                return selectedPages;
-
-            for (var i = 0; i < pageIds.length; i++) {
-                var page = pages[pageIds[i]];
-                if (angular.isUndefined(page))
-                    continue;
-
-                selectedPages.push(page);
-            }
-
-            return selectedPages;
+            return DSPageService.pages(pageIds);
         };
 
         vm.selectPage = function(pageId) {
-            vm.selectedPage = pages[pageId];
+            vm.selectedPage = DSPageService.page(pageId);
         };
 
         vm.selectedPageCrumbs = function() {
-            if (angular.isUndefined(vm.selectedPage) || vm.selectedPage === null)
-                return [];
-
-            var crumbs = [];
-            var page = vm.selectedPage;
-            while (angular.isDefined(page) && page !== null) {
-                crumbs.unshift(page);
-                if (page.parent === null)
-                    page = null;
-                else
-                    page = pages[page.parent];
-            }
-
-            return crumbs;
+            return DSPageService.pageCrumbs(vm.selectedPage);
         };
 
         vm.selectedPageId = function() {
-            if (angular.isUndefined(vm.selectedPage) || vm.selectedPage === null)
+            if (_.isEmpty(vm.selectedPage))
                 return '';
 
             return vm.selectedPage.id;
         };
 
         vm.selectedPageTitle = function() {
-            if (angular.isUndefined(vm.selectedPage) || vm.selectedPage === null)
+            if (_.isEmpty(vm.selectedPage))
                 return '';
 
             return vm.selectedPage.title;
@@ -340,7 +133,7 @@
             return ConnectionSelectionService.getConnectionState(conn);
         };
 
-        vm.selectPage(DATASERVICE_SUMMARY_PAGE);
+        vm.selectPage(DSPageService.DS_HOME_PAGE);
     }
 
 })();

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsHomeController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsHomeController.js
@@ -1,0 +1,68 @@
+(function () {
+    'use strict';
+
+    var pluginName = 'vdb-bench.dataservice';
+    var pluginDirName = 'vdb-bench-dataservice';
+
+    angular
+        .module(pluginName)
+        .controller('DSHomeController', DSHomeController);
+
+    DSHomeController.$inject = ['$scope', 'StorageService'];
+
+    function DSHomeController($scope, StorageService) {
+        var vm = this;
+        vm.name = 'dv-home-dashboard';
+
+        var model = StorageService.getObject(vm.name, null);
+        if (! model) {
+            model = {
+                title: " ",
+                structure: "6-6",
+                rows: [{
+                    columns: [{
+                        styleClass: "col-md-8",
+                        widgets: [{
+                            fullScreen: false,
+                            modalSize: 'lg',
+                            type: "ds-welcome"
+                        }]
+                    }]
+                }, {
+                    columns: [{
+                        styleClass: "col-md-5",
+                        widgets: [{
+                            fullScreen: false,
+                            modalSize: 'lg',
+                            type: "teiid-connected"
+                        }]
+                    }, {
+                        styleClass: "col-md-3",
+                        widgets: [{
+                            fullScreen: false,
+                            modalSize: 'lg',
+                            type: "ds-dataservices"
+                        }]
+                    }, {
+                        styleClass: "col-md-3",
+                        widgets: [{
+                            fullScreen: false,
+                            modalSize: 'lg',
+                            type: "ds-svcsources"
+                        }]
+                    }]
+                }]
+            };
+        }
+
+        vm.model = model;
+
+        $scope.$on('adfDashboardChanged', function(event, name, model) {
+            if (vm.name !== name)
+                return;
+
+            StorageService.setObject(name, model);
+        });
+    }
+
+})();

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsPageService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsPageService.js
@@ -1,0 +1,259 @@
+/**
+ * Dataservice Page Service
+ *
+ * Provides and shares the current page view of the dataservice module
+ */
+(function () {
+
+    'use strict';
+
+    var pluginName = 'vdb-bench.dataservice';
+    var pluginDirName = 'vdb-bench-dataservice';
+
+    angular
+        .module('vdb-bench.dataservice')
+        .factory('DSPageService', DSPageService);
+
+    DSPageService.$inject = ['SYNTAX', 'CONFIG'];
+
+    function DSPageService(syntax, config) {
+        /*
+         * Service instance to be returned
+         */
+        var service = {
+            DS_HOME_PAGE: 'dataservice-home',
+            DATASERVICE_SUMMARY_PAGE: 'dataservice-summary',
+            NEW_DATASERVICE_PAGE: 'dataservice-new',
+            IMPORT_DATASERVICE_PAGE: 'dataservice-import',
+            EXPORT_DATASERVICE_PAGE: 'dataservice-export',
+            EDIT_DATASERVICE_PAGE: 'dataservice-edit',
+            CLONE_DATASERVICE_PAGE: 'dataservice-clone',
+            TEST_DATASERVICE_PAGE: 'dataservice-test',
+            CONNECTION_SUMMARY_PAGE: 'connection-summary',
+            NEW_CONNECTION_PAGE: 'connection-new',
+            IMPORT_CONNECTION_PAGE: 'connection-import',
+            EDIT_CONNECTION_PAGE: 'connection-edit',
+            CLONE_CONNECTION_PAGE: 'connection-clone',
+            SERVICESOURCE_SUMMARY_PAGE: 'datasource-summary',
+            SERVICESOURCE_NEW_PAGE: 'svcsource-new',
+            SERVICESOURCE_IMPORT_PAGE: 'svcsource-import',
+            SERVICESOURCE_EDIT_PAGE: 'svcsource-edit',
+            SERVICESOURCE_CLONE_PAGE: 'svcsource-clone',
+            IMPORT_DRIVER_PAGE: 'driver-import'
+        };
+
+        var pages = {};
+        pages[service.DS_HOME_PAGE] = {
+            id: service.DS_HOME_PAGE,
+            title: 'DS Home',
+            icon: 'fa-dashboard',
+            parent: null,
+            template: config.pluginDir + syntax.FORWARD_SLASH +
+                            pluginDirName + syntax.FORWARD_SLASH +
+                            service.DS_HOME_PAGE + syntax.DOT + syntax.HTML
+        };
+        pages[service.DATASERVICE_SUMMARY_PAGE] = {
+            id: service.DATASERVICE_SUMMARY_PAGE,
+            title: 'Data Services',
+            icon: 'fa-search',
+            parent: service.DS_HOME_PAGE,
+            template: config.pluginDir + syntax.FORWARD_SLASH +
+                            pluginDirName + syntax.FORWARD_SLASH +
+                            service.DATASERVICE_SUMMARY_PAGE + syntax.DOT + syntax.HTML
+        };
+        pages[service.NEW_DATASERVICE_PAGE] = {
+            id: service.NEW_DATASERVICE_PAGE,
+            title: 'New Data Service',
+            icon: 'fa-plus',
+            parent: service.DATASERVICE_SUMMARY_PAGE,
+            template: config.pluginDir + syntax.FORWARD_SLASH +
+                            pluginDirName + syntax.FORWARD_SLASH +
+                            service.NEW_DATASERVICE_PAGE + syntax.DOT + syntax.HTML
+        };
+        pages[service.IMPORT_DATASERVICE_PAGE] = {
+            id: service.IMPORT_DATASERVICE_PAGE,
+            title: 'Import Data Service',
+            icon: 'pficon-import',
+            parent: service.DATASERVICE_SUMMARY_PAGE,
+            template: config.pluginDir + syntax.FORWARD_SLASH +
+                            pluginDirName + syntax.FORWARD_SLASH +
+                            service.IMPORT_DATASERVICE_PAGE + syntax.DOT + syntax.HTML
+        };
+        pages[service.EXPORT_DATASERVICE_PAGE] = {
+            id: service.EXPORT_DATASERVICE_PAGE,
+            title: 'Export Data Service',
+            icon: 'pficon-export',
+            parent: service.DATASERVICE_SUMMARY_PAGE,
+            template: config.pluginDir + syntax.FORWARD_SLASH +
+                            pluginDirName + syntax.FORWARD_SLASH +
+                            service.EXPORT_DATASERVICE_PAGE + syntax.DOT + syntax.HTML
+        };
+        pages[service.EDIT_DATASERVICE_PAGE] = {
+            id: service.EDIT_DATASERVICE_PAGE,
+            title: 'Edit Data Service',
+            icon: 'pficon-edit',
+            parent: service.DATASERVICE_SUMMARY_PAGE,
+            template: config.pluginDir + syntax.FORWARD_SLASH +
+                            pluginDirName + syntax.FORWARD_SLASH +
+                            service.EDIT_DATASERVICE_PAGE + syntax.DOT + syntax.HTML
+        };
+        pages[service.CLONE_DATASERVICE_PAGE] = {
+            id: service.CLONE_DATASERVICE_PAGE,
+            title: 'Copy Data Service',
+            icon: 'pficon-replicator',
+            parent: service.DATASERVICE_SUMMARY_PAGE,
+            template: config.pluginDir + syntax.FORWARD_SLASH +
+                            pluginDirName + syntax.FORWARD_SLASH +
+                            service.CLONE_DATASERVICE_PAGE + syntax.DOT + syntax.HTML
+        };
+        pages[service.TEST_DATASERVICE_PAGE] = {
+            id: service.TEST_DATASERVICE_PAGE,
+            title: 'Test Data Service',
+            icon: 'pficon-running',
+            parent: service.DATASERVICE_SUMMARY_PAGE,
+            template: config.pluginDir + syntax.FORWARD_SLASH +
+                            pluginDirName + syntax.FORWARD_SLASH +
+                            service.TEST_DATASERVICE_PAGE + syntax.DOT + syntax.HTML
+        };
+        pages[service.CONNECTION_SUMMARY_PAGE] = {
+            id: service.CONNECTION_SUMMARY_PAGE,
+            title: 'Connection Summary',
+            template: config.pluginDir + syntax.FORWARD_SLASH +
+                            pluginDirName + syntax.FORWARD_SLASH +
+                            'connections' + syntax.FORWARD_SLASH +
+                            service.CONNECTION_SUMMARY_PAGE + syntax.DOT + syntax.HTML
+        };
+        pages[service.NEW_CONNECTION_PAGE] = {
+            id: service.NEW_CONNECTION_PAGE,
+            title: 'New Connection',
+            template: config.pluginDir + syntax.FORWARD_SLASH +
+                            pluginDirName + syntax.FORWARD_SLASH +
+                            'connections' + syntax.FORWARD_SLASH +
+                            service.NEW_CONNECTION_PAGE + syntax.DOT + syntax.HTML
+        };
+        pages[service.IMPORT_CONNECTION_PAGE] = {
+            id: service.IMPORT_CONNECTION_PAGE,
+            title: 'Import Connection',
+            template: config.pluginDir + syntax.FORWARD_SLASH +
+                            pluginDirName + syntax.FORWARD_SLASH +
+                            'connections' + syntax.FORWARD_SLASH +
+                            service.IMPORT_CONNECTION_PAGE + syntax.DOT + syntax.HTML
+        };
+        pages[service.EDIT_CONNECTION_PAGE] = {
+            id: service.EDIT_CONNECTION_PAGE,
+            title: 'Edit Connection',
+            template: config.pluginDir + syntax.FORWARD_SLASH +
+                            pluginDirName + syntax.FORWARD_SLASH +
+                            'connections' + syntax.FORWARD_SLASH +
+                            service.EDIT_CONNECTION_PAGE + syntax.DOT + syntax.HTML
+        };
+        pages[service.CLONE_CONNECTION_PAGE] = {
+            id: service.CLONE_CONNECTION_PAGE,
+            title: 'Clone Connection',
+            template: config.pluginDir + syntax.FORWARD_SLASH +
+                            pluginDirName + syntax.FORWARD_SLASH +
+                            'connections' + syntax.FORWARD_SLASH +
+                            service.CLONE_CONNECTION_PAGE + syntax.DOT + syntax.HTML
+        };
+        pages[service.SERVICESOURCE_SUMMARY_PAGE] = {
+            id: service.SERVICESOURCE_SUMMARY_PAGE,
+            title: 'Service-source Summary',
+            icon: 'pficon-storage-domain',
+            parent: service.DS_HOME_PAGE,
+            template: config.pluginDir + syntax.FORWARD_SLASH +
+                            pluginDirName + syntax.FORWARD_SLASH +
+                            'datasources' + syntax.FORWARD_SLASH +
+                            service.SERVICESOURCE_SUMMARY_PAGE + syntax.DOT + syntax.HTML
+        };
+        pages[service.SERVICESOURCE_NEW_PAGE] = {
+            id: service.SERVICESOURCE_NEW_PAGE,
+            title: 'New Service-source',
+            icon: 'fa-plus',
+            parent: service.SERVICESOURCE_SUMMARY_PAGE,
+            template: config.pluginDir + syntax.FORWARD_SLASH +
+                            pluginDirName + syntax.FORWARD_SLASH +
+                            'datasources' + syntax.FORWARD_SLASH +
+                            service.SERVICESOURCE_NEW_PAGE + syntax.DOT + syntax.HTML
+        };
+        pages[service.SERVICESOURCE_EDIT_PAGE] = {
+            id: service.SERVICESOURCE_EDIT_PAGE,
+            title: 'Edit Service-source',
+            icon: 'pficon-edit',
+            parent: service.SERVICESOURCE_SUMMARY_PAGE,
+            template: config.pluginDir + syntax.FORWARD_SLASH +
+                            pluginDirName + syntax.FORWARD_SLASH +
+                            'datasources' + syntax.FORWARD_SLASH +
+                            service.SERVICESOURCE_EDIT_PAGE + syntax.DOT + syntax.HTML
+        };
+        pages[service.SERVICESOURCE_CLONE_PAGE] = {
+            id: service.SERVICESOURCE_CLONE_PAGE,
+            title: 'Clone Service-source',
+            icon: 'pficon-replicator',
+            parent: service.SERVICESOURCE_SUMMARY_PAGE,
+            template: config.pluginDir + syntax.FORWARD_SLASH +
+                            pluginDirName + syntax.FORWARD_SLASH +
+                            'datasources' + syntax.FORWARD_SLASH +
+                            service.SERVICESOURCE_CLONE_PAGE + syntax.DOT + syntax.HTML
+        };
+        pages[service.SERVICESOURCE_IMPORT_PAGE] = {
+            id: service.SERVICESOURCE_IMPORT_PAGE,
+            title: 'Import Service-source',
+            icon: 'pficon-import',
+            parent: service.SERVICESOURCE_SUMMARY_PAGE,
+            template: config.pluginDir + syntax.FORWARD_SLASH +
+                            pluginDirName + syntax.FORWARD_SLASH +
+                            'datasources' + syntax.FORWARD_SLASH +
+                            service.SERVICESOURCE_IMPORT_PAGE + syntax.DOT + syntax.HTML
+        };
+        pages[service.IMPORT_DRIVER_PAGE] = {
+            id: service.IMPORT_DRIVER_PAGE,
+            title: 'Import Driver',
+            template: config.pluginDir + syntax.FORWARD_SLASH +
+                            pluginDirName + syntax.FORWARD_SLASH +
+                            'connections' + syntax.FORWARD_SLASH +
+                            service.IMPORT_DRIVER_PAGE + syntax.DOT + syntax.HTML
+        };
+
+        service.page = function(pageId) {
+            if (_.isEmpty(pageId))
+                return null;
+
+            return pages[pageId];
+        };
+
+        service.pages = function(pageIds) {
+            var selectedPages = [];
+            if (_.isEmpty(pageIds))
+                return selectedPages;
+
+            for (var i = 0; i < pageIds.length; i++) {
+                var page = pages[pageIds[i]];
+                if (_.isEmpty(page))
+                    continue;
+
+                selectedPages.push(page);
+            }
+
+            return selectedPages;
+        };
+
+        service.pageCrumbs = function(targetPage) {
+            if (_.isEmpty(targetPage))
+                return [];
+
+            var crumbs = [];
+            var page = targetPage;
+            while (! _.isEmpty(page)) {
+                crumbs.unshift(page);
+                if (page.parent === null)
+                    page = null;
+                else
+                    page = pages[page.parent];
+            }
+
+            return crumbs;
+        };
+
+        return service;
+    }
+})();

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/vdb-bench.dataservice.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/vdb-bench.dataservice.js
@@ -5,6 +5,12 @@
         /*
          * Angular modules
          */
+        'adf',
+        'adf.structures.base',
+        'adf.widget.ds-welcome',
+        'adf.widget.ds-dataservices',
+        'adf.widget.ds-svcsources',
+        'adf.widget.teiid-connected',
         'ui.bootstrap',
         'ui.codemirror',
         'prettyXml',

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservices/content/css/style.less
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservices/content/css/style.less
@@ -1,0 +1,20 @@
+.ds-dashboard-widgets-dataservices {
+    font-weight: bold;
+}
+.ds-dashboard-widgets-dataservices-list-tr-names-container {
+    border: solid 1px #DEDDDD;
+    padding: 0.5em;
+    margin-top: 1em;
+}
+.ds-dashboard-widgets-dataservices-list-tr-names {
+    overflow: auto;
+}
+.ds-dashboard-widgets-dataservices-list-group {
+    margin-bottom: 0 !important;
+}
+
+#ds-dashboard-widgets-dataservices-footer {
+    font-size: 14px;
+    margin: 20px 0 0 0 !important;
+    border-bottom: 1px solid #d1d1d1;
+}

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservices/dataservices.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservices/dataservices.html
@@ -1,0 +1,32 @@
+<div class="ds-dashboard-widgets-dataservices">
+    <uib-progressbar class="progress-striped active" value="dynamic" type="info" ng-show="vm.loading"></uib-progressbar>
+
+    <p ng-show="! vm.loading && vm.error">Status Error:<br/>'{{vm.error}}'</p>
+
+    <div ng-show="! vm.loading && ! vm.error">
+        Number of dataservices: <span style="color: blue;">{{vm.total}}</span>
+
+        <div class="ds-dashboard-widgets-dataservices-list-tr-names-container" ng-show="vm.total > 0">
+            <div class="ds-dashboard-widgets-dataservices-list-tr-names">
+                <input class="accordian-list-filter" type="text" ng-model="vm.trFilter" placeholder="filter...">
+                <div class="list-group accordian-list ds-dashboard-widgets-dataservices-list-group">
+                    <a class="list-group-item" pagination-id="tr-paginate" dir-paginate="tr in vm.names|filter:vm.trFilter|orderBy:'toString()'|itemsPerPage:3">
+                        {{tr}}
+                    </a>
+                    <dir-pagination-controls pagination-id="tr-paginate" max-size="3" direction-links="true" boundary-links="true"></dir-pagination-controls>
+                </div>
+            </div>
+        </div>
+        <div id="ds-dashboard-widgets-dataservices-footer" class="card-pf-footer">
+            <p>
+                <a ng-click="vm.selectPage('dataservice-summary')">
+                    <span class="fa fa-fw {{vm.page('dataservice-summary').icon}}"></span><span>List All</span>
+                </a>
+                <span></span>
+                <a ng-click="vm.selectPage('dataservice-new')" class="pull-right">
+                    <span class="fa fa-fw {{vm.page('dataservice-new').icon}}"></span><span>Create</span>
+                </a>
+            </p>
+        </div>
+    </div>
+</div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservices/dataservices.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservices/dataservices.js
@@ -1,0 +1,99 @@
+(function () {
+    'use strict';
+
+    var pluginDirName = 'vdb-bench-dataservice/widgets/dataservices';
+
+    angular.module('adf.widget.ds-dataservices', [
+        'ui.bootstrap',
+        'angularUtils.directives.dirPagination',
+        'adf.provider',
+        'vdb-bench.core'
+    ])
+        .config(config)
+        .controller('DSDataservicesController', DSDataservicesController);
+
+    config.$inject = ['dashboardProvider', 'CONFIG', 'SYNTAX'];
+
+    function config(dashboardProvider, config, syntax) {
+        dashboardProvider
+            .widget('ds-dataservices', {
+                title: 'Workspace Dataservices',
+                description: 'Displays the current data services in the workspace',
+                templateUrl: config.pluginDir + syntax.FORWARD_SLASH +
+                                    pluginDirName + syntax.FORWARD_SLASH +
+                                    'dataservices.html',
+                controller: 'DSDataservicesController',
+                controllerAs: 'vm'
+            });
+    }
+
+    DSDataservicesController.$inject = ['RepoRestService', '$scope', '$rootScope', 'DSPageService'];
+
+    function DSDataservicesController(RepoRestService, $scope, $rootScope, DSPageService) {
+        var vm = this;
+
+        vm.loading = true;
+        vm.total = {};
+        vm.names = [];
+
+        function setTotal(total) {
+            vm.total = total;
+        }
+
+        function setNames(dataservices) {
+            if (_.isEmpty(dataservices))
+                vm.names = [];
+
+            var names = [];
+            for (var i = 0; i < dataservices.length; ++i) {
+                names.push(dataservices[i].keng__id);
+            }
+
+            vm.names = names;
+        }
+
+        function setError(error) {
+            vm.error = error;
+        }
+
+        vm.selectPage = function(pageId) {
+            //
+            // Should notify the dataPageController to change the page view
+            //
+            $rootScope.$broadcast("dataServicePageChanged", pageId);
+        };
+
+        vm.page = function(pageId) {
+            return DSPageService.page(pageId);
+        };
+
+        vm.init = function(){
+            try {
+                RepoRestService.getDataServices().then(
+                    function (dataservices) {
+                        setError(null);
+                        setTotal(dataservices.length);
+                        setNames(dataservices);
+                        vm.loading = false;
+                    },
+                    function (response) {
+                        // Some kind of error has occurred
+                        setTotal(0);
+                        setNames(null);
+
+                        setError(response.message);
+                        vm.loading = false;
+                    });
+            } catch (error) {
+                setTotal(0);
+                setNames(null);
+
+                setError(error.message);
+                vm.loading = false;
+            }
+        };
+
+        vm.init();
+    }
+    
+})();

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/service-sources/content/css/style.less
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/service-sources/content/css/style.less
@@ -1,0 +1,19 @@
+.ds-dashboard-widgets-svcsources {
+    font-weight: bold;
+}
+.ds-dashboard-widgets-svcsources-list-tr-names-container {
+    border: solid 1px #DEDDDD;
+    padding: 0.5em;
+    margin-top: 1em;
+}
+.ds-dashboard-widgets-svcsources-list-tr-names {
+    overflow: auto;
+}
+.ds-dashboard-widgets-svcsources-list-group {
+    margin-bottom: 0 !important;
+}
+#ds-dashboard-widgets-svcsources-footer {
+    font-size: 14px;
+    margin: 20px 0 0 0 !important;
+    border-bottom: 1px solid #d1d1d1;
+}

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/service-sources/svcsources.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/service-sources/svcsources.html
@@ -1,0 +1,32 @@
+<div class="ds-dashboard-widgets-svcsources">
+    <uib-progressbar class="progress-striped active" value="dynamic" type="info" ng-show="vm.loading"></uib-progressbar>
+
+    <p ng-show="! vm.loading && vm.error">Status Error:<br/>'{{vm.error}}'</p>
+
+    <div ng-show="! vm.loading && ! vm.error">
+        Number of service-sources: <span style="color: blue;">{{vm.total}}</span>
+
+        <div class="ds-dashboard-widgets-svcsources-list-tr-names-container" ng-show="vm.total > 0">
+            <div class="ds-dashboard-widgets-svcsources-list-tr-names">
+                <input class="accordian-list-filter" type="text" ng-model="vm.trFilter" placeholder="filter...">
+                <div class="list-group accordian-list ds-dashboard-widgets-svcsources-list-group">
+                    <a class="list-group-item" pagination-id="tr-paginate" dir-paginate="tr in vm.names|filter:vm.trFilter|orderBy:'toString()'|itemsPerPage:3">
+                        {{tr}}
+                    </a>
+                    <dir-pagination-controls pagination-id="tr-paginate" max-size="3" direction-links="true" boundary-links="true"></dir-pagination-controls>
+                </div>
+            </div>
+        </div>
+        <div id="ds-dashboard-widgets-svcsources-footer" class="card-pf-footer">
+            <p>
+                <a ng-click="vm.selectPage('datasource-summary')">
+                    <span class="fa fa-fw {{vm.page('datasource-summary').icon}}"></span><span>List All</span>
+                </a>
+                <span></span>
+                <a ng-click="vm.selectPage('svcsource-new')" class="pull-right">
+                    <span class="fa fa-fw {{vm.page('svcsource-new').icon}}"></span><span>Create</span>
+                </a>
+            </p>
+        </div>
+    </div>
+</div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/service-sources/svcsources.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/service-sources/svcsources.js
@@ -1,0 +1,91 @@
+(function () {
+    'use strict';
+
+    var pluginDirName = 'vdb-bench-dataservice/widgets/service-sources';
+
+    angular.module('adf.widget.ds-svcsources', [
+        'ui.bootstrap',
+        'angularUtils.directives.dirPagination',
+        'adf.provider',
+        'vdb-bench.core'
+    ])
+        .config(config)
+        .controller('DSSvcSourcesController', DSSvcSourcesController);
+
+    config.$inject = ['dashboardProvider', 'CONFIG', 'SYNTAX'];
+
+    function config(dashboardProvider, config, syntax) {
+        dashboardProvider
+            .widget('ds-svcsources', {
+                title: 'Workspace Service-sources',
+                description: 'Displays the current service sources in the workspace',
+                templateUrl: config.pluginDir + syntax.FORWARD_SLASH +
+                                    pluginDirName + syntax.FORWARD_SLASH +
+                                    'svcsources.html',
+                controller: 'DSSvcSourcesController',
+                controllerAs: 'vm'
+            });
+    }
+
+    DSSvcSourcesController.$inject = ['SvcSourceSelectionService', '$scope', '$rootScope', 'DSPageService'];
+
+    function DSSvcSourcesController(SvcSourceSelectionService, $scope, $rootScope, DSPageService) {
+        var vm = this;
+
+        vm.loading = true;
+        vm.total = {};
+        vm.names = [];
+
+        function setTotal(total) {
+            vm.total = total;
+        }
+
+        function setNames(sources) {
+            if (_.isEmpty(sources))
+                vm.names = [];
+
+            var names = [];
+            for (var i = 0; i < sources.length; ++i) {
+                names.push(sources[i].keng__id);
+            }
+
+            vm.names = names;
+        }
+
+        function setError(error) {
+            vm.error = error;
+        }
+
+        vm.selectPage = function(pageId) {
+            //
+            // Should notify the dataPageController to change the page view
+            //
+            $rootScope.$broadcast("dataServicePageChanged", pageId);
+        };
+
+        vm.page = function(pageId) {
+            return DSPageService.page(pageId);
+        };
+
+        vm.init = function() {
+            if (SvcSourceSelectionService.isLoading())
+                return;
+
+            var sources = SvcSourceSelectionService.getServiceSources();
+            setError(null);
+            setTotal(sources.length);
+            setNames(sources);
+            vm.loading = false;
+        };
+
+        $scope.$on('loadingServiceSourcesChanged', function(event, loadingState) {
+            if (loadingState !== false)
+                return;
+
+            vm.init();
+        });
+
+        vm.init();
+    }
+    
+})();

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/welcome/welcome.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/welcome/welcome.html
@@ -1,0 +1,22 @@
+<div class="dshome-widgets-welcome">
+    <uib-progressbar class="progress-striped active" value="dynamic" type="info" ng-show="vm.loading"></uib-progressbar>
+
+    <div class="card-pf-heading">
+        <h2 class="card-pf-title">
+                <span class="fa fa-fw fa-comment"></span>
+                <span>Welcome to the <strong>Data Service Builder</strong></span>
+            </h2>
+    </div>
+    <div class="card-pf-body">
+        <p>
+            Hey <strong>{{vm.getUsername()}}</strong>, thanks for logging into the <strong>Data Service Builder</strong>. 
+            Hopefully you're finding it easy to use this tool to design and collaborate on new (and existing) Data Services.
+        </p>
+        <div>
+            <ul>
+                <li><a href="http://teiiddesigner.jboss.org">Data Service Builder Project Page</a></li>
+                <li><a href="http://teiid.jboss.org">Teiid Project Page</a></li>
+            </ul>
+        </div>
+    </div>
+</div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/welcome/welcome.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/welcome/welcome.js
@@ -1,0 +1,38 @@
+(function () {
+    'use strict';
+
+    var pluginDirName = 'vdb-bench-dataservice/widgets/welcome';
+
+    angular.module('adf.widget.ds-welcome', [
+        'adf.provider',
+        'vdb-bench.core'
+    ])
+        .config(config)
+        .controller('DSWelcomeController', DSWelcomeController);
+
+    config.$inject = ['dashboardProvider', 'CONFIG', 'SYNTAX'];
+
+    function config(dashboardProvider, config, syntax) {
+        dashboardProvider
+            .widget('ds-welcome', {
+                title: 'Welcome',
+                description: '',
+                templateUrl: config.pluginDir + syntax.FORWARD_SLASH +
+                                    pluginDirName + syntax.FORWARD_SLASH +
+                                    'welcome.html',
+                controller: 'DSWelcomeController',
+                controllerAs: 'vm'
+            });
+    }
+
+    DSWelcomeController.$inject = ['CredentialService'];
+
+    function DSWelcomeController(CredentialService) {
+        var vm = this;
+
+        vm.getUsername = function() {
+            return CredentialService.credentials().username; 
+        };
+    }
+    
+})();

--- a/vdb-bench-assembly/plugins/vdb-bench-teiid/widgets/connected/connected.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-teiid/widgets/connected/connected.js
@@ -15,7 +15,7 @@
     function config(dashboardProvider, config, syntax) {
         dashboardProvider
             .widget('teiid-connected', {
-                title: 'Connection',
+                title: 'Teiid Connection',
                 description: 'Displays the connected status of the local Teiid Instance',
                 templateUrl: config.pluginDir + syntax.FORWARD_SLASH +
                                     pluginDirName + syntax.FORWARD_SLASH +


### PR DESCRIPTION
- bower.json
  - Need to restore dependency on D3
- index.html
  - Other than new inclusions, comments out the major components of the
    vdb-bench-teiid plugin as seems to display itself as the default
- dataservice-home
  - Implements page as adf widgets using the adf dashboard
- dataservice-navbar
  - Fixes coded icon constants
  - Fixes navbar links to DS Home
- dataservicePageController
- dsPageService
  - Although, page controller still controls the selected page, the pages
    array is moved to a service so that it can be shared with other
    controllers, eg. widgets.
- Implements 3 new basic widgets for displaying on the home page
