### PR TITLE
Service editing changes for sprint-5

### DIFF
--- a/vdb-bench-assembly/index.html
+++ b/vdb-bench-assembly/index.html
@@ -120,6 +120,7 @@
     <script src="plugins/vdb-bench-core/DriverSelectionService.js"></script>
     <script src="plugins/vdb-bench-core/TranslatorSelectionService.js"></script>
     <script src="plugins/vdb-bench-core/SvcSourceSelectionService.js"></script>
+    <script src="plugins/vdb-bench-core/TableSelectionService.js"></script>
     <!-- endinject -->
 
     <!-- vdb-bench-widgets -->
@@ -130,6 +131,8 @@
     <script src="plugins/vdb-bench-widgets/vdbComponentTree.js"></script>
     <script src="plugins/vdb-bench-widgets/attributeWidget.js"></script>
     <script src="plugins/vdb-bench-widgets/vdbList.js"></script>
+    <script src="plugins/vdb-bench-widgets/serviceSourceList.js"></script>
+    <script src="plugins/vdb-bench-widgets/modelTableList.js"></script>
     <script src="plugins/vdb-bench-widgets/vdbVisualize.js"></script>
     <script src="plugins/vdb-bench-widgets/fileImportControl.js"></script>
     <script src="plugins/vdb-bench-widgets/sqlControl.js"></script>

--- a/vdb-bench-assembly/plugins/vdb-bench-core/SvcSourceSelectionService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/SvcSourceSelectionService.js
@@ -274,7 +274,7 @@
         /*
          * Select the given serviceSource
          */
-        service.selectServiceSource = function(serviceSource, noUpdateModel) {
+        service.selectServiceSource = function(serviceSource) {
             //
             // Set the selected serviceSource
             //

--- a/vdb-bench-assembly/plugins/vdb-bench-core/TableSelectionService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/TableSelectionService.js
@@ -1,0 +1,65 @@
+/**
+ * Table Selection Service
+ *
+ * Provides simple API for managing table selections
+ */
+(function () {
+
+    'use strict';
+
+    angular
+        .module('vdb-bench.core')
+        .factory('TableSelectionService', TableSelectionService);
+
+    TableSelectionService.$inject = ['$rootScope'];
+
+    function TableSelectionService($rootScope) {
+
+        var table = {};
+        table.table = null;
+
+        /*
+         * Service instance to be returned
+         */
+        var service = {};
+
+        /*
+         * Select the given table
+         */
+        service.selectTable = function(aTable) {
+            //
+            // Set the selected table
+            //
+            table.table = aTable;
+
+            // Useful for broadcasting the selected table has been updated
+            $rootScope.$broadcast("selectedTableChanged", table.table);
+        };
+
+        /*
+         * return selected table
+         */
+        service.selectedTable = function() {
+            return table.table;
+        };
+
+        /*
+         * return selected table
+         */
+        service.hasSelectedTable = function() {
+            if (! angular.isDefined(table.table))
+                return false;
+
+            if (_.isEmpty(table.table))
+                return false;
+
+            if (table.table === null)
+                return false;
+
+            return true;
+        };
+
+        return service;
+    }
+
+})();

--- a/vdb-bench-assembly/plugins/vdb-bench-core/constants.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/constants.js
@@ -37,7 +37,8 @@
             HASH: '#',
             SPEECH_MARKS: '"',
             HTML: 'html',
-            UNKNOWN: 'unknown'
+            UNKNOWN: 'unknown',
+            TEMP: 'temp'
         })
 
         .constant('REST_URI', {
@@ -51,6 +52,10 @@
             SEARCH: '/search',
             TEIID: '/teiid',
             TRANSLATORS: '/VdbTranslators',
+            TABLES: '/Tables',
+            COLUMNS: '/Columns',
+            SERVICE_VDB_FOR_SINGLE_TABLE: 'ServiceVdbForSingleTable',
+            MODEL_FROM_TEIID_DDL: 'ModelFromTeiidDdl',
             DATA_SERVICES_CLONE: '/dataservices/clone',
             DATA_SERVICE: '/dataservice',
             DATA_SERVICES: '/dataservices',
@@ -58,7 +63,7 @@
             DATA_SOURCE: '/datasource',
             DATA_SOURCES: '/datasources',
             VDBS_CLONE: '/vdbs/clone',
-            COPY_TO_REPO: 'copyToRepo',
+            VDBS_FROM_TEIID: 'VdbsFromTeiid',
             DRIVER: '/driver',
             DRIVERS: '/drivers',
             MODEL: '/Model',

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-edit.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-edit.html
@@ -9,42 +9,34 @@
                         <div class="form-group">
                             <label class="col-md-2 control-label" for="textInput">Name</label>
                             <div class="col-md-6">
-                              <input type="text" readonly="readonly" ng-model="nameVar" ng-init="nameVar=vmmain.selectedDataservice().keng__id" class="form-control">
+                              <input type="text" readonly="readonly" ng-model="vm.serviceName" ng-init="vm.serviceName=vmmain.selectedDataservice().keng__id" class="form-control">
                             </div>
                         </div>
                         <div class="form-group">
                             <label class="col-md-2 control-label" for="textInput">Description</label>
                             <div class="col-md-10">
-                              <input type="text" ng-model="descriptionVar" ng-init="descriptionVar=vmmain.selectedDataservice().tko__description" class="form-control">
+                              <input type="text" ng-model="vm.serviceDescription" ng-init="vm.serviceDescription=vmmain.selectedDataservice().tko__description" class="form-control">
                             </div>
                         </div>
-                        <div class="form-group">
-                            <label class="col-md-2 control-label" for="textInput">Service Model</label>
-                            <div class="col-md-4">
-                              <input type="text" ng-model="viewModelVar" class="form-control">
-                            </div>
-                            <label class="col-md-1 control-label" for="textInput">View</label>
-                            <div class="col-md-5">
-                              <input type="text" ng-model="viewNameVar" class="form-control">
-                            </div>
+                        <h4>Choose the source and table for your service</h4>
+                        <div class="col-md-5">
+                            <h4><strong>Sources</strong></h4>
+                            <service-source-list></service-source-list>
                         </div>
-                        <div class="form-group">
-                            <label class="col-md-2 control-label" for="textInput">View DDL</label>
-                            <div class="col-md-10">
-                              <!-- <input type="textarea" ng-model="viewDdlVar" ng-init="viewDdlVar=vmmain.selectedDataservice().tko__description" class="form-control"> -->
-                              <textarea form="dsForm" rows="6" cols="100" wrap="soft" ng-model="viewDdlVar"></textarea>
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label class="col-md-2 control-label" for="svcSources">Service Sources</label>
-                            <div class="col-md-6">
-                                <select id="svcSources" size="4" ng-style="{'width': '100px'}" ng-model="svcSourceVar" ng-options="svcSource as svcSource.keng__id for svcSource in vm.getSvcSources()" />
-                            </div>
+                        <div class="col-md-5">
+                            <h4><strong>Tables</strong></h4>
+                            <model-table-list></model-table-list>
                         </div>
                     </form>
-                    <button class="btn btn-primary" ng-click="vm.onUpdateDataServiceClicked(nameVar, descriptionVar)" ng-class="{active:vmmain.selectedPage.id == 'dataservice-edit'}"> Save</button>
-                    <button class="btn btn-default" ng-click="vmmain.selectPage('dataservice-summary')" ng-class="{active:vmmain.selectedPage.id == 'dataservice-edit'}"> Cancel</button>
-                </div>
+                    <div class="col-md-12">
+                        <p></p>
+                    </div>
+                    <div class="col-md-12">
+                        <input type="submit" class="btn btn-primary" value="Save" ng-click="vm.onSaveDataServiceClicked()"
+                                                  ng-disabled="vm.canSaveDataService() !== true || vmmain.selectedPage.id !== 'dataservice-edit'"/>
+                        <input type="button" class="btn btn-default" value="Cancel" ng-click="vmmain.selectPage('dataservice-summary')"
+                                                  ng-disabled="vmmain.selectedPage.id !== 'dataservice-edit'"/>
+                    </div>
             </div>
         </div>
 </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-new.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-new.html
@@ -10,18 +10,34 @@
                         <div class="form-group">
                             <label class="col-md-2 control-label" for="textInput">Name</label>
                             <div class="col-md-6">
-                              <input type="text" ng-model="nameVar" class="form-control">
+                              <input type="text" ng-model="vm.serviceName" class="form-control">
                             </div>
                         </div>
                         <div class="form-group">
                             <label class="col-md-2 control-label" for="textInput">Description</label>
                             <div class="col-md-10">
-                              <input type="text" ng-model="descriptionVar" class="form-control">
+                              <input type="text" ng-model="vm.serviceDescription" class="form-control">
                             </div>
                         </div>
+                        <h4>Choose the source and table for your service</h4>
+                        <div class="col-md-5">
+                            <h4><strong>Sources</strong></h4>
+                            <service-source-list></service-source-list>
+                        </div>
+                        <div class="col-md-5">
+                            <h4><strong>Tables</strong></h4>
+                            <model-table-list></model-table-list>
+                        </div>
                     </form>
-                    <button class="btn btn-primary" ng-click="vm.onCreateDataServiceClicked(nameVar, descriptionVar)" ng-class="{active:vmmain.selectedPage.id == 'dataservice-new'}"> Create</button>
-                    <button class="btn btn-default" ng-click="vmmain.selectPage('dataservice-summary')" ng-class="{active:vmmain.selectedPage.id == 'dataservice-new'}"> Cancel</button>
+                </div>
+                <div class="col-md-12">
+                    <p></p>
+                </div>
+                <div class="col-md-12">
+                    <input type="submit" class="btn btn-primary" value="Create" ng-click="vm.onCreateDataServiceClicked()"
+                                              ng-disabled="vm.canCreateDataService() !== true || vmmain.selectedPage.id !== 'dataservice-new'"/>
+                    <input type="button" class="btn btn-default" value="Cancel" ng-click="vmmain.selectPage('dataservice-summary')"
+                                              ng-disabled="vmmain.selectedPage.id !== 'dataservice-new'"/>
                 </div>
             </div>
         </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-summary.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-summary.html
@@ -11,7 +11,7 @@
 	   <div class="row">
 	       <div class="col-md-4"></div>
 	       <div class="col-md-6">
-                <button class="btn btn-primary" ng-click="vmmain.selectPage('dataservice-new')" ng-class="{active:vmmain.selectedPage.id == 'dataservice-summary'}">Create Data Service</button>
+                <button class="btn btn-primary" ng-click="vm.createNewService()" ng-class="{active:vmmain.selectedPage.id == 'dataservice-summary'}">Create Data Service</button>
                 <button class="btn btn-primary" ng-click="vmmain.selectPage('dataservice-import')" ng-class="{active:vmmain.selectedPage.id == 'dataservice-summary'}">Import Data Service</button>
 	       </div>
 	       <div class="col-md-2"></div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasource-summary.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasource-summary.html
@@ -60,21 +60,6 @@
      </div>
 -->
     
-        <!-- Modal displayed when vdb create starts -->
-        <div id="deleteVDBModal" class="modal fade in" aria-hidden="false" ng-show="vm.deleteVdbInProgress==true">
-            <div class="modal-dialog">
-
-                <!-- Modal content-->
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h4 class="modal-title">Source Delete In Progress</h4>
-                    </div>
-                    <div class="modal-body">
-                        <span><i class="fa fa-spinner fa-spin fa-2x fa-fw"></i>Deleting the Source</span>
-                    </div>
-                </div>
-            </div>
-        </div>
     </div>
 
 </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceNewController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceNewController.js
@@ -15,11 +15,9 @@
                                      SvcSourceSelectionService, ConnectionSelectionService, TranslatorSelectionService) {
         var vm = this;
 
-        //ConnectionSelectionService.refresh();
         vm.connsLoading = ConnectionSelectionService.isLoading();
         vm.allConnections = ConnectionSelectionService.getConnections();
         
-        //TranslatorSelectionService.refresh();
         vm.transLoading = TranslatorSelectionService.isLoading();
         vm.allTranslators = TranslatorSelectionService.getTranslators();
         
@@ -72,8 +70,6 @@
                         if(theVdb.keng__id === svcSourceName) {
                             createVdbModel( svcSourceName, connectionName, translatorName, jndiName );
                         }
-
-                        SvcSourceSelectionService.setLoading(false);
                     },
                     function (resp) {
                         SvcSourceSelectionService.setLoading(false);
@@ -96,8 +92,6 @@
                         if(theModel.keng__id === connectionName) {
                             createVdbModelSource( svcSourceName, connectionName, connectionName, translatorName, jndiName );
                         }
-
-                        SvcSourceSelectionService.setLoading(false);
                     },
                     function (resp) {
                         SvcSourceSelectionService.setLoading(false);
@@ -146,7 +140,6 @@
                         }
                         // Reinitialise the list of service sources
                         SvcSourceSelectionService.refresh('datasource-summary');
-                        SvcSourceSelectionService.setLoading(false);
                    },
                     function (response) {
                         SvcSourceSelectionService.setDeploying(false, vdbName, false, RepoRestService.responseMessage(response));

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-edit.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-edit.html
@@ -13,19 +13,19 @@
                 <div class="form-group">
                     <label class="col-md-2 control-label" for="textInput">Name</label>
                     <div class="col-md-6">
-                        <input type="text" readonly="readonly" ng-model="nameVar" ng-init="nameVar=vmmain.selectedServiceSource().keng__id" class="form-control">
+                        <input type="text" readonly="readonly" ng-model="vm.svcSourceName" ng-init="vm.svcSourceName=vmmain.selectedServiceSource().keng__id" class="form-control">
                     </div>
                 </div>
                 <div class="form-group">
                     <label class="col-md-2 control-label" for="textInput">Description</label>
                     <div class="col-md-6">
-                        <input type="text" ng-model="descriptionVar" ng-init="descriptionVar=vmmain.selectedServiceSource().vdb__description" class="form-control">
+                        <input type="text" ng-model="vm.svcSourceDescription" ng-init="vm.svcSourceDescription=vmmain.selectedServiceSource().vdb__description" class="form-control">
                     </div>
                 </div>
                 <div class="form-group">
                     <label class="col-md-2 control-label" for="conns">Connection</label>
                     <div class="col-md-6">
-                        <select id="conns" ng-model="selectedConnection" ng-options="connection as connection.keng__id for connection in vm.getConnections() track by connection.keng__id">
+                        <select id="conns" ng-model="vm.connection" ng-options="connection as connection.keng__id for connection in vm.getConnections()  | orderBy: 'keng__id'">
                             <option value="">-- choose connection --</option>
                         </select>
                     </div>
@@ -33,14 +33,16 @@
                 <div class="form-group">
                     <label class="col-md-2 control-label" for="translators">Translator</label>
                     <div class="col-md-6">
-                        <select id="translators" ng-model="selectedTranslator" ng-options="translator as translator.keng__id for translator in vm.getTranslators()">
+                        <select id="translators" ng-model="vm.translator" ng-options="translator as translator.keng__id for translator in vm.getTranslators() | orderBy: 'keng__id'">
                             <option value="">-- choose translator --</option>
                         </select>
                     </div>
                 </div>
             </form>
-            <button class="btn btn-primary" ng-click="vm.onEditSvcSourceClicked(nameVar,descriptionVar,selectedConnection.keng__id,selectedConnection.tko__jndiName,selectedTranslator.keng__id)" ng-class="{active:vmmain.selectedPage.id == 'svcsource-edit'}"> Save</button>
-            <button class="btn btn-default" ng-click="vmmain.selectPage('datasource-summary')" ng-class="{active:vmmain.selectedPage.id == 'svcsource-edit'}"> Cancel</button>
+            <input type="submit" class="btn btn-success" value="Save" ng-click="vm.onEditSvcSourceClicked()"
+                                              ng-disabled="vm.canUpdateSvcSource() !== true || vmmain.selectedPage.id !== 'svcsource-edit'"/>
+            <input type="button" class="btn btn-primary" value="Cancel" ng-click="vmmain.selectPage('datasource-summary')"
+                                              ng-disabled="vmmain.selectedPage.id !== 'svcsource-edit'"/>
         </div>
       </div>
     </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-new.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-new.html
@@ -1,10 +1,10 @@
 <div class="container-fluid" ng-controller="SvcSourceNewController as vm">
-    <div id="svcsource-new-updating" ng-show="vm.connsLoading==true || vm.transLoading==true" class="col-md-10 row">
+    <div id="svcsource-new-updating" ng-show="vm.connsLoading==true || vm.transLoading==true || vm.createAndDeployInProgress==true" class="col-md-10 row">
         <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
         <span class="sr-only">Loading...</span>
     </div>
     
-    <div id="svcsource-new-controls" ng-show="vm.connsLoading==false && vm.transLoading==false" class="col-md-10 row">
+    <div id="svcsource-new-controls" ng-show="vm.connsLoading==false && vm.transLoading==false && vm.createAndDeployInProgress==false" class="col-md-10 row">
       <div class="row">
         <div class="col-md-11">
             <h1><i class="fa fa-database" aria-hidden="true"></i>New Service Source</h1>
@@ -19,7 +19,7 @@
                 <div class="form-group">
                     <label class="col-md-2 control-label" for="textInput">Description</label>
                     <div class="col-md-6">
-                        <input type="text" ng-model="vm.svcSourceDescripion" class="form-control">
+                        <input type="text" ng-model="vm.svcSourceDescription" class="form-control">
                     </div>
                 </div>
                 <div class="form-group">
@@ -48,27 +48,5 @@
         </div>
       </div>
     </div>
-    
-    <!-- Modal displayed when vdb create starts -->
-    <div id="createVDBModal" class="modal fade in" aria-hidden="false" ng-show="vm.createAndDeployInProgress==true">
-      <div class="modal-dialog">
-        <!-- Modal content-->
-        <div class="modal-content">
-          <div class="modal-header">
-            <h4 class="modal-title">Source Create In Progress</h4>
-          </div>
-          <div class="modal-body">
-            <span><i class="fa fa-spinner fa-spin fa-2x fa-fw"></i>Creating the Source</span>
-          </div>
-        </div>
-
-      </div>
-    </div>  
-
-    <!--
-    <progressModalWidget show="vm.createAndDeployInProgress==true" width='750px' height='60%'>
-      <p>Modal Content Goes here<p>
-    </progressModalWidget>
-    -->
-    
+        
 </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsEditController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsEditController.js
@@ -8,34 +8,127 @@
         .module(pluginName)
         .controller('DSEditController', DSEditController);
 
-    DSEditController.$inject = ['$rootScope', 'RepoRestService', 'DSSelectionService', 'SvcSourceSelectionService'];
+    DSEditController.$inject = ['$scope', '$rootScope', 'REST_URI', 'SYNTAX', 'RepoRestService', 'DSSelectionService', 
+                                'SvcSourceSelectionService', 'TableSelectionService'];
 
-    function DSEditController($rootScope, RepoRestService, DSSelectionService, SvcSourceSelectionService) {
+    function DSEditController($scope, $rootScope, REST_URI, SYNTAX, RepoRestService, DSSelectionService, 
+                               SvcSourceSelectionService, TableSelectionService) {
         var vm = this;
         
         vm.svcSourcesLoading = SvcSourceSelectionService.isLoading();
         vm.svcSources = SvcSourceSelectionService.getServiceSources();
+        vm.saveButtonDisabled = true;
         
+        /*
+         * When the selected service source changed
+         */
+        $scope.$on('selectedServiceSourceChanged', function (event) {
+            var selectedSrc = SvcSourceSelectionService.selectedServiceSource();
+            if(selectedSrc === null) {
+                // Requests modelTable to refresh
+                $rootScope.$broadcast("refreshModelTableList");
+                return;
+            }
+            // Get the source name
+            var selSvcSourceName = selectedSrc.keng__id;
+            
+            // Gets selected model name, then builds a temp model based on its ddl
+            var successCallback = function(selSvcSourceModelName) {
+                // Create Temp Model in the workspace using the selected model ddl
+                buildTempVdbAndModel(selSvcSourceName,selSvcSourceModelName);
+            };
+
+            var failureCallback = function(errorMsg) {
+                alert("Failed to get connection: \n"+errorMsg);
+            };
+            
+            SvcSourceSelectionService.selectedServiceSourceConnectionName(successCallback, failureCallback);
+        });
+
         // Gets the available service sources
         vm.getSvcSources = function() {
             return vm.svcSources;
         };
 
-        // Event handler for clicking the update button
-        vm.onUpdateDataServiceClicked = function ( dataserviceName, dataserviceDescription ) {
+        /**
+         * Creates a temp model in the workspace from teiid DDL.  Temp model is used to build the Views
+         */
+        function buildTempVdbAndModel ( vdbName, modelName ) {
+            // Gets the teiid model schema.  If successful, create a temp model using the schema
             try {
-                RepoRestService.updateDataService( dataserviceName, dataserviceDescription ).then(
-                    function () {
-                        // Reinitialise the list of data services
-                        DSSelectionService.refresh();
-                        // Broadcast the pageChange
-                        $rootScope.$broadcast("dataServicePageChanged", 'dataservice-summary');
-                    },
-                    function (response) {
-                        throw RepoRestService.newRestException("Failed to update the dataservice. \n" + response.message);
-                    });
-            } catch (error) {} finally {
+                RepoRestService.updateVdbModelFromDdl( SYNTAX.TEMP+vdbName, modelName, vdbName, modelName ).then(
+                        function ( result ) {
+                            // Requests modelTable to refresh
+                            $rootScope.$broadcast("refreshModelTableList");
+                        },
+                        function (response) {
+                            // Requests modelTable to refresh
+                            $rootScope.$broadcast("refreshModelTableList");
+                        });
+            } catch (error) {
+                // Requests modelTable to refresh
+                $rootScope.$broadcast("refreshModelTableList");
+            } finally {
             }
+        }
+
+        /**
+         * Can the service be saved
+         */
+        vm.canSaveDataService = function() {
+            if (angular.isUndefined(vm.serviceName) ||
+                vm.serviceName === null || vm.serviceName === SYNTAX.EMPTY_STRING)
+                return false;
+            
+            var selectedSrc = SvcSourceSelectionService.selectedServiceSource();
+            if(selectedSrc===null) return false;
+
+            var selectedTable = TableSelectionService.selectedTable();
+            if(selectedTable === null) return false;
+
+            return true;
+        };
+        
+        // Event handler for clicking the save button
+        //   - generate the data service using selections
+        //   - delete 'scratch' models when done
+        vm.onSaveDataServiceClicked = function ( ) {
+            if (! vm.canSaveDataService())
+                return;
+            
+            // Gets the VDB / Model / Table selections
+            var selectedSrc = SvcSourceSelectionService.selectedServiceSource();
+            var selSvcSourceName = selectedSrc.keng__id;
+            
+            // Gets selected model name, create the dataservice VDB
+            var successCallback = function(selSvcSourceModelName) {
+                var table = TableSelectionService.selectedTable();
+                var tableName = table.keng__id;
+                
+                // Path to modelSource and temp table for definition of the dataservice vdb
+                var relativeModelSourcePath = selSvcSourceName+"/"+selSvcSourceModelName+"/vdb:sources/"+selSvcSourceModelName;
+                var relativeTablePath = SYNTAX.TEMP+selSvcSourceName+"/"+selSvcSourceModelName+"/"+tableName;
+                
+                try {
+                    RepoRestService.setDataServiceVdbForSingleTable( vm.serviceName, relativeTablePath, relativeModelSourcePath ).then(
+                        function () {
+                            // Reinitialise the list of data services
+                            DSSelectionService.refresh();
+                            // Broadcast the pageChange
+                            $rootScope.$broadcast("dataServicePageChanged", 'dataservice-summary');
+                        },
+                        function (response) {
+                            throw RepoRestService.newRestException("Failed to update the dataservice. \n" + response.message);
+                        });
+                } catch (error) {} finally {
+                }
+            };
+
+            var failureCallback = function(errorMsg) {
+                alert("Failed to get connection: \n"+errorMsg);
+            };
+            
+            SvcSourceSelectionService.selectedServiceSourceConnectionName(successCallback, failureCallback);
         };
     }
 

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsNewController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsNewController.js
@@ -8,20 +8,102 @@
         .module(pluginName)
         .controller('DSNewController', DSNewController);
 
-    DSNewController.$inject = ['$rootScope', 'RepoRestService', 'DSSelectionService'];
+    DSNewController.$inject = ['$scope', '$rootScope', 'REST_URI', 'SYNTAX', 'RepoRestService', 'DSSelectionService', 
+                               'SvcSourceSelectionService', 'TableSelectionService'];
 
-    function DSNewController($rootScope, RepoRestService, DSSelectionService) {
+    function DSNewController($scope, $rootScope, REST_URI, SYNTAX, RepoRestService, DSSelectionService, 
+                             SvcSourceSelectionService, TableSelectionService) {
         var vm = this;
+        
+        vm.svcSourcesLoading = SvcSourceSelectionService.isLoading();
+        vm.svcSources = SvcSourceSelectionService.getServiceSources();
+        
+        SvcSourceSelectionService.selectServiceSource(null);
+        TableSelectionService.selectTable(null);
+        
+        /*
+         * When the selected service source changed
+         */
+        $scope.$on('selectedServiceSourceChanged', function (event) {
+            var selectedSrc = SvcSourceSelectionService.selectedServiceSource();
+            if(selectedSrc === null) {
+                // Requests modelTable to refresh
+                $rootScope.$broadcast("refreshModelTableList");
+                return;
+            }
+            // Get Selected source name
+            var selSvcSourceName = selectedSrc.keng__id;
+            
+            // Gets selected model name, then builds a temp model based on its ddl
+            var successCallback = function(selSvcSourceModelName) {
+                // Create Temp Model in the workspace using the selected model ddl
+                buildTempVdbAndModel(selSvcSourceName,selSvcSourceModelName);
+            };
 
-        // Event handler for clicking the create button
-        vm.onCreateDataServiceClicked = function ( dataserviceName, dataserviceDescription ) {
+            var failureCallback = function(errorMsg) {
+                alert("Failed to get connection: \n"+errorMsg);
+            };
+            
+            SvcSourceSelectionService.selectedServiceSourceConnectionName(successCallback, failureCallback);
+        });
+        
+        // Gets the available service sources
+        vm.getSvcSources = function() {
+            return vm.svcSources;
+        };
+        
+        function isNullEmptyOrUndefined(value) {
+            return !value;
+        }
+        
+        /**
+         * Creates a temp model in the workspace from teiid DDL.  Temp model is used to build the Views
+         */
+        function buildTempVdbAndModel ( vdbName, modelName ) {
+            // Gets the teiid model schema.  If successful, create a temp model using the schema
             try {
-                RepoRestService.createDataService( dataserviceName, dataserviceDescription ).then(
+                RepoRestService.updateVdbModelFromDdl( SYNTAX.TEMP+vdbName, modelName, vdbName, modelName ).then(
+                        function ( result ) {
+                            // Requests modelTable to refresh
+                            $rootScope.$broadcast("refreshModelTableList");
+                        },
+                        function (response) {
+                            // Requests modelTable to refresh
+                            $rootScope.$broadcast("refreshModelTableList");
+                        });
+            } catch (error) {
+                // Requests modelTable to refresh
+                $rootScope.$broadcast("refreshModelTableList");
+            } finally {
+            }
+        }
+
+        /**
+         * Can a new source be created
+         */
+        vm.canCreateDataService = function() {
+            if (angular.isUndefined(vm.serviceName) ||
+                vm.serviceName === null || vm.serviceName === SYNTAX.EMPTY_STRING)
+                return false;
+            
+            var selectedSrc = SvcSourceSelectionService.selectedServiceSource();
+            if(selectedSrc===null) return false;
+
+            var selectedTable = TableSelectionService.selectedTable();
+            if(selectedTable === null) return false;
+
+            return true;
+        };
+        
+        // Event handler for clicking the create button
+        vm.onCreateDataServiceClicked = function ( ) {
+            if (! vm.canCreateDataService())
+                return;
+            
+            try {
+                RepoRestService.createDataService( vm.serviceName, vm.serviceDescription ).then(
                     function () {
-                        // Reinitialise the list of data services
-                        DSSelectionService.refresh();
-                        // Broadcast the pageChange
-                        $rootScope.$broadcast("dataServicePageChanged", 'dataservice-summary');
+                        setDataserviceServiceVdb(vm.serviceName);
                     },
                     function (response) {
                         throw RepoRestService.newRestException("Failed to create the dataservice. \n" + response.message);
@@ -29,6 +111,46 @@
             } catch (error) {} finally {
             }
         };
+        
+        /**
+         * Sets the service VDB based on the table selections
+         */
+        function setDataserviceServiceVdb( dataserviceName ) {
+            // Gets the VDB / Model / Table selections
+            var selectedSrc = SvcSourceSelectionService.selectedServiceSource();
+            var selSvcSourceName = selectedSrc.keng__id;
+            
+            // Gets selected model name, create the dataservice VDB
+            var successCallback = function(selSvcSourceModelName) {
+                var table = TableSelectionService.selectedTable();
+                var tableName = table.keng__id;
+                
+                // Path to modelSource and temp table for definition of the dataservice vdb
+                var relativeModelSourcePath = selSvcSourceName+"/"+selSvcSourceModelName+"/vdb:sources/"+selSvcSourceModelName;
+                var relativeTablePath = SYNTAX.TEMP+selSvcSourceName+"/"+selSvcSourceModelName+"/"+tableName;
+                
+                try {
+                    RepoRestService.setDataServiceVdbForSingleTable( dataserviceName, relativeTablePath, relativeModelSourcePath ).then(
+                        function () {
+                            // Reinitialise the list of data services
+                            DSSelectionService.refresh();
+                            // Broadcast the pageChange
+                            $rootScope.$broadcast("dataServicePageChanged", 'dataservice-summary');
+                        },
+                        function (response) {
+                            throw RepoRestService.newRestException("Failed to update the dataservice. \n" + response.message);
+                        });
+                } catch (error) {} finally {
+                }
+            };
+
+            var failureCallback = function(errorMsg) {
+                alert("Failed to get connection: \n"+errorMsg);
+            };
+            
+            SvcSourceSelectionService.selectedServiceSourceConnectionName(successCallback, failureCallback);
+        }
+
     }
 
 })();

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsSummaryController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsSummaryController.js
@@ -52,6 +52,13 @@
             SvcSourceSelectionService.refresh('datasource-summary');
         };
 
+        /**
+         * Create New Service click
+         */
+        vm.createNewService = function() {
+            SvcSourceSelectionService.refresh('dataservice-new');
+        };
+        
         var matchesFilter = function (item, filter) {
           var match = true;
      
@@ -288,8 +295,8 @@
          * Handle new dataservice click
          */
         var newDataServiceClicked = function( ) {
-            // Broadcast the pageChange
-            $rootScope.$broadcast("dataServicePageChanged", 'dataservice-new');
+            // Start refresh of Service Sources, changing to new page
+            SvcSourceSelectionService.refresh('dataservice-new');
         };
         
         /**

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/fileImportControl.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/fileImportControl.js
@@ -131,7 +131,7 @@
                     //
                     // Attempt to upload the file to the workspace
                     //
-                    RepoRestService.upload(documentType, parameters, data).then(
+                    RepoRestService.upload(documentType, "", parameters, data).then(
                         function (importStatus) {
                             vm.showProgress(false);
                             setError(null);

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/modelTableList.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/modelTableList.html
@@ -1,0 +1,16 @@
+<div>
+    <div id="modelTableList-updating" ng-show="vm.tablesLoading==true" class="col-md-10 row">
+        <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
+        <span class="sr-only">Loading...</span>
+    </div>
+        
+    <div id="modelTableList-table-row" class="list-view-container source-listview" ng-show="vm.tablesLoading==false">
+       <div pf-list-view config="vm.listConfig" items="vm.items">
+         <div class="list-view-pf-description">
+           <div class="list-group-item-heading">
+             {{item.keng__id}}
+           </div>
+         </div>
+       </div>
+     </div>
+</div>

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/modelTableList.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/modelTableList.js
@@ -1,0 +1,114 @@
+(function () {
+    'use strict';
+
+    var pluginName = 'vdb-bench.widgets';
+    var pluginDirName = 'vdb-bench-widgets';
+
+    angular
+        .module(pluginName)
+        .directive('modelTableList', ModelTableList);
+
+    ModelTableList.$inject = ['CONFIG', 'SYNTAX'];
+    ModelTableListController.$inject = ['$scope', '$rootScope', 'RepoRestService', 'REST_URI', 'SYNTAX', 
+                                        'SvcSourceSelectionService', 'TableSelectionService', 'pfViewUtils'];
+
+    function ModelTableList(config, syntax) {
+        var directive = {
+            restrict: 'E',
+            scope: {},
+            controller: ModelTableListController,
+            controllerAs: 'vm',
+            templateUrl: config.pluginDir + syntax.FORWARD_SLASH +
+                pluginDirName + syntax.FORWARD_SLASH +
+                'modelTableList.html'
+        };
+
+        return directive;
+    }
+
+    function ModelTableListController($scope, $rootScope, RepoRestService, REST_URI, SYNTAX, 
+                                      SvcSourceSelectionService, TableSelectionService, pfViewUtils) {
+        var vm = this;
+
+        vm.tablesLoading = false;
+        vm.allItems = [];
+        vm.items = vm.allItems;
+
+        /*
+         * When the data services have been loaded
+         */
+        $scope.$on('refreshModelTableList', function (event) {
+            vm.tablesLoading = true;
+            var selectedSource = SvcSourceSelectionService.selectedServiceSource();
+            if(selectedSource === null) {
+                vm.allItems = [];
+                vm.items = [];
+                vm.tablesLoading = false;
+                return;
+            }
+            var tempVdbName = SYNTAX.TEMP+selectedSource.keng__id;
+            
+            var successCallback = function(modelName) {
+                // Update the items using the Repo scratch object
+                try {
+                    RepoRestService.getVdbModelTables( tempVdbName, modelName ).then(
+                        function ( result ) {
+                            vm.allItems = result;
+                            vm.items = vm.allItems;
+                            vm.tablesLoading = false;
+                       },
+                        function (response) {
+                            vm.tablesLoading = false;
+                            throw RepoRestService.newRestException("Failed to get Tables. \n" + response.data.error);
+                        });
+                } catch (error) {} finally {
+                }
+            };
+
+            var failureCallback = function(errorMsg) {
+            	alert("Failed to get connection: \n"+errorMsg);
+            };
+            
+            SvcSourceSelectionService.selectedServiceSourceConnectionName(successCallback,failureCallback);
+        });
+
+        /**
+         * Access to the collection of filtered data services
+         */
+        vm.getTables = function() {
+            return vm.items;
+        };
+
+        /**
+         * Access to the collection of filtered data services
+         */
+        vm.getAllTables = function() {
+            return vm.allItems;
+        };
+     
+        /** 
+         * Handle row selection
+         */
+        var handleSelect = function (item, e) {
+            var itemsSelected = vm.listConfig.selectedItems;
+            if(itemsSelected.length === 0) {
+                TableSelectionService.selectTable(null);
+            } else {
+                TableSelectionService.selectTable(item);
+            }
+        };  
+                
+        /**
+         * List and Card Configuration
+         */
+        vm.listConfig = {
+          selectItems: true,
+          showSelectBox: false,
+          multiSelect: false,
+          selectionMatchProp: 'keng__id',
+          onSelect: handleSelect,
+          checkDisabled: false
+        };
+        
+    }
+})();

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/serviceSourceList.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/serviceSourceList.html
@@ -1,0 +1,16 @@
+<div>
+    <div id="serviceSourceList-updating" ng-show="vm.srcLoading==true" class="col-md-10 row">
+        <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
+        <span class="sr-only">Loading...</span>
+    </div>
+        
+    <div id="serviceSourceList-table-row" class="list-view-container source-listview" ng-show="vm.srcLoading==false">
+       <div pf-list-view config="vm.listConfig" items="vm.getServiceSources()">
+         <div class="list-view-pf-description">
+           <div class="list-group-item-heading">
+             {{item.keng__id}}
+           </div>
+         </div>
+       </div>
+     </div>
+</div>

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/serviceSourceList.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/serviceSourceList.js
@@ -1,0 +1,96 @@
+(function () {
+    'use strict';
+
+    var pluginName = 'vdb-bench.widgets';
+    var pluginDirName = 'vdb-bench-widgets';
+
+    angular
+        .module(pluginName)
+        .directive('serviceSourceList', ServiceSourceList);
+
+    ServiceSourceList.$inject = ['CONFIG', 'SYNTAX'];
+    ServiceSourceListController.$inject = ['$scope', '$rootScope', 'RepoRestService', 'REST_URI', 'SYNTAX', 
+                                           'SvcSourceSelectionService', 'pfViewUtils'];
+
+    function ServiceSourceList(config, syntax) {
+        var directive = {
+            restrict: 'E',
+            scope: {},
+            controller: ServiceSourceListController,
+            controllerAs: 'vm',
+            templateUrl: config.pluginDir + syntax.FORWARD_SLASH +
+                pluginDirName + syntax.FORWARD_SLASH +
+                'serviceSourceList.html'
+        };
+
+        return directive;
+    }
+
+    function ServiceSourceListController($scope, $rootScope, RepoRestService, REST_URI, SYNTAX, 
+                                          SvcSourceSelectionService, pfViewUtils) {
+        var vm = this;
+
+        vm.srcLoading = SvcSourceSelectionService.isLoading();
+        vm.allItems = SvcSourceSelectionService.getServiceSources();
+        vm.items = vm.allItems;
+
+        /*
+         * When the data services have been loaded
+         */
+        $scope.$on('loadingServiceSourcesChanged', function (event, loading) {
+            vm.srcLoading = loading;
+            if(vm.srcLoading === false) {
+                vm.allItems = SvcSourceSelectionService.getServiceSources();
+                vm.items = vm.allItems;
+           }
+        });
+
+        /**
+         * Access to the collection of filtered data services
+         */
+        vm.getServiceSources = function() {
+            return vm.items;
+        };
+
+        /**
+         * Access to the collection of filtered data services
+         */
+        vm.getAllServiceSources = function() {
+            return vm.allItems;
+        };
+     
+        /** 
+         * Handle row selection
+         */
+        var handleSelect = function (item, e) {
+            var itemsSelected = vm.listConfig.selectedItems;
+            if(itemsSelected.length === 0) {
+                SvcSourceSelectionService.selectServiceSource(null);
+            } else {
+                SvcSourceSelectionService.selectServiceSource(item);
+            }
+        };  
+        
+        /**
+         * List and Card Configuration
+         */
+        vm.listConfig = {
+          selectItems: true,
+          showSelectBox: false,
+          multiSelect: false,
+          selectionMatchProp: 'keng__id',
+          onSelect: handleSelect,
+          checkDisabled: false
+        };
+        
+        /**
+         * Access to the collection of data services
+         */
+        vm.refresh = function() {
+            vm.allItems = SvcSourceSelectionService.getServiceSources();
+            vm.items = vm.allItems;
+        };
+
+        vm.refresh();
+    }
+})();


### PR DESCRIPTION
Allows simple editing of Dataservices.
- new functions added to RepositoryRestService
- Added TableSelectionService to track table selection during dataservice editing.
- Added directives for serviceSource and table lists, used on dataservice pages
- removed a couple progress dialogs
- updated service source edit page to actually do the update
