### PR TITLE
UI terminology change from 'service source' to 'source'

### DIFF
--- a/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
@@ -271,7 +271,8 @@
                     "keng__dataPath": getUserWorkspacePath()+"/"+vdbName,
                     "keng__kType": "Vdb",
                     "vdb__name": vdbName,
-                    "vdb__description": vdbDescription
+                    "vdb__description": vdbDescription,
+                    "vdb__originalFile" : getUserWorkspacePath()+"/"+vdbName
                 };
                 
                 // Property added to distinguish service sources
@@ -299,7 +300,8 @@
                     "keng__dataPath": getUserWorkspacePath()+"/"+vdbName,
                     "keng__kType": "Vdb",
                     "vdb__name": vdbName,
-                    "vdb__description": vdbDescription
+                    "vdb__description": vdbDescription,
+                    "vdb__originalFile" : getUserWorkspacePath()+"/"+vdbName
                 };
                 
                 // Property added to distinguish service sources
@@ -316,7 +318,7 @@
         /**
          * Service: create a new VDB in the repository
          */
-        service.createVdbModel = function (vdbName, modelName) {
+        service.createVdbModel = function (vdbName, modelName, isSource) {
             if (!vdbName || !modelName) {
                 throw new RestServiceException("VDB name or model name is not defined");
             }
@@ -328,6 +330,19 @@
                     "keng__kType": "Model",
                     "mmcore__modelType": "PHYSICAL"
                 };
+                
+                
+                // Adds importer properties for service sources
+                if (isSource)  {
+                    payload.keng__properties = [{ "name": "importer.TableTypes",
+                                                  "value": "TABLE"},
+                                                { "name": "importer.UseFullSchemaName",
+                                                  "value": "false"},
+                                                { "name": "importer.UseQualifiedName",
+                                                  "value": "false"},
+                                                { "name": "importer.UseCatalogName",
+                                                  "value": "false"}];
+                }
 
                 var uri = REST_URI.WORKSPACE + REST_URI.VDBS + SYNTAX.FORWARD_SLASH + vdbName + SYNTAX.FORWARD_SLASH + REST_URI.MODELS + SYNTAX.FORWARD_SLASH + modelName;
                 return restService.all(uri).post(payload);

--- a/vdb-bench-assembly/plugins/vdb-bench-core/SvcSourceSelectionService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/SvcSourceSelectionService.js
@@ -294,18 +294,18 @@
          */
         service.selectedServiceSourceConnectionName = function(onSuccessCallback, onFailureCallback) {
             if(_.isEmpty(svcSrc.serviceSource)) {
-                onFailureCallback("No service source selected");
+                onFailureCallback("No source selected");
                 return;
             }
 
             if(_.isEmpty(svcSrc.serviceSource.keng__dataPath)) {
-                onFailureCallback("Selected service does not contain a workspace path");
+                onFailureCallback("Selected source does not contain a workspace path");
                 return;
             }
 
             // Update the selected source modelName and TranslatorName - only if its in local workspace
             if (svcSrc.serviceSource.keng__dataPath.indexOf("tko:workspace") < 0) {
-                onFailureCallback("Selected service source is not in the workspace");
+                onFailureCallback("Selected source is not in the workspace");
                 return;
             }
 
@@ -313,7 +313,7 @@
                 RepoRestService.getVdbModels(svcSrc.serviceSource.keng__id).then(
                     function (models) {
                         if (_.isEmpty(models) || models.length === 0) {
-                            onFailureCallback("Failed getting VDB Connection name.\nThe service source model is not available");
+                            onFailureCallback("Failed getting VDB Connection name.\nThe source model is not available");
                             return;
                         }
 

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasourceSummaryController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasourceSummaryController.js
@@ -419,14 +419,20 @@
         vm.actionsConfig = {
           primaryActions: [
             {
+              name: 'New',
+              title: 'Create a Source',
+              actionFn: newSvcSourceClicked,
+              isDisabled: false
+            },
+            {
               name: 'Edit',
-              title: 'Edit the ServiceSource',
+              title: 'Edit the Source',
               actionFn: editSvcSourceClicked,
               isDisabled: true
             },
             {
               name: 'Delete',
-              title: 'Delete the ServiceSource',
+              title: 'Delete the Source',
               actionFn: deleteSvcSourceClicked,
               isDisabled: true
             }
@@ -434,13 +440,13 @@
           moreActions: [
             {
               name: 'Export',
-              title: 'Export the ServiceSource',
+              title: 'Export the Source',
               actionFn: exportSvcSourceClicked,
               isDisabled: true
             },
             {
               name: 'Copy',
-              title: 'Copy the ServiceSource',
+              title: 'Copy the Source',
               actionFn: cloneSvcSourceClicked,
               isDisabled: true
             },
@@ -448,14 +454,8 @@
               isSeparator: true
             },
             {
-              name: 'New',
-              title: 'Create a ServiceSource',
-              actionFn: newSvcSourceClicked,
-              isDisabled: false
-            },
-            {
               name: 'Import',
-              title: 'Import a ServiceSource',
+              title: 'Import a Source',
               actionFn: importSvcSourceClicked,
               isDisabled: false
             },
@@ -475,22 +475,22 @@
         vm.menuActions = [
             {
                 name: 'Edit',
-                title: 'Edit the Service-source',
+                title: 'Edit the Source',
                 actionFn: editSvcSourceMenuAction
             },
             {
                 name: 'Delete',
-                title: 'Delete the Service-source',
+                title: 'Delete the Source',
                 actionFn: deleteSvcSourceMenuAction
             },
             {
                 name: 'Export',
-                title: 'Export the Service-source',
+                title: 'Export the Source',
                 actionFn: exportSvcSourceMenuAction
             },
             {
                 name: 'Copy',
-                title: 'Copy the Service-source',
+                title: 'Copy the Source',
                 actionFn: cloneSvcSourceMenuAction
             }
           ];

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceCloneController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceCloneController.js
@@ -37,7 +37,7 @@
                         deployVdb(newSvcSourceName);
                     },
                     function (response) {
-                        throw RepoRestService.newRestException("Failed to clone the service source. \n" + response.message);
+                        throw RepoRestService.newRestException("Failed to clone the source. \n" + response.message);
                     });
             } catch (error) {} finally {
             }

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceEditController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceEditController.js
@@ -111,7 +111,7 @@
                     	updateVdbDescription( vm.svcSourceName, vm.svcSourceDescription);
                     },
                     function (response) {
-                        throw RepoRestService.newRestException("Failed to update the service source. \n" + response.message);
+                        throw RepoRestService.newRestException("Failed to update the source. \n" + response.message);
                     });
             } catch (error) {} finally {
             }

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceNewController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceNewController.js
@@ -73,11 +73,11 @@
                     },
                     function (resp) {
                         SvcSourceSelectionService.setLoading(false);
-                        throw RepoRestService.newRestException("Failed to create the service source Vdb. \n" + RepoRestService.responseMessage(resp));
+                        throw RepoRestService.newRestException("Failed to create the source Vdb. \n" + RepoRestService.responseMessage(resp));
                     });
             } catch (error) {
                 SvcSourceSelectionService.setLoading(false);
-                throw RepoRestService.newRestException("Failed to create the service source Vdb. \n" + error);
+                throw RepoRestService.newRestException("Failed to create the source Vdb. \n" + error);
             }
         }
 
@@ -87,7 +87,7 @@
         function createVdbModel( svcSourceName, connectionName, translatorName, jndiName ) {
             // Creates the Model within the VDB, then add the ModelSource to the Model
             try {
-                RepoRestService.createVdbModel( svcSourceName, connectionName ).then(
+                RepoRestService.createVdbModel( svcSourceName, connectionName, true ).then(
                     function (theModel) {
                         if(theModel.keng__id === connectionName) {
                             createVdbModelSource( svcSourceName, connectionName, connectionName, translatorName, jndiName );
@@ -144,11 +144,11 @@
                     function (response) {
                         SvcSourceSelectionService.setDeploying(false, vdbName, false, RepoRestService.responseMessage(response));
                         SvcSourceSelectionService.setLoading(false);
-                        throw RepoRestService.newRestException("Failed to deploy the Service-source. \n" + RepoRestService.responseMessage(response));
+                        throw RepoRestService.newRestException("Failed to deploy the Source. \n" + RepoRestService.responseMessage(response));
                     });
             } catch (error) {
                 SvcSourceSelectionService.setLoading(false);
-                throw RepoRestService.newRestException("Failed to deploy the Service-source. \n" + error);
+                throw RepoRestService.newRestException("Failed to deploy the Source. \n" + error);
             }
         }
 

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-clone.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-clone.html
@@ -3,8 +3,8 @@
         <div class="col-sm-8 col-md-9">                
             <div class="row">
                 <div class="col-sm-9">
-                    <h1><i class="fa fa-database" aria-hidden="true"></i>Copy Service Source '{{vmmain.selectedServiceSource().keng__id}}'</h1>
-                    <h3>&nbsp;&nbsp;Enter a name for the new service source</h3>
+                    <h1><i class="fa fa-database" aria-hidden="true"></i>Copy Source '{{vmmain.selectedServiceSource().keng__id}}'</h1>
+                    <h3>&nbsp;&nbsp;Enter a name for the new source</h3>
                     <form class="form-horizontal">
                         <div class="form-group">
                             <label class="col-md-2 control-label" for="textInput">Name</label>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-edit.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-edit.html
@@ -7,8 +7,8 @@
     <div id="svcsource-edit-controls" ng-show="vm.connsLoading==false && vm.transLoading==false" class="col-md-10 row">
       <div class="row">
         <div class="col-md-11">
-            <h1><i class="fa fa-database" aria-hidden="true"></i>Edit Service Source</h1>
-            <h3>&nbsp;&nbsp;Edit the Service Source</h3>
+            <h1><i class="fa fa-database" aria-hidden="true"></i>Edit Source</h1>
+            <h3>&nbsp;&nbsp;Edit the Source</h3>
             <form class="form-horizontal">
                 <div class="form-group">
                     <label class="col-md-2 control-label" for="textInput">Name</label>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-import.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-import.html
@@ -3,7 +3,7 @@
         <div class="col-sm-8 col-md-9">                
             <div class="row">
                 <div class="col-sm-9">
-                    <h1><i class="fa fa-database" aria-hidden="true"></i>Import Service Source</h1>
+                    <h1><i class="fa fa-database" aria-hidden="true"></i>Import Source</h1>
                     <h3>&nbsp;&nbsp;Choose the VDB file to import from your file system</h3>
                     <!-- Show the import dialog when importing -->
                     <div ng-init="vm.onImportSvcSourceClicked()" ng-show="!vm.init && vm.showImport">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-new.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-new.html
@@ -7,8 +7,8 @@
     <div id="svcsource-new-controls" ng-show="vm.connsLoading==false && vm.transLoading==false && vm.createAndDeployInProgress==false" class="col-md-10 row">
       <div class="row">
         <div class="col-md-11">
-            <h1><i class="fa fa-database" aria-hidden="true"></i>New Service Source</h1>
-            <h3>&nbsp;&nbsp;Create a new Service Source</h3>
+            <h1><i class="fa fa-database" aria-hidden="true"></i>New Source</h1>
+            <h3>&nbsp;&nbsp;Create a new Source</h3>
             <form class="form-horizontal">
                 <div class="form-group">
                     <label class="col-md-2 control-label" for="textInput">Name</label>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsPageService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsPageService.js
@@ -157,7 +157,7 @@
         };
         pages[service.SERVICESOURCE_SUMMARY_PAGE] = {
             id: service.SERVICESOURCE_SUMMARY_PAGE,
-            title: 'Service-source Summary',
+            title: 'Source Summary',
             icon: 'pficon-storage-domain',
             parent: service.DS_HOME_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
@@ -167,7 +167,7 @@
         };
         pages[service.SERVICESOURCE_NEW_PAGE] = {
             id: service.SERVICESOURCE_NEW_PAGE,
-            title: 'New Service-source',
+            title: 'New Source',
             icon: 'fa-plus',
             parent: service.SERVICESOURCE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
@@ -177,7 +177,7 @@
         };
         pages[service.SERVICESOURCE_EDIT_PAGE] = {
             id: service.SERVICESOURCE_EDIT_PAGE,
-            title: 'Edit Service-source',
+            title: 'Edit Source',
             icon: 'pficon-edit',
             parent: service.SERVICESOURCE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
@@ -187,7 +187,7 @@
         };
         pages[service.SERVICESOURCE_CLONE_PAGE] = {
             id: service.SERVICESOURCE_CLONE_PAGE,
-            title: 'Clone Service-source',
+            title: 'Clone Source',
             icon: 'pficon-replicator',
             parent: service.SERVICESOURCE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
@@ -197,7 +197,7 @@
         };
         pages[service.SERVICESOURCE_IMPORT_PAGE] = {
             id: service.SERVICESOURCE_IMPORT_PAGE,
-            title: 'Import Service-source',
+            title: 'Import Source',
             icon: 'pficon-import',
             parent: service.SERVICESOURCE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsSummaryController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsSummaryController.js
@@ -259,7 +259,6 @@
          * Edit a dataservice
          */
         vm.editDataService = function(item) {
-            console.log("HELLO");
             // Need to select the item first
             DSSelectionService.selectDataService(item);
 
@@ -362,6 +361,12 @@
        vm.actionsConfig = {
           primaryActions: [
             {
+              name: 'New',
+              title: 'Create a Dataservice',
+              actionFn: newDataServiceClicked,
+              isDisabled: false
+            },
+            {
               name: 'Edit',
               title: 'Edit the Dataservice',
               actionFn: editDataServiceClicked,
@@ -395,12 +400,6 @@
             },
             {
               isSeparator: true
-            },
-            {
-              name: 'New',
-              title: 'Create a Dataservice',
-              actionFn: newDataServiceClicked,
-              isDisabled: false
             },
             {
               name: 'Import',

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/service-sources/svcsources.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/service-sources/svcsources.html
@@ -4,7 +4,7 @@
     <p ng-show="! vm.loading && vm.error">Status Error:<br/>'{{vm.error}}'</p>
 
     <div ng-show="! vm.loading && ! vm.error">
-        Number of service-sources: <span style="color: blue;">{{vm.total}}</span>
+        Number of sources: <span style="color: blue;">{{vm.total}}</span>
 
         <div class="ds-dashboard-widgets-svcsources-list-tr-names-container" ng-show="vm.total > 0">
             <div class="ds-dashboard-widgets-svcsources-list-tr-names">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/service-sources/svcsources.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/service-sources/svcsources.js
@@ -17,8 +17,8 @@
     function config(dashboardProvider, config, syntax) {
         dashboardProvider
             .widget('ds-svcsources', {
-                title: 'Workspace Service-sources',
-                description: 'Displays the current service sources in the workspace',
+                title: 'Workspace Sources',
+                description: 'Displays the current sources in the workspace',
                 templateUrl: config.pluginDir + syntax.FORWARD_SLASH +
                                     pluginDirName + syntax.FORWARD_SLASH +
                                     'svcsources.html',


### PR DESCRIPTION
- changes 'Service source' terminology to 'Source' in the UI
- fixes VDB create/update in RepositoryRestService, need to supply originalFile property value
- moves 'New' button to primary actions on Dataservice and Datasource summary pages
- adds importer properties to source vdbs
