### PR TITLE
sprint 6 updates

### DIFF
--- a/vdb-bench-assembly/plugins/vdb-bench-core/DSSelectionService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/DSSelectionService.js
@@ -23,6 +23,8 @@
         ds.deploymentServiceName = null;
         ds.deploymentSuccess = false;
         ds.deploymentMessage = null;
+        ds.editServiceSourceSelection = null;
+        ds.editServiceSourceTableSelection = null;
 
         /*
          * Service instance to be returned
@@ -116,6 +118,22 @@
          */
         service.getDataServices = function() {
             return ds.dataservices;
+        };
+
+        service.setEditSourceSelection = function(sourceName) {
+            ds.editServiceSourceSelection = sourceName;
+        };
+
+        service.getEditSourceSelection = function() {
+            return ds.editServiceSourceSelection;
+        };
+
+        service.setEditSourceTableSelection = function(tableName) {
+            ds.editServiceSourceTableSelection = tableName;
+        };
+
+        service.getEditSourceTableSelection = function() {
+            return ds.editServiceSourceTableSelection;
         };
 
         /*

--- a/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
@@ -748,6 +748,34 @@
         };
 
         /**
+         * Service: Gets the workspace source VDB matches for a DataService's sources.
+         */
+        service.getWkspSourceVdbsForDataService = function (dataserviceName) {
+            return getRestService().then(function (restService) {
+                if (!dataserviceName) {
+                    throw RestServiceException("Data service name is not defined");
+                }
+
+                var uri = REST_URI.WORKSPACE + REST_URI.DATA_SERVICES + SYNTAX.FORWARD_SLASH + dataserviceName + SYNTAX.FORWARD_SLASH + REST_URI.SOURCE_VDB_MATCHES;
+                return restService.one(uri).get();
+            });
+        };
+
+        /**
+         * Service: Gets the service view tableNames for a DataService's view.
+         */
+        service.getTableNamesForDataService = function (dataserviceName) {
+            return getRestService().then(function (restService) {
+                if (!dataserviceName) {
+                    throw RestServiceException("Data service name is not defined");
+                }
+
+                var uri = REST_URI.WORKSPACE + REST_URI.DATA_SERVICES + SYNTAX.FORWARD_SLASH + dataserviceName + SYNTAX.FORWARD_SLASH + REST_URI.SERVICE_VIEW_TABLES;
+                return restService.one(uri).get();
+            });
+        };
+
+        /**
          * Service: deploy a data service from the resposiory
          */
         service.deployDataService = function (dataserviceName) {

--- a/vdb-bench-assembly/plugins/vdb-bench-core/constants.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/constants.js
@@ -55,6 +55,8 @@
             TABLES: '/Tables',
             COLUMNS: '/Columns',
             SERVICE_VDB_FOR_SINGLE_TABLE: 'ServiceVdbForSingleTable',
+            SERVICE_VIEW_TABLES: 'serviceViewTables',
+            SOURCE_VDB_MATCHES: 'sourceVdbMatches',
             MODEL_FROM_TEIID_DDL: 'ModelFromTeiidDdl',
             DATA_SERVICES_CLONE: '/dataservices/clone',
             DATA_SERVICE: '/dataservice',

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/connections/connectionCloneController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/connections/connectionCloneController.js
@@ -26,7 +26,7 @@
                         $rootScope.$broadcast("dataServicePageChanged", 'connection-summary');
                    },
                     function (response) {
-                        throw RepoRestService.newRestException("Failed to clone the connection. \n" + response.message);
+                        throw RepoRestService.newRestException("Failed to clone the connection. \n" + RepoRestService.responseMessage(response));
                     });
             } catch (error) {} finally {
             }

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/connections/connectionEditController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/connections/connectionEditController.js
@@ -24,7 +24,7 @@
                         $rootScope.$broadcast("dataServicePageChanged", 'connection-summary');
                     },
                     function (response) {
-                        throw RepoRestService.newRestException("Failed to update the connection. \n" + response.message);
+                        throw RepoRestService.newRestException("Failed to update the connection. \n" + RepoRestService.responseMessage(response));
                     });
             } catch (error) {} finally {
             }

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/connections/connectionNewController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/connections/connectionNewController.js
@@ -45,7 +45,7 @@
                         $rootScope.$broadcast("dataServicePageChanged", 'connection-summary');
                     },
                     function (response) {
-                        throw RepoRestService.newRestException("Failed to create the connection. \n" + response.message);
+                        throw RepoRestService.newRestException("Failed to create the connection. \n" + RepoRestService.responseMessage(response));
                     });
             } catch (error) {} finally {
             }

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/connections/connectionSummaryController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/connections/connectionSummaryController.js
@@ -151,7 +151,7 @@
                         ConnectionSelectionService.refresh();
                     },
                     function (response) {
-                        throw RepoRestService.newRestException("Failed to remove the connection. \n" + response.message);
+                        throw RepoRestService.newRestException("Failed to remove the connection. \n" + RepoRestService.responseMessage(response));
                     });
             } catch (error) {} finally {
             }
@@ -179,8 +179,8 @@
                         }
                    },
                     function (response) {
-                        ConnectionSelectionService.setDeploying(false, selConnName, false, response.message);
-                        throw RepoRestService.newRestException("Failed to deploy the connection. \n" + response.message);
+                        ConnectionSelectionService.setDeploying(false, selConnName, false, RepoRestService.responseMessage(response));
+                        throw RepoRestService.newRestException("Failed to deploy the connection. \n" + RepoRestService.responseMessage(response));
                     });
             } catch (error) {} finally {
                 vm.deploymentSuccess = false;

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/connections/driverImportController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/connections/driverImportController.js
@@ -56,8 +56,8 @@
                             }
                        },
                         function (response) {
-                            DriverSelectionService.setDeploying(false, driverName, false, response.message);
-                            throw RepoRestService.newRestException("Failed to deploy the driver. \n" + response.message);
+                            DriverSelectionService.setDeploying(false, driverName, false, RepoRestService.responseMessage(response));
+                            throw RepoRestService.newRestException("Failed to deploy the driver. \n" + RepoRestService.responseMessage(response));
                         });
                 } catch (error) {} finally {
                     vm.deploymentSuccess = false;

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/content/css/styles.less
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/content/css/styles.less
@@ -210,7 +210,25 @@
 
 .ds-summary-results .list-group-item:hover,
 .svcsource-summary-results .list-group-item:hover {
-    background-color: #cff5ff;
+    background-color: #bbbbbb;
+}
+
+.ds-summary-results .list-group-item.active,
+.svcsource-summary-results .list-group-item.active {
+    background-color: #b3e3ff;
+    border-color: transparent;
+}
+
+.ds-summary-results .list-view-pf-main-info,
+.svcsource-summary-results .list-view-pf-main-info {
+    padding-top: 10px;
+    padding-bottom: 10px;
+}
+
+.ds-summary-results .list-view-pf-actions,
+.svcsource-summary-results .list-view-pf-actions {
+    margin-top: 10px;
+    margin-bottom: 10px;
 }
 
 .svcsource-summary-results-container {

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-clone.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-clone.html
@@ -4,7 +4,7 @@
         <div class="col-sm-8 col-md-9">                
             <div class="row">
                 <div class="col-sm-9">
-                    <h1><i class="fa pficon-replicator" aria-hidden="true"></i>Copy DataService '{{vmmain.selectedDataservice().keng__id}}'</h1>
+                    <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}} '{{vmmain.selectedDataservice().keng__id}}'</span></h2>
                     <h3>&nbsp;&nbsp;Enter a name for the new dataservice</h3>
                     <form class="form-horizontal">
                         <div class="form-group">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-edit.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-edit.html
@@ -1,42 +1,44 @@
 <div class="container-fluid" ng-controller="DSEditController as vm">
 
     <div id="dsEdit-edit-controls" ng-show="vm.svcSourcesLoading==false" class="col-md-10 row">
-            <div class="row">
-                <div class="col-sm-9">
-                    <h1><i class="fa pficon-edit" aria-hidden="true"></i> Edit DataService '{{vmmain.selectedDataservice().keng__id}}'</h1>
-                    <h3>&nbsp;&nbsp;Edit the DataService</h3>
-                    <form name="dsForm" class="form-horizontal">
-                        <div class="form-group">
-                            <label class="col-md-2 control-label" for="textInput">Name</label>
-                            <div class="col-md-6">
-                              <input type="text" readonly="readonly" ng-model="vm.serviceName" ng-init="vm.serviceName=vmmain.selectedDataservice().keng__id" class="form-control">
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label class="col-md-2 control-label" for="textInput">Description</label>
-                            <div class="col-md-10">
-                              <input type="text" ng-model="vm.serviceDescription" ng-init="vm.serviceDescription=vmmain.selectedDataservice().tko__description" class="form-control">
-                            </div>
-                        </div>
-                        <h4>Choose the source and table for your service</h4>
-                        <div class="col-md-5">
-                            <h4><strong>Sources</strong></h4>
-                            <service-source-list></service-source-list>
-                        </div>
-                        <div class="col-md-5">
-                            <h4><strong>Tables</strong></h4>
-                            <model-table-list></model-table-list>
-                        </div>
-                    </form>
-                    <div class="col-md-12">
-                        <p></p>
+        <div class="row">
+            <div class="col-sm-9">
+                <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}} '{{vmmain.selectedDataservice().keng__id}}'</span></h2>
+                <h3>&nbsp;&nbsp;Change the definition of your Data Service by choosing a different source and table</h3>
+                <form name="dsForm" class="form-horizontal">
+                    <div class="col-md-5">
+                        <h4><strong>Sources</strong></h4>
+                        <service-source-list selection="{{vm.initialSourceName}}"></service-source-list>
                     </div>
-                    <div class="col-md-12">
-                        <input type="submit" class="btn btn-primary" value="Save" ng-click="vm.onSaveDataServiceClicked()"
-                                                  ng-disabled="vm.canSaveDataService() !== true || vmmain.selectedPage.id !== 'dataservice-edit'"/>
-                        <input type="button" class="btn btn-default" value="Cancel" ng-click="vmmain.selectPage('dataservice-summary')"
-                                                  ng-disabled="vmmain.selectedPage.id !== 'dataservice-edit'"/>
+                    <div class="col-md-5">
+                        <h4><strong>Tables</strong></h4>
+                        <model-table-list selection="{{vm.initialSourceTableName}}"></model-table-list>
                     </div>
+                    <div class="col-md-12"></div>
+                    <div class="form-group">
+                        <label class="col-md-2 control-label" style="margin-top: 20px" for="textInput">Name</label>
+                        <div class="col-md-6" style="margin-top: 20px" >
+                          <input type="text" readonly="readonly" ng-model="vm.serviceName" ng-init="vm.serviceName=vmmain.selectedDataservice().keng__id" class="form-control">
+                        </div>
+                    </div>
+                    <div class="form-group">
+                        <label class="col-md-2 control-label" for="textInput">Description</label>
+                        <div class="col-md-6">
+                          <input type="text" ng-model="vm.serviceDescription" ng-init="vm.serviceDescription=vmmain.selectedDataservice().tko__description" class="form-control">
+                        </div>
+                    </div>
+                </form>
+                <div class="col-md-12">
+                    <p></p>
+                </div>
+                <div class="col-md-12">
+                    <input type="submit" class="btn btn-primary" value="Save" ng-click="vm.onSaveDataServiceClicked()"
+                                              ng-disabled="vm.canSaveDataService() !== true || vmmain.selectedPage.id !== 'dataservice-edit'"/>
+                    <input type="button" class="btn btn-default" value="Cancel" ng-click="vmmain.selectPage('dataservice-summary')"
+                                              ng-disabled="vmmain.selectedPage.id !== 'dataservice-edit'"/>
+                </div>
             </div>
         </div>
+    </div>
+
 </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-new.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-new.html
@@ -1,45 +1,60 @@
 <div class="container-fluid" ng-controller="DSNewController as vm">
 
-    <div class="row">
-        <div class="col-sm-8 col-md-9">                
-            <div class="row">
-                <div class="col-sm-9">
-                    <h1><i class="fa fa-plus" aria-hidden="true"></i> New DataService</h1>
-                    <h3>&nbsp;&nbsp;Create a new DataService</h3>
-                    <form class="form-horizontal">
-                        <div class="form-group">
-                            <label class="col-md-2 control-label" for="textInput">Name</label>
-                            <div class="col-md-6">
-                              <input type="text" ng-model="vm.serviceName" class="form-control">
-                            </div>
+    <!-- Content shown if No Sources yet -->
+    <div id="dataservice-new-nosources" ng-show="vm.hasSources==false" class="col-md-10 row">
+        <div class="row">
+            <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
+            <p>Before you can create a new Data Service, you will need to configure a source.  To configure a Source, 
+            click <a href ng-click="vmmain.selectPage('svcsource-new')"><span class="fa fa-fw {{vmmain.page('svcsource-new').icon}}"></span><span>{{vmmain.page('svcsource-new').title}}</span></a></p>
+        </div>
+    </div>
+    
+    <div id="dataservice-new-controls" ng-show="vm.hasSources==true" class="col-md-10 row">
+        <div class="col-sm-9 row">
+            <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
+            <h4>A Data Service can be composed of one or more of your available sources.  Start creating a Data Service by selecting a source, then
+            select one of it's source tables.  If you don't see your desired source, click 
+            <a href ng-click="vmmain.selectPage('svcsource-new')"><span class="fa fa-fw {{vmmain.page('svcsource-new').icon}}"></span><span>{{vmmain.page('svcsource-new').title}}</span></a>
+            </h4>
+            <div class="col-md-5">
+                <h4><strong>Sources</strong></h4>
+                <service-source-list></service-source-list>
+            </div>
+            <div class="col-md-5">
+                <h4><strong>Tables</strong></h4>
+                <model-table-list></model-table-list>
+            </div>
+            <div class="col-md-12" ng-show="vm.showNameAndDescription">
+                <p></p>
+                <h4>Choose a name (and optional description) for your Data Service</h4>
+                <p></p>
+                <form class="form-horizontal">
+                    <div class="form-group">
+                        <label class="col-md-2 control-label" for="textInput">Name</label>
+                        <div class="col-md-6">
+                          <input type="text" ng-model="vm.serviceName" class="form-control">
                         </div>
-                        <div class="form-group">
-                            <label class="col-md-2 control-label" for="textInput">Description</label>
-                            <div class="col-md-10">
-                              <input type="text" ng-model="vm.serviceDescription" class="form-control">
-                            </div>
+                        <div class="col-md-4"></div>
+                    </div>
+                    <div class="form-group">
+                        <label class="col-md-2 control-label" for="textInput">Description</label>
+                        <div class="col-md-6">
+                          <input type="text" ng-model="vm.serviceDescription" class="form-control">
                         </div>
-                        <h4>Choose the source and table for your service</h4>
-                        <div class="col-md-5">
-                            <h4><strong>Sources</strong></h4>
-                            <service-source-list></service-source-list>
-                        </div>
-                        <div class="col-md-5">
-                            <h4><strong>Tables</strong></h4>
-                            <model-table-list></model-table-list>
-                        </div>
-                    </form>
-                </div>
-                <div class="col-md-12">
-                    <p></p>
-                </div>
-                <div class="col-md-12">
-                    <input type="submit" class="btn btn-primary" value="Create" ng-click="vm.onCreateDataServiceClicked()"
-                                              ng-disabled="vm.canCreateDataService() !== true || vmmain.selectedPage.id !== 'dataservice-new'"/>
-                    <input type="button" class="btn btn-default" value="Cancel" ng-click="vmmain.selectPage('dataservice-summary')"
-                                              ng-disabled="vmmain.selectedPage.id !== 'dataservice-new'"/>
-                </div>
+                        <div class="col-md-4"></div>
+                    </div>
+                </form>
+            </div>
+            <div class="col-md-12">
+                <p></p>
+            </div>
+            <div class="col-md-12">
+                <input type="submit" class="btn btn-primary" value="Create" ng-click="vm.onCreateDataServiceClicked()"
+                                          ng-disabled="vm.canCreateDataService() !== true || vmmain.selectedPage.id !== 'dataservice-new'"/>
+                <input type="button" class="btn btn-default" value="Cancel" ng-click="vmmain.selectPage('dataservice-summary')"
+                                          ng-disabled="vmmain.selectedPage.id !== 'dataservice-new'"/>
             </div>
         </div>
     </div>
+
 </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-summary.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-summary.html
@@ -1,32 +1,46 @@
 <div id="ds-summary-container" class="container-fluid" ng-controller="DSSummaryController as vm">
 
-    <div id="dataservice-summary-noservices" ng-show="vm.dsLoading==false && vm.getAllDataServices().length==0" class="col-md-10 row" style="border-style:solid;border-width:2px;padding-bottom:10px;border-color:#999999;background-color:#EEEEEE">
-	   <div class="row">
-           <div class="col-md-2"></div>
-	       <div class="col-md-8">
-	           <img src="plugins/vdb-bench-dataservice/content/img/EmptyLibraryImage.png" style="max-height:100%;max-width:100%;">
-	       </div>
-           <div class="col-md-2"></div>
-	   </div>
-	   <div class="row">
-	       <div class="col-md-4"></div>
-	       <div class="col-md-6">
-                <button class="btn btn-primary" ng-click="vm.createNewService()" ng-class="{active:vmmain.selectedPage.id == 'dataservice-summary'}">Create Data Service</button>
-                <button class="btn btn-primary" ng-click="vmmain.selectPage('dataservice-import')" ng-class="{active:vmmain.selectedPage.id == 'dataservice-summary'}">Import Data Service</button>
-	       </div>
-	       <div class="col-md-2"></div>
-	   </div>
+    <!-- Content shown if No Sources or DataServices yet -->
+    <div id="dataservice-summary-nosources" ng-show="vm.dsLoading==false && vm.sourcesLoading==false && vm.hasSources==false && vm.hasServices==false" class="col-md-10 row">
+        <div class="row">
+            <h2>Welcome to the <strong>Data Services Builder</strong>!</h2>
+            <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
+            <p>A Data Service is created using one or more Sources.  To create your first Source, click 
+               <a href ng-click="vmmain.selectPage('svcsource-new')"><span class="fa fa-fw {{vmmain.page('svcsource-new').icon}}"></span><span>{{vmmain.page('svcsource-new').title}}</span></a>
+               <br>
+               You can also import an existing Data Service.  To import a Data Service,
+               click <a href ng-click="vmmain.selectPage('dataservice-import')"><span class="fa fa-fw {{vmmain.page('dataservice-import').icon}}"></span><span>{{vmmain.page('dataservice-import').title}}</span></a>
+            </p>
+        </div>
     </div>
-    <div id="dataservice-summary-updating" ng-show="vm.dsLoading==true" class="col-md-10 row">
+
+    <!-- Content shown if No DataServices yet -->
+    <div id="dataservice-summary-noservices" ng-show="vm.dsLoading==false && vm.sourcesLoading==false && vm.hasSources==true && vm.hasServices==false" class="col-md-10 row">
+        <div class="row">
+            <h2>Welcome to the <strong>Data Services Builder</strong>!</h2>
+            <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
+            <p>A Data Service is created using one or more Sources.  To create your first Data Service, click 
+               <a href ng-click="vmmain.selectPage('dataservice-new')"><span class="fa fa-fw {{vmmain.page('dataservice-new').icon}}"></span><span>{{vmmain.page('dataservice-new').title}}</span></a>
+               <br>
+               You can also import an existing Data Service.  To import a Data Service,
+               click <a href ng-click="vmmain.selectPage('dataservice-import')"><span class="fa fa-fw {{vmmain.page('dataservice-import').icon}}"></span><span>{{vmmain.page('dataservice-import').title}}</span></a>
+            </p>
+        </div>
+    </div>
+
+    <div id="dataservice-summary-updating" ng-show="vm.dsLoading==true || vm.sourcesLoading==true" class="col-md-10 row">
         <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
         <span class="sr-only">Loading...</span>
     </div>
 
-    <div id="ds-summary-table" class="col-md-10 row" ng-show="vm.dsLoading==false && vm.getAllDataServices().length>0">
+    <div id="ds-summary-table" class="col-md-10 row" ng-show="vm.dsLoading==false && vm.sourcesLoading==false && vm.hasServices==true">
+        <div class="row">
+            <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
+        </div>
         <div pf-toolbar id="dataserviceToolbar" config="vm.toolbarConfig"></div>
 
-        <div class="row ds-summary-results">
             <div class="col-md-12 list-view-container" ng-if="vm.viewType == 'listView'">
+        <div class="row ds-summary-results">
                 <div pf-list-view config="vm.listConfig" items="vm.getDataServices()" menu-actions="vm.menuActions">
                         <div class="list-view-pf-left">
                             <span class="fa fa-cube list-view-pf-icon-sm"></span>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-test.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-test.html
@@ -9,7 +9,7 @@
     <div ng-show="vm.dsDeploymentInProgress==false" class="row">
         <div class="col-sm-12">
             <div id="ds-test-header">
-                <h1><i class="fa pficon-running" aria-hidden="true"></i> Test DataService '{{vmmain.selectedDataservice().keng__id}}'</h1>
+                <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}} '{{vmmain.selectedDataservice().keng__id}}'</span></h2>
             </div>
         </div>
     </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservicePageController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservicePageController.js
@@ -133,7 +133,7 @@
             return ConnectionSelectionService.getConnectionState(conn);
         };
 
-        vm.selectPage(DSPageService.DS_HOME_PAGE);
+        vm.selectPage(DSPageService.DATASERVICE_SUMMARY_PAGE);
     }
 
 })();

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasource-summary.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasource-summary.html
@@ -1,16 +1,31 @@
 <div id="svcsource-summary-container" class="container-fluid" ng-controller="DatasourceSummaryController as vm">
     
+    <!-- Content shown if No Sources yet -->
+    <div id="svcsource-summary-nosources" ng-show="vm.srcLoading==false && vm.hasSources==false" class="col-md-10 row">
+        <div class="row">
+            <h2>Welcome to the <strong>Data Services Builder</strong>!</h2>
+            <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
+            <p>Currently, there are no Sources configured.  To get started, 
+               click <a href ng-click="vmmain.selectPage('svcsource-new')"><span class="fa fa-fw {{vmmain.page('svcsource-new').icon}}"></span><span>{{vmmain.page('svcsource-new').title}}</span></a>
+            </p>
+        </div>
+    </div>
+    
     <div id="svcsource-summary-updating" ng-show="vm.srcLoading==true" class="col-md-10 row">
         <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
         <span class="sr-only">Loading...</span>
     </div>
 
-    <div id="svcsource-summary-table" class="col-md-10 row">
+    <div id="svcsource-summary-table" class="col-md-10 row" ng-show="vm.srcLoading==false && vm.hasSources==true">
+        <div class="row">
+            <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
+        </div>
+
         <div pf-toolbar id="svcsourceToolbar" config="vm.toolbarConfig"></div>
 
         <div class="svcsource-summary-results-container">
             <div class="svcsource-summary-results">
-                <div class="col-md-12 list-view-container" ng-if="vm.viewType == 'listView'" ng-show="vm.srcLoading==false">
+                <div class="col-md-12 list-view-container" ng-if="vm.viewType == 'listView'">
                     <div pf-list-view config="vm.listConfig" items="vm.getServiceSources()" menu-actions="vm.menuActions">
                         <div class="list-view-pf-left">
                             <span class="fa fa-database list-view-pf-icon-sm"></span>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasourceSummaryController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasourceSummaryController.js
@@ -23,6 +23,7 @@
         vm.selectedSourceDDL = "";
         vm.deleteVdbInProgress = false;
         vm.displayDdl = false; // Do not display by default
+        vm.hasSources = false;
 
         /**
          * Options for the codemirror editor used for previewing ddl
@@ -47,7 +48,10 @@
                 vm.items = vm.allItems;
                 vm.filterConfig.resultsCount = vm.items.length;
                 vm.deleteVdbInProgress = false;
-           }
+                vm.hasSources = vm.allItems.length>0;
+            } else {
+                vm.hasSources = false;
+            }
         });
 
         /**
@@ -524,6 +528,7 @@
             vm.allItems = SvcSourceSelectionService.getServiceSources();
             vm.items = vm.allItems;
             vm.filterConfig.resultsCount = vm.items.length;
+            vm.hasSources = vm.allItems.length>0;
         };
 
         vm.refresh();

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceCloneController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceCloneController.js
@@ -37,7 +37,7 @@
                         deployVdb(newSvcSourceName);
                     },
                     function (response) {
-                        throw RepoRestService.newRestException("Failed to clone the service source. \n" + response.message);
+                        throw RepoRestService.newRestException("Failed to clone the source. \n" + RepoRestService.responseMessage(response));
                     });
             } catch (error) {} finally {
             }
@@ -63,7 +63,7 @@
                    },
                     function (response) {
                         SvcSourceSelectionService.setDeploying(false, vdbName, false, response.message);
-                        throw RepoRestService.newRestException("Failed to deploy the ServiceSource. \n" + response.message);
+                        throw RepoRestService.newRestException("Failed to deploy the ServiceSource. \n" + RepoRestService.responseMessage(response));
                     });
             } catch (error) {} finally {
             }

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceEditController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceEditController.js
@@ -111,7 +111,7 @@
                     	updateVdbDescription( vm.svcSourceName, vm.svcSourceDescription);
                     },
                     function (response) {
-                        throw RepoRestService.newRestException("Failed to update the service source. \n" + response.message);
+                        throw RepoRestService.newRestException("Failed to update the source. \n" + RepoRestService.responseMessage(response));
                     });
             } catch (error) {} finally {
             }

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceNewController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceNewController.js
@@ -15,6 +15,8 @@
                                      SvcSourceSelectionService, ConnectionSelectionService, TranslatorSelectionService) {
         var vm = this;
 
+        vm.numberSources = 0;
+        
         vm.connsLoading = ConnectionSelectionService.isLoading();
         vm.allConnections = ConnectionSelectionService.getConnections();
         
@@ -61,6 +63,7 @@
         function createAndDeploySvcSourceVdb ( svcSourceName, svcSourceDescription, connectionName, jndiName, translatorName ) {
             // Set loading true for modal popup
             vm.createAndDeployInProgress = true;
+            vm.numberSources = SvcSourceSelectionService.getServiceSources().length;
             SvcSourceSelectionService.setLoading(true);
             
             // Creates the VDB.  On success, the VDB Model is added to the VDB
@@ -138,8 +141,12 @@
                         } else {
                             SvcSourceSelectionService.setDeploying(false, vdbName, false, result.Information.ErrorMessage1);
                         }
-                        // Reinitialise the list of service sources
-                        SvcSourceSelectionService.refresh('datasource-summary');
+                        // Refresh and direct to appropriate page.  If no sources prior to this create, go directly to new service page
+                        if(vm.numberSources===0) {
+                            SvcSourceSelectionService.refresh('dataservice-new');
+                        } else {
+                            SvcSourceSelectionService.refresh('datasource-summary');
+                        }
                    },
                     function (response) {
                         SvcSourceSelectionService.setDeploying(false, vdbName, false, RepoRestService.responseMessage(response));

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-clone.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-clone.html
@@ -3,8 +3,8 @@
         <div class="col-sm-8 col-md-9">                
             <div class="row">
                 <div class="col-sm-9">
-                    <h1><i class="fa fa-database" aria-hidden="true"></i>Copy Service Source '{{vmmain.selectedServiceSource().keng__id}}'</h1>
-                    <h3>&nbsp;&nbsp;Enter a name for the new service source</h3>
+                    <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}} '{{vmmain.selectedServiceSource().keng__id}}'</span></h2>
+                    <h3>&nbsp;&nbsp;Enter a name for the new source</h3>
                     <form class="form-horizontal">
                         <div class="form-group">
                             <label class="col-md-2 control-label" for="textInput">Name</label>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-edit.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-edit.html
@@ -7,10 +7,10 @@
     <div id="svcsource-edit-controls" ng-show="vm.connsLoading==false && vm.transLoading==false" class="col-md-10 row">
       <div class="row">
         <div class="col-md-11">
-            <h1><i class="fa fa-database" aria-hidden="true"></i>Edit Service Source</h1>
-            <h3>&nbsp;&nbsp;Edit the Service Source</h3>
+            <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
+            <h4>Reconfigure an existing Source:</h4>
             <form class="form-horizontal">
-                <div class="form-group">
+                <div class="form-group" style="margin-top: 20px">
                     <label class="col-md-2 control-label" for="textInput">Name</label>
                     <div class="col-md-6">
                         <input type="text" readonly="readonly" ng-model="vm.svcSourceName" ng-init="vm.svcSourceName=vmmain.selectedServiceSource().keng__id" class="form-control">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-import.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-import.html
@@ -3,7 +3,7 @@
         <div class="col-sm-8 col-md-9">                
             <div class="row">
                 <div class="col-sm-9">
-                    <h1><i class="fa fa-database" aria-hidden="true"></i>Import Service Source</h1>
+                    <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
                     <h3>&nbsp;&nbsp;Choose the VDB file to import from your file system</h3>
                     <!-- Show the import dialog when importing -->
                     <div ng-init="vm.onImportSvcSourceClicked()" ng-show="!vm.init && vm.showImport">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-new.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-new.html
@@ -7,10 +7,10 @@
     <div id="svcsource-new-controls" ng-show="vm.connsLoading==false && vm.transLoading==false && vm.createAndDeployInProgress==false" class="col-md-10 row">
       <div class="row">
         <div class="col-md-11">
-            <h1><i class="fa fa-database" aria-hidden="true"></i>New Service Source</h1>
-            <h3>&nbsp;&nbsp;Create a new Service Source</h3>
+            <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
+            <h4>Sources are the building blocks for your Data Services.  Start the Source configuration by selecting one of your available Connection definitions.</h4>
             <form class="form-horizontal">
-                <div class="form-group">
+                <div class="form-group" style="margin-top: 20px">
                     <label class="col-md-2 control-label" for="textInput">Name</label>
                     <div class="col-md-6">
                         <input type="text" ng-model="vm.svcSourceName" class="form-control" required="true">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsCloneController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsCloneController.js
@@ -26,7 +26,7 @@
                         $rootScope.$broadcast("dataServicePageChanged", 'dataservice-summary');
                    },
                     function (response) {
-                        throw RepoRestService.newRestException("Failed to clone the dataservice. \n" + response.message);
+                        throw RepoRestService.newRestException("Failed to clone the dataservice. \n" + RepoRestService.responseMessage(response));
                     });
             } catch (error) {} finally {
             }

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsNewController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsNewController.js
@@ -17,6 +17,10 @@
         
         vm.svcSourcesLoading = SvcSourceSelectionService.isLoading();
         vm.svcSources = SvcSourceSelectionService.getServiceSources();
+        vm.hasSources = vm.svcSources.length>0;
+        vm.selectedSrc = null;
+        vm.selectedTable = null;
+        vm.showNameAndDescription = false;
         
         SvcSourceSelectionService.selectServiceSource(null);
         TableSelectionService.selectTable(null);
@@ -25,14 +29,16 @@
          * When the selected service source changed
          */
         $scope.$on('selectedServiceSourceChanged', function (event) {
-            var selectedSrc = SvcSourceSelectionService.selectedServiceSource();
-            if(selectedSrc === null) {
+            vm.selectedSrc = SvcSourceSelectionService.selectedServiceSource();
+            vm.selectedTable = null;
+            updateNameDescriptionState();
+            if(vm.selectedSrc === null) {
                 // Requests modelTable to refresh
                 $rootScope.$broadcast("refreshModelTableList");
                 return;
             }
             // Get Selected source name
-            var selSvcSourceName = selectedSrc.keng__id;
+            var selSvcSourceName = vm.selectedSrc.keng__id;
             
             // Gets selected model name, then builds a temp model based on its ddl
             var successCallback = function(selSvcSourceModelName) {
@@ -45,6 +51,14 @@
             };
             
             SvcSourceSelectionService.selectedServiceSourceConnectionName(successCallback, failureCallback);
+        });
+
+        /*
+         * When the selected table changes
+         */
+        $scope.$on('selectedTableChanged', function (event) {
+            vm.selectedTable = TableSelectionService.selectedTable();
+            updateNameDescriptionState();
         });
         
         // Gets the available service sources
@@ -94,6 +108,17 @@
 
             return true;
         };
+
+        /**
+         * should show name and description
+         */
+        function updateNameDescriptionState() {
+            if(vm.selectedTable === null || vm.selectedSrc === null) {
+                vm.showNameAndDescription = false;
+            } else {
+                vm.showNameAndDescription = true;
+            }
+        }
         
         // Event handler for clicking the create button
         vm.onCreateDataServiceClicked = function ( ) {
@@ -106,7 +131,7 @@
                         setDataserviceServiceVdb(vm.serviceName);
                     },
                     function (response) {
-                        throw RepoRestService.newRestException("Failed to create the dataservice. \n" + response.message);
+                        throw RepoRestService.newRestException("Failed to create the dataservice. \n" + RepoRestService.responseMessage(response));
                     });
             } catch (error) {} finally {
             }
@@ -138,7 +163,7 @@
                             $rootScope.$broadcast("dataServicePageChanged", 'dataservice-summary');
                         },
                         function (response) {
-                            throw RepoRestService.newRestException("Failed to update the dataservice. \n" + response.message);
+                            throw RepoRestService.newRestException("Failed to update the dataservice. \n" + RepoRestService.responseMessage(response));
                         });
                 } catch (error) {} finally {
                 }

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsPageService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsPageService.js
@@ -54,7 +54,7 @@
         };
         pages[service.DATASERVICE_SUMMARY_PAGE] = {
             id: service.DATASERVICE_SUMMARY_PAGE,
-            title: 'Data Services',
+            title: 'Data Service Summary',
             icon: 'fa-search',
             parent: service.DS_HOME_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
@@ -149,7 +149,7 @@
         };
         pages[service.CLONE_CONNECTION_PAGE] = {
             id: service.CLONE_CONNECTION_PAGE,
-            title: 'Clone Connection',
+            title: 'Copy Connection',
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
                             'connections' + syntax.FORWARD_SLASH +
@@ -167,8 +167,8 @@
         };
         pages[service.SERVICESOURCE_NEW_PAGE] = {
             id: service.SERVICESOURCE_NEW_PAGE,
-            title: 'New Service-source',
-            icon: 'fa-plus',
+            title: 'Configure Source',
+            icon: 'pficon-settings',
             parent: service.SERVICESOURCE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
@@ -187,7 +187,7 @@
         };
         pages[service.SERVICESOURCE_CLONE_PAGE] = {
             id: service.SERVICESOURCE_CLONE_PAGE,
-            title: 'Clone Service-source',
+            title: 'Copy Source',
             icon: 'pficon-replicator',
             parent: service.SERVICESOURCE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/content/css/styles.less
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/content/css/styles.less
@@ -239,3 +239,40 @@ svg {
 #btn-save-repo {
     padding: 6px 25px;
 }
+
+.pick-list-results .list-group-item,
+.pick-list-results .list-group-item:first-child {
+    margin-bottom: 5px;
+    border-top: 1px solid #ffffff;
+    border-bottom: 1px solid #ffffff;
+}
+
+.pick-list-results .list-group-item:hover {
+    background-color: #999999;
+}
+
+.pick-list-results .list-group-item.active {
+    background-color: #b3e3ff;
+    border-color: transparent;
+}
+
+.pick-list-results .list-view-pf-main-info {
+    padding-top: 7px;
+    padding-bottom: 7px;
+}
+
+.pick-list-results {
+    height: 190px;
+    overflow: auto;
+    line-height: 1.00;
+    padding-top: 0px;
+    padding-bottom: 0px;
+}
+
+.pick-list-container {
+    border: 1px solid #000000;
+    height: 200px;
+    min-height: 200px;
+    margin: 10px;
+    padding: 0;
+}

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/modelTableList.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/modelTableList.html
@@ -3,14 +3,18 @@
         <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
         <span class="sr-only">Loading...</span>
     </div>
-        
-    <div id="modelTableList-table-row" class="list-view-container source-listview" ng-show="vm.tablesLoading==false">
-       <div pf-list-view config="vm.listConfig" items="vm.items">
-         <div class="list-view-pf-description">
-           <div class="list-group-item-heading">
-             {{item.keng__id}}
-           </div>
-         </div>
-       </div>
-     </div>
+    
+    <div class="pick-list-container">
+        <div class="pick-list-results">
+            <div id="modelTableList-table-row" class="list-view-container" ng-show="vm.tablesLoading==false">
+                <div pf-list-view config="vm.listConfig" items="vm.items">
+                    <div class="list-view-pf-description">
+                        <div class="list-group-item-heading">
+                        {{item.keng__id}}
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
 </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/modelTableList.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/modelTableList.js
@@ -16,6 +16,9 @@
         var directive = {
             restrict: 'E',
             scope: {},
+            bindToController: {
+                selection : '@'
+            },
             controller: ModelTableListController,
             controllerAs: 'vm',
             templateUrl: config.pluginDir + syntax.FORWARD_SLASH +
@@ -55,11 +58,12 @@
                         function ( result ) {
                             vm.allItems = result;
                             vm.items = vm.allItems;
+                            setSelection();
                             vm.tablesLoading = false;
                        },
                         function (response) {
                             vm.tablesLoading = false;
-                            throw RepoRestService.newRestException("Failed to get Tables. \n" + response.data.error);
+                            throw RepoRestService.newRestException("Failed to get Tables. \n" + RepoRestService.responseMessage(response));
                         });
                 } catch (error) {} finally {
                 }
@@ -72,6 +76,22 @@
             SvcSourceSelectionService.selectedServiceSourceConnectionName(successCallback,failureCallback);
         });
 
+        function setSelection() {
+            // Selection if specified
+            var selItems = [];
+            if(vm.selection !== null) {
+            	// See if item match
+                var itemsLength = vm.items.length;
+                for (var i = 0; i < itemsLength; i++) {
+                	if(vm.items[i].keng__id==vm.selection) {
+                		selItems.push(vm.items[i]);
+                        break;
+                	}
+                } 
+            }
+            vm.listConfig.selectedItems = selItems;
+        }
+        
         /**
          * Access to the collection of filtered data services
          */

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/serviceSourceList.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/serviceSourceList.html
@@ -4,13 +4,18 @@
         <span class="sr-only">Loading...</span>
     </div>
         
-    <div id="serviceSourceList-table-row" class="list-view-container source-listview" ng-show="vm.srcLoading==false">
-       <div pf-list-view config="vm.listConfig" items="vm.getServiceSources()">
-         <div class="list-view-pf-description">
-           <div class="list-group-item-heading">
-             {{item.keng__id}}
-           </div>
-         </div>
-       </div>
-     </div>
+    <div class="pick-list-container">
+        <div class="pick-list-results">
+            <div id="serviceSourceList-table-row" class="source-list-view-container" ng-show="vm.srcLoading==false">
+                <div pf-list-view class="source-list-view-content" config="vm.listConfig" items="vm.getServiceSources()">
+                  <div class="list-view-pf-description">
+                    <div class="list-group-item-heading">
+                      {{item.keng__id}}
+                    </div>
+                  </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    
 </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/serviceSourceList.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/serviceSourceList.js
@@ -16,6 +16,9 @@
         var directive = {
             restrict: 'E',
             scope: {},
+            bindToController: {
+                selection : '@'
+            },
             controller: ServiceSourceListController,
             controllerAs: 'vm',
             templateUrl: config.pluginDir + syntax.FORWARD_SLASH +
@@ -42,7 +45,7 @@
             if(vm.srcLoading === false) {
                 vm.allItems = SvcSourceSelectionService.getServiceSources();
                 vm.items = vm.allItems;
-           }
+            }
         });
 
         /**
@@ -80,7 +83,8 @@
           multiSelect: false,
           selectionMatchProp: 'keng__id',
           onSelect: handleSelect,
-          checkDisabled: false
+          checkDisabled: false,
+          selectedItems: {}
         };
         
         /**
@@ -89,6 +93,23 @@
         vm.refresh = function() {
             vm.allItems = SvcSourceSelectionService.getServiceSources();
             vm.items = vm.allItems;
+            
+            // Set the selection (if specified)
+            var selItems = [];
+            if(vm.selection !== null) {
+            	// See if item match
+                var itemsLength = vm.items.length;
+                for (var i = 0; i < itemsLength; i++) {
+                	if(vm.items[i].keng__id==vm.selection) {
+                		selItems.push(vm.items[i]);
+                        break;
+                	}
+                } 
+            }
+            if(selItems.length==1) {
+                vm.listConfig.selectedItems = selItems;
+                SvcSourceSelectionService.selectServiceSource(selItems[0]);
+            }
         };
 
         vm.refresh();

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/sqlControl.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/sqlControl.js
@@ -137,7 +137,7 @@
                 },
                 function (response) {
                     vm.showProgress(false);
-                    vm.errorMsg = response.data.error;
+                    vm.errorMsg = RepoRestService.responseMessage(response);
                 });
         };
     }


### PR DESCRIPTION
- change error response in several places to use RepoRestService.responseMessage
- update dataservice creation and editing pages.
- startup now goes to dataservice summary page.  user will get guidance depending on number of dataservices and source in their workspace.
- changes some terminology based on feedback (eg 'configure' source)
- source and table lists now allow a selection to be provided
- css changes to reduce height of summary lists
- css changes to style the source and table lists
