### PR TITLE
TEIIDTOOLS-35 Incorporate i18n support

### DIFF
--- a/.project
+++ b/.project
@@ -10,8 +10,14 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.wst.jsdt.core.jsNature</nature>
 	</natures>
 </projectDescription>

--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -1,0 +1,36 @@
+{
+
+    "shared" : {
+        "Cancel" : "Cancel",
+        "Connection" : "Connection",
+        "CopyThis" : "Copy {{this}}",
+        "DataService" : "Data Service",
+        "Description" : "Description",
+        "Driver" : "Driver",
+        "EditThis" : "Edit {{this}}",
+        "ExportThis" : "Export {{this}}",
+        "ImportThis" : "Import {{this}}",
+        "Name" : "Name",
+        "NewThis" : "New {{this}}",
+        "Save" : "Save",
+        "Source" : "Source",
+        "ThisSummary" : "{{this}} Summary"
+    },
+
+    "dsPageService" : {
+        "configureSoureTitle" : "Configure Source",
+        "homeTitle" : "Dashboard",
+        "testDataServiceTitle" : "Test Data Service"
+    },
+
+    "dataservice-edit" : {
+        "Cancel" : "@:shared.Cancel",
+        "Description" : "@:shared.Description",
+        "instructionsMsg" : "Change the definition of your Data Service by choosing a different source and table",
+        "Name" : "@:shared.Name",
+        "Save" : "@:shared.Save",
+        "Sources" : "Sources",
+        "Tables" : "Tables"
+    }
+
+}

--- a/vdb-bench-assembly/app/vdb-bench-app.js
+++ b/vdb-bench-assembly/app/vdb-bench-app.js
@@ -6,7 +6,7 @@ var App;
     App.pluginName = 'VdbBenchApp';
     App.templatePath = 'app/';
 
-    App._module = angular.module(App.pluginName, ['vdb-bench.core']);
+    App._module = angular.module(App.pluginName, ['vdb-bench.core', 'pascalprecht.translate']);
 
     App._module.factory('CredentialService', CredentialService);
     CredentialService.$inject = ['localStorage', '$window'];
@@ -163,8 +163,8 @@ var App;
     }
 
     App._module.config(configure);
-    configure.$inject = ["$locationProvider", "$routeProvider", "$dialogProvider"];
-    function configure($locationProvider, $routeProvider, $dialogProvider) {
+    configure.$inject = ["$locationProvider", "$routeProvider", "$dialogProvider", "$translateProvider"];
+    function configure($locationProvider, $routeProvider, $dialogProvider, $translateProvider) {
         $locationProvider.html5Mode(true);
         $dialogProvider.options({
             backdropFade: true,
@@ -174,6 +174,35 @@ var App;
             .when('/login', {
                 templateUrl: App.templatePath + 'login.html'
             });
+        
+        // configure i18n
+        $translateProvider.useSanitizeValueStrategy('sanitize');
+        $translateProvider.useStaticFilesLoader({
+            prefix: 'app/i18n/messages-',
+            suffix: '.json'
+        });
+        
+        // default all en_* and every other locale to en right now
+        $translateProvider.registerAvailableLanguageKeys(['en'], {
+            'en_*': 'en',
+            '*': 'en'
+         });
+        
+        // try to get locale from browser
+        var l_lang;
+        if (navigator.languages != undefined) { // Chrome
+        	l_lang = navigator.languages[0];
+        } else if (navigator.userLanguage) { // Explorer
+            l_lang = navigator.userLanguage;
+        } else if (navigator.language) { // FF
+            l_lang = navigator.language;
+        } else {
+        	l_lang = 'en'; // fallback
+        }
+        
+        // must set lang
+        $translateProvider.preferredLanguage(l_lang);
+        $translateProvider.fallbackLanguage('en');
     }
 
     App._module.run(run);

--- a/vdb-bench-assembly/bower.json
+++ b/vdb-bench-assembly/bower.json
@@ -31,6 +31,8 @@
     "angular": "~1.5",
     "angular-animate": "~1.5.5",
     "angular-route": "~1.5.5",
+    "angular-translate": "~2.13.0",
+    "angular-translate-loader-static-files": "~2.13.0",
     "angularUtils-pagination": "angular-utils-pagination#~0.9.2",
     "angular-dashboard-framework": "^0.11.0",
     "adf-structures-base": "^0.1.1",

--- a/vdb-bench-assembly/index.html
+++ b/vdb-bench-assembly/index.html
@@ -90,7 +90,9 @@
     <script src="libs/angular-file-saver/dist/angular-file-saver.bundle.js"></script>
     <script src="libs/angular-base64/angular-base64.js"></script>
     <script src="libs/angular-ui-grid/ui-grid.min.js"></script>
-
+    <script src="libs/angular-translate/angular-translate.js"></script>
+    <script src="libs/angular-translate-loader-static-files/angular-translate-loader-static-files.js"></script>
+    
     <!-- dependencies for angular-dashboard-framework -->
     <script src="libs/Sortable/Sortable.js"></script>
     <script src="libs/angular-dashboard-framework/dist/angular-dashboard-framework.js"></script>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-edit.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-edit.html
@@ -4,25 +4,25 @@
         <div class="row">
             <div class="col-sm-9">
                 <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}} '{{vmmain.selectedDataservice().keng__id}}'</span></h2>
-                <h3>&nbsp;&nbsp;Change the definition of your Data Service by choosing a different source and table</h3>
+                <h3>{{:: 'dataservice-edit.instructionsMsg' | translate}}</h3>
                 <form name="dsForm" class="form-horizontal">
                     <div class="col-md-5">
-                        <h4><strong>Sources</strong></h4>
+                        <h4><strong>{{:: 'dataservice-edit.Sources' | translate}}</strong></h4>
                         <service-source-list selection="{{vm.initialSourceName}}"></service-source-list>
                     </div>
                     <div class="col-md-5">
-                        <h4><strong>Tables</strong></h4>
+                        <h4><strong>{{:: 'dataservice-edit.Tables' | translate}}</strong></h4>
                         <model-table-list selection="{{vm.initialSourceTableName}}"></model-table-list>
                     </div>
                     <div class="col-md-12"></div>
                     <div class="form-group">
-                        <label class="col-md-2 control-label" style="margin-top: 20px" for="textInput">Name</label>
+                        <label class="col-md-2 control-label" style="margin-top: 20px" for="textInput">{{:: 'dataservice-edit.Name' | translate}}</label>
                         <div class="col-md-6" style="margin-top: 20px" >
                           <input type="text" readonly="readonly" ng-model="vm.serviceName" ng-init="vm.serviceName=vmmain.selectedDataservice().keng__id" class="form-control">
                         </div>
                     </div>
                     <div class="form-group">
-                        <label class="col-md-2 control-label" for="textInput">Description</label>
+                        <label class="col-md-2 control-label" for="textInput">{{:: 'dataservice-edit.Description' | translate}}</label>
                         <div class="col-md-6">
                           <input type="text" ng-model="vm.serviceDescription" ng-init="vm.serviceDescription=vmmain.selectedDataservice().tko__description" class="form-control">
                         </div>
@@ -32,9 +32,9 @@
                     <p></p>
                 </div>
                 <div class="col-md-12">
-                    <input type="submit" class="btn btn-primary" value="Save" ng-click="vm.onSaveDataServiceClicked()"
+                    <input type="submit" class="btn btn-primary" value="{{:: 'dataservice-edit.Save' | translate}}" ng-click="vm.onSaveDataServiceClicked()"
                                               ng-disabled="vm.canSaveDataService() !== true || vmmain.selectedPage.id !== 'dataservice-edit'"/>
-                    <input type="button" class="btn btn-default" value="Cancel" ng-click="vmmain.selectPage('dataservice-summary')"
+                    <input type="button" class="btn btn-default" value="{{:: 'dataservice-edit.Cancel' | translate}}" ng-click="vmmain.selectPage('dataservice-summary')"
                                               ng-disabled="vmmain.selectedPage.id !== 'dataservice-edit'"/>
                 </div>
             </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsPageService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsPageService.js
@@ -14,9 +14,9 @@
         .module('vdb-bench.dataservice')
         .factory('DSPageService', DSPageService);
 
-    DSPageService.$inject = ['SYNTAX', 'CONFIG'];
+    DSPageService.$inject = ['SYNTAX', 'CONFIG', '$translate'];
 
-    function DSPageService(syntax, config) {
+    function DSPageService(syntax, config, $translate) {
         /*
          * Service instance to be returned
          */
@@ -45,7 +45,7 @@
         var pages = {};
         pages[service.DS_HOME_PAGE] = {
             id: service.DS_HOME_PAGE,
-            title: 'DS Home',
+            title: $translate.instant('dsPageService.homeTitle'),
             icon: 'fa-dashboard',
             parent: null,
             template: config.pluginDir + syntax.FORWARD_SLASH +
@@ -54,7 +54,7 @@
         };
         pages[service.DATASERVICE_SUMMARY_PAGE] = {
             id: service.DATASERVICE_SUMMARY_PAGE,
-            title: 'Data Service Summary',
+            title: $translate.instant('shared.ThisSummary', $translate.instant('shared.DataService')),
             icon: 'fa-search',
             parent: service.DS_HOME_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
@@ -63,7 +63,7 @@
         };
         pages[service.NEW_DATASERVICE_PAGE] = {
             id: service.NEW_DATASERVICE_PAGE,
-            title: 'New Data Service',
+            title: $translate.instant('shared.NewThis', $translate.instant('shared.DataService')),
             icon: 'fa-plus',
             parent: service.DATASERVICE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
@@ -72,7 +72,7 @@
         };
         pages[service.IMPORT_DATASERVICE_PAGE] = {
             id: service.IMPORT_DATASERVICE_PAGE,
-            title: 'Import Data Service',
+            title: $translate.instant('shared.ImportThis', $translate.instant('shared.DataService')),
             icon: 'pficon-import',
             parent: service.DATASERVICE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
@@ -81,7 +81,7 @@
         };
         pages[service.EXPORT_DATASERVICE_PAGE] = {
             id: service.EXPORT_DATASERVICE_PAGE,
-            title: 'Export Data Service',
+            title: $translate.instant('shared.ExportThis', $translate.instant('shared.DataService')),
             icon: 'pficon-export',
             parent: service.DATASERVICE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
@@ -90,7 +90,7 @@
         };
         pages[service.EDIT_DATASERVICE_PAGE] = {
             id: service.EDIT_DATASERVICE_PAGE,
-            title: 'Edit Data Service',
+            title: $translate.instant('shared.EditThis', $translate.instant('shared.DataService')),
             icon: 'pficon-edit',
             parent: service.DATASERVICE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
@@ -99,7 +99,7 @@
         };
         pages[service.CLONE_DATASERVICE_PAGE] = {
             id: service.CLONE_DATASERVICE_PAGE,
-            title: 'Copy Data Service',
+            title: $translate.instant('shared.CopyThis', $translate.instant('shared.DataService')),
             icon: 'pficon-replicator',
             parent: service.DATASERVICE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
@@ -108,7 +108,7 @@
         };
         pages[service.TEST_DATASERVICE_PAGE] = {
             id: service.TEST_DATASERVICE_PAGE,
-            title: 'Test Data Service',
+            title: $translate.instant('dsPageService.testDataServiceTitle'),
             icon: 'pficon-running',
             parent: service.DATASERVICE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
@@ -117,7 +117,7 @@
         };
         pages[service.CONNECTION_SUMMARY_PAGE] = {
             id: service.CONNECTION_SUMMARY_PAGE,
-            title: 'Connection Summary',
+            title: $translate.instant('shared.ThisSummary', $translate.instant('shared.Connection')),
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
                             'connections' + syntax.FORWARD_SLASH +
@@ -125,7 +125,7 @@
         };
         pages[service.NEW_CONNECTION_PAGE] = {
             id: service.NEW_CONNECTION_PAGE,
-            title: 'New Connection',
+            title: $translate.instant('shared.NewThis', $translate.instant('shared.Connection')),
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
                             'connections' + syntax.FORWARD_SLASH +
@@ -133,7 +133,7 @@
         };
         pages[service.IMPORT_CONNECTION_PAGE] = {
             id: service.IMPORT_CONNECTION_PAGE,
-            title: 'Import Connection',
+            title: $translate.instant('shared.ImportThis', $translate.instant('shared.Connection')),
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
                             'connections' + syntax.FORWARD_SLASH +
@@ -141,7 +141,7 @@
         };
         pages[service.EDIT_CONNECTION_PAGE] = {
             id: service.EDIT_CONNECTION_PAGE,
-            title: 'Edit Connection',
+            title: $translate.instant('shared.EditThis', $translate.instant('shared.Connection')),
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
                             'connections' + syntax.FORWARD_SLASH +
@@ -149,7 +149,7 @@
         };
         pages[service.CLONE_CONNECTION_PAGE] = {
             id: service.CLONE_CONNECTION_PAGE,
-            title: 'Copy Connection',
+            title: $translate.instant('shared.CopyThis', $translate.instant('shared.Connection')),
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
                             'connections' + syntax.FORWARD_SLASH +
@@ -157,7 +157,7 @@
         };
         pages[service.SERVICESOURCE_SUMMARY_PAGE] = {
             id: service.SERVICESOURCE_SUMMARY_PAGE,
-            title: 'Source Summary',
+            title: $translate.instant('shared.ThisSummary', $translate.instant('shared.Source')),
             icon: 'pficon-storage-domain',
             parent: service.DS_HOME_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
@@ -167,7 +167,7 @@
         };
         pages[service.SERVICESOURCE_NEW_PAGE] = {
             id: service.SERVICESOURCE_NEW_PAGE,
-            title: 'Configure Source',
+            title: $translate.instant('dsPageService.configureSoureTitle'),
             icon: 'pficon-settings',
             parent: service.SERVICESOURCE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
@@ -177,7 +177,7 @@
         };
         pages[service.SERVICESOURCE_EDIT_PAGE] = {
             id: service.SERVICESOURCE_EDIT_PAGE,
-            title: 'Edit Source',
+            title: $translate.instant('shared.EditThis', $translate.instant('shared.Source')),
             icon: 'pficon-edit',
             parent: service.SERVICESOURCE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
@@ -187,7 +187,7 @@
         };
         pages[service.SERVICESOURCE_CLONE_PAGE] = {
             id: service.SERVICESOURCE_CLONE_PAGE,
-            title: 'Copy Source',
+            title: $translate.instant('shared.CopyThis', $translate.instant('shared.Source')),
             icon: 'pficon-replicator',
             parent: service.SERVICESOURCE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
@@ -197,7 +197,7 @@
         };
         pages[service.SERVICESOURCE_IMPORT_PAGE] = {
             id: service.SERVICESOURCE_IMPORT_PAGE,
-            title: 'Import Source',
+            title: $translate.instant('shared.ImportThis', $translate.instant('shared.Source')),
             icon: 'pficon-import',
             parent: service.SERVICESOURCE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
@@ -207,7 +207,7 @@
         };
         pages[service.IMPORT_DRIVER_PAGE] = {
             id: service.IMPORT_DRIVER_PAGE,
-            title: 'Import Driver',
+            title: $translate.instant('shared.ImportThis', $translate.instant('shared.Driver')),
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
                             'connections' + syntax.FORWARD_SLASH +


### PR DESCRIPTION
Selected the angular-translate translation framework. This PR only adds the framework, an 'en' locale messages file, and translates the strings in one html file and one javascript file. If all looks good, we can translate the other strings/messages found in the other files. Here are the files that changed and what was done::
- bower.json: added the angular-translate related libraries. Wasn't sure how to represent the versions so please take a look
- /.project: Eclipse added the maven builder
- vdb-bench-assembly/app/vdb-bench-app.js: added angular-translate as a module dependency, configures the translate service, loads the language bundle
- vdb-bench-assembly/index.html: added script tags for the angular-translate libraries
- dataservice-edit.html: now calls the translate service for its static strings
- dsPageService.js: now calls the translate service for its static strings
- messages-en.json: the 'en' language bundle. Content is divided into sections for each page, as well as, a section for shared messages.