### PR TITLE
Address issue with editing of service sources

### DIFF
--- a/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
@@ -428,6 +428,21 @@
         };
 
         /**
+         * Service: delete the specified model from a repository vdb
+         */
+        service.deleteVdbModel = function (vdbName, modelName) {
+            if (!vdbName || !modelName) {
+                throw new RestServiceException("Vdb name or model name for delete is not defined");
+            }
+
+            return getRestService().then(function (restService) {
+
+                return restService.one(REST_URI.WORKSPACE + REST_URI.VDBS + SYNTAX.FORWARD_SLASH + vdbName + 
+                		               REST_URI.MODELS + SYNTAX.FORWARD_SLASH + modelName).remove();
+            });
+        };
+
+        /**
          * Service: delete a vdb from the resposiory
          */
         service.deleteTeiidVdb = function (vdbName) {

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-summary.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-summary.html
@@ -56,11 +56,6 @@
                                 </div>
                             </div>
                             <div class="list-view-pf-additional-info">
-                                <div class="list-view-pf-additional-info-item" uib-tooltip="The name of the service vdb of this dataservice">
-                                    <span class="pficon pficon-service"></span>
-                                    <strong><i>{{item.serviceVdbName}}</i></strong>
-                                </div>
-
                                 <!-- TODO - consider what else to include here, preferably the service sources available -->
 
                                 <div class="list-view-pf-additional-info-item" uib-tooltip="The number of native data connections, eg. JDBC databases, utilised by this dataservice">


### PR DESCRIPTION
Addresses an issue with service source editing.  If a user changes the source connection during an edit, the current code fails.  
Modified to check for a change in connection.
- if the connection is changed, the original model is removed from the sourceVdb and a model with the new connection is created
- if the connection does not change, the existing model can be updated.
Also removed the serviceVdb name from dataservice summary table based on demo feedback