### PR TITLE
Fix for race conditions when vdb is expected to be active

### DIFF
--- a/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
@@ -13,10 +13,10 @@
 
     RepoRestService.$inject = ['CONFIG', 'SYNTAX', 'REST_URI', 'VDB_SCHEMA',
                                              'VDB_KEYS', 'RepoSelectionService', 'Restangular',
-                                             '$http', '$q', '$base64', 'CredentialService'];
+                                             '$http', '$q', '$base64', 'CredentialService', '$interval'];
 
     function RepoRestService(CONFIG, SYNTAX, REST_URI, VDB_SCHEMA, VDB_KEYS, RepoSelectionService,
-                                            Restangular, $http, $q, $base64, CredentialService) {
+                                            Restangular, $http, $q, $base64, CredentialService, $interval) {
 
         /*
          * Service instance to be returned
@@ -818,6 +818,43 @@
                 var uri = REST_URI.TEIID + REST_URI.DATA_SERVICE;
                 return restService.all(uri).post(payload);
             });
+        };
+
+        /**
+         * Service: Poll the teiid server for the point that the vdb becomes active
+         * Has a timeout limit of 1 minute.
+         */
+        service.pollForActiveVdb = function(vdbName, successCallback, failCallback) {
+
+            var promise = $interval(function() {
+                service.getTeiidVdbStatus().then(
+                    function (status) {
+                        if (_.isEmpty(status) || _.isEmpty(status.vdbs))
+                            return;
+
+                        for (var i = 0; i < status.vdbs.length; ++i) {
+                            var vdb = status.vdbs[i];
+                            if (vdbName !== vdb.name)
+                                continue;
+
+                            if (vdb.active) {
+                                successCallback();
+                                $interval.cancel(promise);
+                                return;
+                            }
+                        }
+                    },
+                    function (response) {
+                        if (failCallback)
+                            failCallback(service.responseMessage(response));
+
+                        //
+                        // Failure to connect the first time means its not
+                        // going to connect the remaining 59 times
+                        //
+                        $interval.cancel(promise);
+                    });
+            }, 2000, 30); // timeout after 30 iterations (or 60 seconds)
         };
 
         /**

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsSummaryController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsSummaryController.js
@@ -226,14 +226,29 @@
          * Handle deploy dataservice click
          */
         var deployDataServiceClicked = function ( ) {
-            var selDSName = DSSelectionService.selectedDataService().keng__id;
+            var selDS = DSSelectionService.selectedDataService();
+            var selDSName = selDS.keng__id;
+            var dsVdbName = DSSelectionService.selectedDataServiceVdbName();
+
             DSSelectionService.setDeploying(true, selDSName, false, null);
             try {
                 RepoRestService.deployDataService( selDSName ).then(
                     function ( result ) {
                         vm.deploymentSuccess = result.Information.deploymentSuccess == "true";
                         if(vm.deploymentSuccess === true) {
-                            DSSelectionService.setDeploying(false, selDSName, true, null);
+
+                            var successCallback = function() {
+                                DSSelectionService.setDeploying(false, selDSName, true, null);
+                            };
+                            var failCallback = function(failMessage) {
+                                DSSelectionService.setDeploying(false, selDSName, false, failMessage);
+                            };
+
+                            //
+                            // Monitor the service vdb of the dataservice to determine when its active
+                            //
+                            RepoRestService.pollForActiveVdb(dsVdbName, successCallback, failCallback);
+
                         } else {
                             DSSelectionService.setDeploying(false, selDSName, false, result.Information.ErrorMessage1);
                         }


### PR DESCRIPTION
* After deployment, a vdb may take a few seconds to become active. Thus,
  its possible for pages to load wrongly, expecting an active vdb when its
  not quite progressed so far.

* RepositoryRestService
 * Polling function that uses $interval to poll the server every 2 seconds
   for the status of the teiid vdbs. On receipt, it finds the vdb in
   question and checks its status.
 * Should the vdb be active then the success callback is called and the
   $interval cancelled.
 * Failure in getting the teiid status will call the failure callback and
   cancel the $interval.

* dsSummaryController
 * On success of deploying the dataservice, monitor the service vdb for
   its active state. At that point, set the deployment flag to true.