### PR TITLE
Source translation updates

### DIFF
--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -4,23 +4,30 @@
         "Cancel" : "Cancel",
         "Connection" : "Connection",
         "Connections" : "Connections",
+        "Copy" : "Copy",
         "CopyThis" : "Copy {{this}}",
         "Create" : "Create",
         "Dashboard" : "Dashboard",
         "DataService" : "Data Service",
         "DataServices" : "Data Services",
+        "Delete" : "Delete",
         "Description" : "Description",
         "Driver" : "Driver",
+        "Edit" : "Edit",
         "EditThis" : "Edit {{this}}",
+        "Export" : "Export",
         "ExportThis" : "Export {{this}}",
+        "Import" : "Import",
         "ImportThis" : "Import {{this}}",
         "loadingProgressMsg" : "Loading...",
         "Name" : "Name",
+        "New" : "New",
         "NewThis" : "New {{this}}",
         "Save" : "Save",
         "Source" : "Source",
         "Sources" : "Sources",
         "Tables" : "Tables",
+        "Translator" : "Translator",
         "ThisSummary" : "{{this}} Summary"
     },
 
@@ -82,6 +89,94 @@
         "enterQueryMsg" : "Enter an SQL query to test the DataService",
         "failedDeploymentMsg" : "The Data Service could not be deployed:",
         "ODataEndpoint" : "OData Endpoint: "
+    },
+
+    "datasource-summary" : {
+        "welcomeMsg" : "Welcome to the <strong>Data Services Builder</strong>!",
+        "Loading" : "@:shared.loadingProgressMsg",
+        "noSourcesInstructionsMsg" : "Currently, there are no Sources configured.  To get started, click ",
+        "sourceSchema" : "Source Schema"
+    },
+    
+    "datasourceSummaryController" : {
+        "actionNameCopy" : "@:shared.Copy",
+        "actionNameDelete" : "@:shared.Delete",
+        "actionNameDisplayDdl" : "Display DDL",
+        "actionNameEdit" : "@:shared.Edit",
+        "actionNameExport" : "@:shared.Export",
+        "actionNameImport" : "@:shared.Import",
+        "actionNameNew" : "@:shared.New",
+        "actionNameRefresh" : "Refresh",
+        "actionTitleCopy" : "Copy the Source",
+        "actionTitleDelete" : "Delete the Source",
+        "actionTitleDisplayDdl" : "Show / Hide the DDL window",
+        "actionTitleEdit" : "Edit the Source",
+        "actionTitleExport" : "Export the Source",
+        "actionTitleImport" : "Import a Source",
+        "actionTitleNew" : "Create a Source",
+        "actionTitleRefresh" : "Refresh the Table",
+        "gettingDdlMsg" : "Fetching DDL ...",
+        "getDdlFailedMsg" : "Failed to get the DDL.",
+        "removeSourceFailedMsg" : "Failed to remove the ServiceSource.",
+        "getModelSourceFailedMsg" : "Failed to get model source:",
+        "getModelSourceConnectionFailedMsg" : "Failed to get connection:"
+    },
+
+    "svcsource-clone" : {
+        "Cancel" : "@:shared.Cancel",
+        "Create" : "@:shared.Create",
+        "instructionsMsg" : "Enter a name for the new source",
+        "Loading" : "@:shared.loadingProgressMsg",
+        "Name" : "@:shared.Name"
+    },
+
+    "svcsource-edit" : {
+        "Cancel" : "@:shared.Cancel",
+        "Connections" : "@:shared.Connections",
+        "Description" : "@:shared.Description",
+        "instructionsMsg" : "Reconfigure an existing Source:",
+        "Loading" : "@:shared.loadingProgressMsg",
+        "Name" : "@:shared.Name",
+        "Save" : "@:shared.Save",
+        "Translator" : "@:shared.Translator"
+    },
+
+    "svcsource-import" : {
+        "instructionsMsg" : "Choose the VDB file to import from your file system"
+    },
+
+    "svcsource-new" : {
+        "Cancel" : "@:shared.Cancel",
+        "chooseTranslator" : "-- choose translator --",
+        "Connections" : "@:shared.Connections",
+        "Description" : "@:shared.Description",
+        "instructionsMsg" : "Start configuring a new Source by selecting one of your available Connection definitions.",
+        "Loading" : "@:shared.loadingProgressMsg",
+        "nameDescriptionInstructionsMsg" : "Choose a name (and optional description) for your Source",
+        "Name" : "@:shared.Name",
+        "Save" : "@:shared.Save",
+        "Translator" : "@:shared.Translator"
+    },
+
+    "svcSourceCloneController" : {
+        "copyFailedMsg" : "Failed to copy the source.",
+        "deployFailedMsg" : "Failed to deploy the source."
+    },
+
+    "svcSourceEditController" : {
+        "getTranslatorsFailedMsg" : "Failed attempting to fetch translator.",
+        "sourceUpdateFailedMsg" : "Failed to update the source.",
+        "sourceDeployFailedMsg" : "Failed to deploy the source.",
+        "sourceModelCreateFailedMsg" : "Failed to create the source model.",
+        "sourceModelConnectionCreateFailedMsg" : "Failed to create the source model connection."
+    },
+
+    "svcSourceNewController" : {
+        "getTranslatorsFailedMsg" : "Failed attempting to fetch translator.",
+        "sourceCreateFailedMsg" : "Failed to create the source.",
+        "sourceDeployFailedMsg" : "Failed to deploy the source.",
+        "sourceModelCreateFailedMsg" : "Failed to create the source model.",
+        "sourceModelConnectionCreateFailedMsg" : "Failed to create the source model connection."
     }
 
 }

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasource-summary.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasource-summary.html
@@ -3,14 +3,14 @@
     <!-- Content shown if No Sources yet -->
     <div id="svcsource-summary-nosources" ng-show="vm.srcLoading==false && vm.hasSources==false" class="col-md-10 row">
         <div class="row">
-            <h2>Welcome to the <strong>Data Services Builder</strong>!</h2>
+            <h2 ng-bind-html=":: 'datasource-summary.welcomeMsg' | translate"></h2>
             <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
-            <p>Currently, there are no Sources configured.  To get started, 
-               click <a href ng-click="vmmain.selectPage('svcsource-new')"><span class="fa fa-fw {{vmmain.page('svcsource-new').icon}}"></span><span>{{vmmain.page('svcsource-new').title}}</span></a>
+            <p>{{:: 'datasource-summary.noSourcesInstructionsMsg' | translate}}
+            <a href ng-click="vmmain.selectPage('svcsource-new')"><span class="fa fa-fw {{vmmain.page('svcsource-new').icon}}"></span><span>{{vmmain.page('svcsource-new').title}}</span></a>
             </p>
         </div>
     </div>
-    
+
     <div id="svcsource-summary-table" class="col-md-10 row">
         <div class="row" ng-show="vm.srcLoading==true || vm.hasSources==true">
             <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
@@ -20,7 +20,7 @@
 
         <div id="svcsource-summary-updating" ng-show="vm.srcLoading==true">
             <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
-            <span class="sr-only">Loading...</span>
+            <span class="sr-only">{{:: 'datasource-summary.Loading' | translate}}</span>
         </div>
 
         <div class="svcsource-summary-results-container" ng-show="vm.srcLoading==false && vm.hasSources==true">
@@ -64,7 +64,7 @@
 
             <div class="svcsource-summary-results-ddl" ng-show="vm.srcLoading==false && vm.getServiceSources().length>0 && vm.displayDdl==true">
                 <div class="svcsource-summary-results-ddl-titlebar">
-                    <h5 class="svcsource-summary-results-ddl-titlebar-title">Source Schema</h5>
+                    <h5 class="svcsource-summary-results-ddl-titlebar-title">{{:: 'datasource-summary.sourceSchema' | translate}}</h5>
                     <h5 class="svcsource-summary-results-ddl-titlebar-close" ng-click="vm.displayDdl = false">X</h5>
                 </div>
                 <div ui-codemirror="{ onLoad : vm.ddlEditorLoaded }" ng-model="vm.selectedSourceDDL" ui-codemirror-opts="vm.ddlEditorOptions">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasourceSummaryController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasourceSummaryController.js
@@ -8,10 +8,10 @@
         .module(pluginName)
         .controller('DatasourceSummaryController', DatasourceSummaryController);
 
-    DatasourceSummaryController.$inject = ['$scope', '$rootScope', 'RepoRestService', 'REST_URI', 'SYNTAX', 
+    DatasourceSummaryController.$inject = ['$scope', '$rootScope', '$translate', 'RepoRestService', 'REST_URI', 'SYNTAX', 
                                            'SvcSourceSelectionService', 'TranslatorSelectionService', 'DownloadService', 'pfViewUtils'];
 
-    function DatasourceSummaryController($scope, $rootScope, RepoRestService, REST_URI, SYNTAX, 
+    function DatasourceSummaryController($scope, $rootScope, $translate, RepoRestService, REST_URI, SYNTAX, 
                                           SvcSourceSelectionService, TranslatorSelectionService, DownloadService, pfViewUtils) {
         var vm = this;
 
@@ -66,7 +66,7 @@
             if (_.isEmpty(SvcSourceSelectionService.selectedServiceSource()))
                 return;
 
-            vm.selectedSourceDDL = 'Fetching DDL ...';
+            vm.selectedSourceDDL = $translate.instant('datasourceSummaryController.gettingDdlMsg');
 
             var vdbName = SvcSourceSelectionService.selectedServiceSource().keng__id;
 
@@ -77,15 +77,18 @@
                             vm.selectedSourceDDL = result.Information.schema;
                         },
                         function (response) {
-                            vm.selectedSourceDDL = "Failed to get the DDL. \n" + RepoRestService.responseMessage(response);
+                            var getDdlFailedMsg = $translate.instant('datasourceSummaryController.getDdlFailedMsg');
+                            vm.selectedSourceDDL = getDdlFailedMsg + "\n" + RepoRestService.responseMessage(response);
                         });
                 } catch (error) {
-                    vm.selectedSourceDDL = "Failed to get the DDL. \n" + error;
+                    var getDdlFailedMsg = $translate.instant('datasourceSummaryController.getDdlFailedMsg');
+                    vm.selectedSourceDDL = getDdlFailedMsg + "\n" + error;
                 }
             };
 
             var failureCallback = function(errorMsg) {
-                vm.selectedSourceDDL = "Failed to get the DDL. \n" + errorMsg;
+                var getDdlFailedMsg = $translate.instant('datasourceSummaryController.getDdlFailedMsg');
+                vm.selectedSourceDDL = getDdlFailedMsg + "\n" + errorMsg;
             };
 
             SvcSourceSelectionService.selectedServiceSourceModel(schemaSuccessCallback, failureCallback);
@@ -137,10 +140,12 @@
                         vm.selectedSourceDDL = "";
                     },
                     function (response) {
-                        throw RepoRestService.newRestException("Failed to remove the ServiceSource. \n" + RepoRestService.responseMessage(response));
+                        var removeSourceFailedMsg = $translate.instant('datasourceSummaryController.removeSourceFailedMsg');
+                        throw RepoRestService.newRestException(removeSourceFailedMsg + "\n" + RepoRestService.responseMessage(response));
                     });
             } catch (error) {
-                throw RepoRestService.newRestException("Failed to remove the ServiceSource. \n" + error);
+                var removeSourceFailedMsg = $translate.instant('datasourceSummaryController.removeSourceFailedMsg');
+                throw RepoRestService.newRestException(removeSourceFailedMsg + "\n" + error);
             }
         }
 
@@ -157,7 +162,8 @@
                         deleteServerVdb(vdbName);
                     },
                     function (response) {
-                        throw RepoRestService.newRestException("Failed to remove the ServiceSource. \n" + RepoRestService.responseMessage(response));
+                        var removeSourceFailedMsg = $translate.instant('datasourceSummaryController.removeSourceFailedMsg');
+                        throw RepoRestService.newRestException(removeSourceFailedMsg + "\n" + RepoRestService.responseMessage(response));
                     });
             } catch (error) {} finally {
             }
@@ -356,17 +362,20 @@
                     $rootScope.$broadcast("dataServicePageChanged", 'svcsource-edit');
                 };
                 var modelSourceFailureCallback = function(modelSourceErrorMsg) {
-                    alert("Failed to get model source: \n"+modelSourceErrorMsg);
+                    var getModelSourceFailedMsg = $translate.instant('datasourceSummaryController.getModelSourceFailedMsg');
+                    alert(getModelSourceFailedMsg + "\n" + modelSourceErrorMsg);
                 };
                 SvcSourceSelectionService.selectedServiceSourceModelSource(modelSourceSuccessCallback,modelSourceFailureCallback);
             };
 
             var failureCallback = function(errorMsg) {
-            	alert("Failed to get connection: \n"+errorMsg);
+                var getModelSourceConnectionFailedMsg = $translate.instant('datasourceSummaryController.getModelSourceConnectionFailedMsg');
+            	alert(getModelSourceConnectionFailedMsg + "\n" + errorMsg);
             };
 
             SvcSourceSelectionService.selectedServiceSourceModel(successCallback, failureCallback);
         };
+
         
         /**
          * Handle edit ServiceSource menu select
@@ -456,40 +465,40 @@
         vm.actionsConfig = {
           primaryActions: [
             {
-              name: 'Refresh',
-              title: 'Refresh the Table',
+              name: $translate.instant('datasourceSummaryController.actionNameRefresh'),
+              title: $translate.instant('datasourceSummaryController.actionTitleRefresh'),
               actionFn: refreshClicked,
               isDisabled: false
             },
             {
-              name: 'New',
-              title: 'Create a Source',
+              name: $translate.instant('datasourceSummaryController.actionNameNew'),
+              title: $translate.instant('datasourceSummaryController.actionTitleNew'),
               actionFn: newSvcSourceClicked,
               isDisabled: false
             },
             {
-              name: 'Edit',
-              title: 'Edit the Source',
+              name: $translate.instant('datasourceSummaryController.actionNameEdit'),
+              title: $translate.instant('datasourceSummaryController.actionTitleEdit'),
               actionFn: editSvcSourceClicked,
               isDisabled: true
             },
             {
-              name: 'Delete',
-              title: 'Delete the Source',
+              name: $translate.instant('datasourceSummaryController.actionNameDelete'),
+              title: $translate.instant('datasourceSummaryController.actionTitleDelete'),
               actionFn: deleteSvcSourceClicked,
               isDisabled: true
             }
           ],
           moreActions: [
             {
-              name: 'Export',
-              title: 'Export the Source',
+              name: $translate.instant('datasourceSummaryController.actionNameExport'),
+              title: $translate.instant('datasourceSummaryController.actionTitleExport'),
               actionFn: exportSvcSourceClicked,
               isDisabled: true
             },
             {
-              name: 'Copy',
-              title: 'Copy the Source',
+              name: $translate.instant('datasourceSummaryController.actionNameCopy'),
+              title: $translate.instant('datasourceSummaryController.actionTitleCopy'),
               actionFn: cloneSvcSourceClicked,
               isDisabled: true
             },
@@ -497,8 +506,8 @@
               isSeparator: true
             },
             {
-              name: 'Import',
-              title: 'Import a Source',
+              name: $translate.instant('datasourceSummaryController.actionNameImport'),
+              title: $translate.instant('datasourceSummaryController.actionTitleImport'),
               actionFn: importSvcSourceClicked,
               isDisabled: false
             },
@@ -506,8 +515,8 @@
               isSeparator: true
             },
             {
-              name: 'Display DDL',
-              title: 'Show / Hide the DDL window',
+              name: $translate.instant('datasourceSummaryController.actionNameDisplayDdl'),
+              title: $translate.instant('datasourceSummaryController.actionTitleDisplayDdl'),
               actionFn: showHideDDLClicked,
               isDisabled: false
             }
@@ -517,23 +526,23 @@
 
         vm.menuActions = [
             {
-                name: 'Edit',
-                title: 'Edit the Source',
+                name: $translate.instant('datasourceSummaryController.actionNameEdit'),
+                title: $translate.instant('datasourceSummaryController.actionTitleEdit'),
                 actionFn: editSvcSourceMenuAction
             },
             {
-                name: 'Delete',
-                title: 'Delete the Source',
+                name: $translate.instant('datasourceSummaryController.actionNameDelete'),
+                title: $translate.instant('datasourceSummaryController.actionTitleDelete'),
                 actionFn: deleteSvcSourceMenuAction
             },
             {
-                name: 'Export',
-                title: 'Export the Source',
+                name: $translate.instant('datasourceSummaryController.actionNameExport'),
+                title: $translate.instant('datasourceSummaryController.actionTitleExport'),
                 actionFn: exportSvcSourceMenuAction
             },
             {
-                name: 'Copy',
-                title: 'Copy the Source',
+                name: $translate.instant('datasourceSummaryController.actionNameCopy'),
+                title: $translate.instant('datasourceSummaryController.actionTitleCopy'),
                 actionFn: cloneSvcSourceMenuAction
             }
           ];

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceCloneController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceCloneController.js
@@ -8,9 +8,9 @@
         .module(pluginName)
         .controller('SvcSourceCloneController', SvcSourceCloneController);
 
-    SvcSourceCloneController.$inject = ['$scope', '$rootScope', 'RepoRestService', 'SvcSourceSelectionService'];
+    SvcSourceCloneController.$inject = ['$scope', '$rootScope', '$translate', 'RepoRestService', 'SvcSourceSelectionService'];
 
-    function SvcSourceCloneController($scope, $rootScope, RepoRestService, SvcSourceSelectionService) {
+    function SvcSourceCloneController($scope, $rootScope, $translate, RepoRestService, SvcSourceSelectionService) {
         var vm = this;
         vm.cloneVdbInProgress = false;
 
@@ -37,7 +37,8 @@
                         deployVdb(newSvcSourceName);
                     },
                     function (response) {
-                        throw RepoRestService.newRestException("Failed to clone the source. \n" + RepoRestService.responseMessage(response));
+                        var copyFailedMsg = $translate.instant('svcSourceCloneController.copyFailedMsg');
+                        throw RepoRestService.newRestException(copyFailedMsg + "\n" + RepoRestService.responseMessage(response));
                     });
             } catch (error) {} finally {
             }
@@ -63,7 +64,8 @@
                    },
                     function (response) {
                         SvcSourceSelectionService.setDeploying(false, vdbName, false, response.message);
-                        throw RepoRestService.newRestException("Failed to deploy the Source. \n" + RepoRestService.responseMessage(response));
+                        var deployFailedMsg = $translate.instant('svcSourceCloneController.deployFailedMsg');
+                        throw RepoRestService.newRestException(deployFailedMsg + "\n" + RepoRestService.responseMessage(response));
                     });
             } catch (error) {} finally {
             }

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceEditController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceEditController.js
@@ -8,10 +8,10 @@
         .module(pluginName)
         .controller('SvcSourceEditController', SvcSourceEditController);
 
-    SvcSourceEditController.$inject = ['$scope', '$rootScope', '$document', 'REST_URI', 'SYNTAX', 'RepoRestService', 
+    SvcSourceEditController.$inject = ['$scope', '$rootScope', '$translate', '$document', 'REST_URI', 'SYNTAX', 'RepoRestService', 
                                        'SvcSourceSelectionService', 'ConnectionSelectionService', 'TranslatorSelectionService'];
 
-    function SvcSourceEditController($scope, $rootScope, $document, REST_URI, SYNTAX, RepoRestService, 
+    function SvcSourceEditController($scope, $rootScope, $translate, $document, REST_URI, SYNTAX, RepoRestService, 
                                       SvcSourceSelectionService, ConnectionSelectionService, TranslatorSelectionService) {
         var vm = this;
 
@@ -121,10 +121,12 @@
                         }
                     },
                     function (resp) {
-                        throw RepoRestService.newRestException("Failed attempting to fetch translator. \n" + RepoRestService.responseMessage(resp));
+                        var fetchFailedMsg = $translate.instant('svcSourceEditController.getTranslatorsFailedMsg');
+                        throw RepoRestService.newRestException(fetchFailedMsg + "\n" + RepoRestService.responseMessage(resp));
                     });
             } catch (error) {
-                throw RepoRestService.newRestException("Failed attempting to fetch translator. \n" + error);
+                var fetchFailedMsg = $translate.instant('svcSourceEditController.getTranslatorsFailedMsg');
+                throw RepoRestService.newRestException(fetchFailedMsg + "\n" + error);
             }
         }
 
@@ -178,7 +180,8 @@
                                 createVdbModel( vm.svcSourceName, connectionName, translatorName, jndiName );
                             },
                             function (response) {
-                                throw RepoRestService.newRestException("Failed to update the source. \n" + RepoRestService.responseMessage(response));
+                                var sourceUpdateFailedMsg = $translate.instant('svcSourceEditController.sourceUpdateFailedMsg');
+                                throw RepoRestService.newRestException(sourceUpdateFailedMsg + "\n" + RepoRestService.responseMessage(response));
                             });
                 // Connection was not changed, we can update the existing model source
                 } else {
@@ -187,13 +190,14 @@
                         	updateVdbDescription( vm.svcSourceName, vm.svcSourceDescription);
                         },
                         function (response) {
-                            throw RepoRestService.newRestException("Failed to update the source. \n" + RepoRestService.responseMessage(response));
+                            var sourceUpdateFailedMsg = $translate.instant('svcSourceEditController.sourceUpdateFailedMsg');
+                            throw RepoRestService.newRestException(sourceUpdateFailedMsg + "\n" + RepoRestService.responseMessage(response));
                         });
                 }
             } catch (error) {} finally {
             }
         };
-        
+
         /**
          * Update the VDB description
          */
@@ -206,11 +210,13 @@
                     },
                     function (resp) {
                         SvcSourceSelectionService.setLoading(false);
-                        throw RepoRestService.newRestException("Failed to update the source. \n" + RepoRestService.responseMessage(resp));
+                        var sourceUpdateFailedMsg = $translate.instant('svcSourceEditController.sourceUpdateFailedMsg');
+                        throw RepoRestService.newRestException(sourceUpdateFailedMsg + "\n" + RepoRestService.responseMessage(resp));
                     });
             } catch (error) {
                 SvcSourceSelectionService.setLoading(false);
-                throw RepoRestService.newRestException("Failed to update the source. \n" + error);
+                var sourceUpdateFailedMsg = $translate.instant('svcSourceEditController.sourceUpdateFailedMsg');
+                throw RepoRestService.newRestException(sourceUpdateFailedMsg + "\n" + error);
             }
         }
 
@@ -234,11 +240,13 @@
                     function (response) {
                         SvcSourceSelectionService.setDeploying(false, vdbName, false, RepoRestService.responseMessage(response));
                         SvcSourceSelectionService.setLoading(false);
-                        throw RepoRestService.newRestException("Failed to deploy the Source. \n" + RepoRestService.responseMessage(response));
+                        var sourceDeployFailedMsg = $translate.instant('svcSourceEditController.sourceDeployFailedMsg');
+                        throw RepoRestService.newRestException(sourceDeployFailedMsg + "\n" + RepoRestService.responseMessage(response));
                     });
             } catch (error) {
                 SvcSourceSelectionService.setLoading(false);
-                throw RepoRestService.newRestException("Failed to deploy the Source. \n" + error);
+                var sourceDeployFailedMsg = $translate.instant('svcSourceEditController.sourceDeployFailedMsg');
+                throw RepoRestService.newRestException(sourceDeployFailedMsg + "\n" + error);
             }
         }
         
@@ -256,11 +264,13 @@
                     },
                     function (resp) {
                         SvcSourceSelectionService.setLoading(false);
-                        throw RepoRestService.newRestException("Failed to create the source model. \n" + RepoRestService.responseMessage(resp));
+                        var sourceModelCreateFailedMsg = $translate.instant('svcSourceEditController.sourceModelCreateFailedMsg');
+                        throw RepoRestService.newRestException(sourceModelCreateFailedMsg + "\n" + RepoRestService.responseMessage(resp));
                     });
             } catch (error) {
                 SvcSourceSelectionService.setLoading(false);
-                throw RepoRestService.newRestException("Failed to create the source model. \n" + error);
+                var sourceModelCreateFailedMsg = $translate.instant('svcSourceEditController.sourceModelCreateFailedMsg');
+                throw RepoRestService.newRestException(sourceModelCreateFailedMsg + "\n" + error);
             }
         }
 
@@ -276,11 +286,13 @@
                     },
                     function (resp) {
                         SvcSourceSelectionService.setLoading(false);
-                        throw RepoRestService.newRestException("Failed to create the source model connection. \n" + RepoRestService.responseMessage(resp));
+                        var sourceModelConnectionCreateFailedMsg = $translate.instant('svcSourceEditController.sourceModelConnectionCreateFailedMsg');
+                        throw RepoRestService.newRestException(sourceModelConnectionCreateFailedMsg + "\n" + RepoRestService.responseMessage(resp));
                     });
             } catch (error) {
                 SvcSourceSelectionService.setLoading(false);
-                throw RepoRestService.newRestException("Failed to create the source model connection. \n" + error);
+                var sourceModelConnectionCreateFailedMsg = $translate.instant('svcSourceEditController.sourceModelConnectionCreateFailedMsg');
+                throw RepoRestService.newRestException(sourceModelConnectionCreateFailedMsg + "\n" + error);
             }
         }
 

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceNewController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceNewController.js
@@ -8,10 +8,10 @@
         .module(pluginName)
         .controller('SvcSourceNewController', SvcSourceNewController);
 
-    SvcSourceNewController.$inject = ['$scope', '$rootScope', 'REST_URI', 'SYNTAX', 'RepoRestService',
+    SvcSourceNewController.$inject = ['$scope', '$rootScope', '$translate', 'REST_URI', 'SYNTAX', 'RepoRestService',
                                       'SvcSourceSelectionService', 'ConnectionSelectionService', 'TranslatorSelectionService'];
 
-    function SvcSourceNewController($scope, $rootScope, REST_URI, SYNTAX, RepoRestService,
+    function SvcSourceNewController($scope, $rootScope, $translate, REST_URI, SYNTAX, RepoRestService,
                                      SvcSourceSelectionService, ConnectionSelectionService, TranslatorSelectionService) {
         var vm = this;
 
@@ -82,12 +82,14 @@
                     function (resp) {
                         updateTranslatorVisibility();
                         updateNameDescriptionVisibility();
-                        throw RepoRestService.newRestException("Failed attempting to fetch translator. \n" + RepoRestService.responseMessage(resp));
+                        var fetchFailedMsg = $translate.instant('svcSourceNewController.getTranslatorsFailedMsg');
+                        throw RepoRestService.newRestException(fetchFailedMsg + "\n" + RepoRestService.responseMessage(resp));
                     });
             } catch (error) {
                 updateTranslatorVisibility();
                 updateNameDescriptionVisibility();
-                throw RepoRestService.newRestException("Failed attempting to fetch translator. \n" + error);
+                var fetchFailedMsg = $translate.instant('svcSourceNewController.getTranslatorsFailedMsg');
+                throw RepoRestService.newRestException(fetchFailedMsg + "\n" + error);
             }
         }
 
@@ -110,11 +112,13 @@
                     },
                     function (resp) {
                         SvcSourceSelectionService.setLoading(false);
-                        throw RepoRestService.newRestException("Failed to create the source Vdb. \n" + RepoRestService.responseMessage(resp));
+                        var sourceCreateFailedMsg = $translate.instant('svcSourceNewController.sourceCreateFailedMsg');
+                        throw RepoRestService.newRestException(sourceCreateFailedMsg + "\n" + RepoRestService.responseMessage(resp));
                     });
             } catch (error) {
                 SvcSourceSelectionService.setLoading(false);
-                throw RepoRestService.newRestException("Failed to create the source Vdb. \n" + error);
+                var sourceCreateFailedMsg = $translate.instant('svcSourceNewController.sourceCreateFailedMsg');
+                throw RepoRestService.newRestException(sourceCreateFailedMsg + "\n" + error);
             }
         }
 
@@ -132,11 +136,13 @@
                     },
                     function (resp) {
                         SvcSourceSelectionService.setLoading(false);
-                        throw RepoRestService.newRestException("Failed to create the source model. \n" + RepoRestService.responseMessage(resp));
+                        var sourceModelCreateFailedMsg = $translate.instant('svcSourceNewController.sourceModelCreateFailedMsg');
+                        throw RepoRestService.newRestException(sourceModelCreateFailedMsg + "\n" + RepoRestService.responseMessage(resp));
                     });
             } catch (error) {
                 SvcSourceSelectionService.setLoading(false);
-                throw RepoRestService.newRestException("Failed to create the source model. \n" + error);
+                var sourceModelCreateFailedMsg = $translate.instant('svcSourceNewController.sourceModelCreateFailedMsg');
+                throw RepoRestService.newRestException(sourceModelCreateFailedMsg + "\n" + error);
             }
         }
 
@@ -152,11 +158,13 @@
                     },
                     function (resp) {
                         SvcSourceSelectionService.setLoading(false);
-                        throw RepoRestService.newRestException("Failed to create the source model connection. \n" + RepoRestService.responseMessage(resp));
+                        var sourceModelConnectionCreateFailedMsg = $translate.instant('svcSourceNewController.sourceModelConnectionCreateFailedMsg');
+                        throw RepoRestService.newRestException(sourceModelConnectionCreateFailedMsg + "\n" + RepoRestService.responseMessage(resp));
                     });
             } catch (error) {
                 SvcSourceSelectionService.setLoading(false);
-                throw RepoRestService.newRestException("Failed to create the source model connection. \n" + error);
+                var sourceModelConnectionCreateFailedMsg = $translate.instant('svcSourceNewController.sourceModelConnectionCreateFailedMsg');
+                throw RepoRestService.newRestException(sourceModelConnectionCreateFailedMsg + "\n" + error);
             }
         }
 
@@ -185,11 +193,13 @@
                     function (response) {
                         SvcSourceSelectionService.setDeploying(false, vdbName, false, RepoRestService.responseMessage(response));
                         SvcSourceSelectionService.setLoading(false);
-                        throw RepoRestService.newRestException("Failed to deploy the Source. \n" + RepoRestService.responseMessage(response));
+                        var sourceDeployFailedMsg = $translate.instant('svcSourceNewController.sourceDeployFailedMsg');
+                        throw RepoRestService.newRestException(sourceDeployFailedMsg + "\n" + RepoRestService.responseMessage(response));
                     });
             } catch (error) {
                 SvcSourceSelectionService.setLoading(false);
-                throw RepoRestService.newRestException("Failed to deploy the Source. \n" + error);
+                var sourceDeployFailedMsg = $translate.instant('svcSourceNewController.sourceDeployFailedMsg');
+                throw RepoRestService.newRestException(sourceDeployFailedMsg + "\n" + error);
             }
         }
 

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-clone.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-clone.html
@@ -1,24 +1,24 @@
 <div class="container-fluid" ng-controller="SvcSourceCloneController as vm">
     <div id="svcsource-clone" ng-show="vm.cloneVdbInProgress==true" class="col-md-10 row">
         <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
-        <span class="sr-only">Loading...</span>
+        <span class="sr-only">{{:: 'svcsource-clone.Loading' | translate}}</span>
     </div>
     
     <div id="svcsource-clone-controls" ng-show="vm.cloneVdbInProgress==false" class="col-md-10 row">
       <div class="row">
         <div class="col-md-11">
           <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}} '{{vmmain.selectedServiceSource().keng__id}}'</span></h2>
-          <h3>&nbsp;&nbsp;Enter a name for the new source</h3>
+          <h3>&nbsp;&nbsp;{{:: 'svcsource-clone.instructionsMsg' | translate}}</h3>
           <form class="form-horizontal">
               <div class="form-group">
-                  <label class="col-md-2 control-label" for="textInput">Name</label>
+                  <label class="col-md-2 control-label" for="textInput">{{:: 'svcsource-clone.Name' | translate}}</label>
                   <div class="col-md-6">
                     <input type="text" ng-model="nameVar" class="form-control">
                   </div>
               </div>
           </form>
-          <button class="btn btn-primary" ng-click="vm.onCloneSvcSourceClicked(vmmain.selectedServiceSource().keng__id, nameVar)" ng-class="{active:vmmain.selectedPage.id == 'svcsource-clone'}"> Create</button>
-          <button class="btn btn-default" ng-click="vmmain.selectPage('datasource-summary')" ng-class="{active:vmmain.selectedPage.id == 'svcsource-clone'}"> Cancel</button>
+          <button class="btn btn-primary" ng-click="vm.onCloneSvcSourceClicked(vmmain.selectedServiceSource().keng__id, nameVar)" ng-class="{active:vmmain.selectedPage.id == 'svcsource-clone'}">{{:: 'svcsource-clone.Create' | translate}}</button>
+          <button class="btn btn-default" ng-click="vmmain.selectPage('datasource-summary')" ng-class="{active:vmmain.selectedPage.id == 'svcsource-clone'}">{{:: 'svcsource-clone.Cancel' | translate}}</button>
         </div>
       </div>
     </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-edit.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-edit.html
@@ -1,21 +1,21 @@
 <div class="container-fluid" ng-controller="SvcSourceEditController as vm">
     <div id="svcsource-edit-updating" ng-show="vm.transLoading==true || vm.updateAndDeployInProgress==true" class="col-md-10 row">
         <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
-        <span class="sr-only">Loading...</span>
+        <span class="sr-only">{{:: 'svcsource-edit.Loading' | translate}}</span>
     </div>
     
     <div id="svcsource-edit-controls" ng-show="vm.transLoading==false && vm.updateAndDeployInProgress==false" class="col-md-10 row">
       <div class="row">
         <div class="col-md-11">
             <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
-            <h4>Reconfigure an existing Source:</h4>
+            <h4>{{:: 'svcsource-edit.instructionsMsg' | translate}}</h4>
             <form class="form-horizontal">
                 <div class="col-md-5">
-                    <h4><strong>Connections</strong></h4>
+                    <h4><strong>{{:: 'svcsource-edit.Connections' | translate}}</strong></h4>
                     <connection-list selection="{{vm.initialConnectionName}}"></connection-list>
                 </div>
                 <div class="col-md-5">
-                    <h4><strong>Translator</strong></h4>
+                    <h4><strong>{{:: 'svcsource-edit.Translator' | translate}}</strong></h4>
                     <img src="{{vm.selectedTranslatorImage}}" width="42" height="24"/>
                     <select id="translators" ng-model="vm.selectedTranslator" ng-options="trans as trans.keng__id for trans in vm.allTranslators"
                                              ng-change="vm.translatorChanged()">
@@ -24,21 +24,21 @@
                 </div>
                 <div class="col-md-12"></div>
                 <div class="form-group" style="margin-top: 20px">
-                    <label class="col-md-2 control-label" for="textInput">Name</label>
+                    <label class="col-md-2 control-label" for="textInput">{{:: 'svcsource-edit.Name' | translate}}</label>
                     <div class="col-md-6">
                         <input type="text" readonly="readonly" ng-model="vm.svcSourceName" ng-init="vm.svcSourceName=vmmain.selectedServiceSource().keng__id" class="form-control">
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-md-2 control-label" for="textInput">Description</label>
+                    <label class="col-md-2 control-label" for="textInput">{{:: 'svcsource-edit.Description' | translate}}</label>
                     <div class="col-md-6">
                         <input type="text" ng-model="vm.svcSourceDescription" ng-init="vm.svcSourceDescription=vmmain.selectedServiceSource().vdb__description" class="form-control">
                     </div>
                 </div>
             </form>
-            <input type="submit" class="btn btn-primary" value="Save" ng-click="vm.onEditSvcSourceClicked()"
+            <input type="submit" class="btn btn-primary" value="{{:: 'svcsource-edit.Save' | translate}}" ng-click="vm.onEditSvcSourceClicked()"
                                               ng-disabled="vm.canUpdateSvcSource() !== true || vmmain.selectedPage.id !== 'svcsource-edit'"/>
-            <input type="button" class="btn btn-default" value="Cancel" ng-click="vmmain.selectPage('datasource-summary')"
+            <input type="button" class="btn btn-default" value="{{:: 'svcsource-edit.Cancel' | translate}}" ng-click="vmmain.selectPage('datasource-summary')"
                                               ng-disabled="vmmain.selectedPage.id !== 'svcsource-edit'"/>
         </div>
       </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-import.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-import.html
@@ -4,7 +4,7 @@
             <div class="row">
                 <div class="col-sm-9">
                     <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
-                    <h3>&nbsp;&nbsp;Choose the VDB file to import from your file system</h3>
+                    <h3>&nbsp;&nbsp;{{:: 'svcsource-import.instructionsMsg' | translate}}</h3>
                     <!-- Show the import dialog when importing -->
                     <div ng-init="vm.onImportSvcSourceClicked()" ng-show="!vm.init && vm.showImport">
                         <file-import-control on-import-complete="vm.onImportDone(result)" on-cancel="vm.onImportCancel()"></file-import-control>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-new.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-new.html
@@ -1,40 +1,40 @@
 <div class="container-fluid" ng-controller="SvcSourceNewController as vm">
     <div id="svcsource-new-updating" ng-show="vm.createAndDeployInProgress==true" class="col-md-10 row">
         <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
-        <span class="sr-only">Loading...</span>
+        <span class="sr-only">{{:: 'svcsource-new.Loading' | translate}}</span>
     </div>
     
     <div id="svcsource-new-controls" ng-show="vm.createAndDeployInProgress==false" class="col-md-10 row">
       <div class="col-sm-9 row">
           <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
-          <h4>Start configuring a new Source by selecting one of your available Connection definitions.</h4>
+          <h4>{{:: 'svcsource-new.instructionsMsg' | translate}}</h4>
           <div class="col-md-5">
-              <h4><strong>Connections</strong></h4>
+              <h4><strong>{{:: 'svcsource-new.Connections' | translate}}</strong></h4>
               <connection-list></connection-list>
           </div>
           <div class="col-md-5" ng-show="vm.showTranslator">
-              <h4><strong>Translator</strong></h4>
+              <h4><strong>{{:: 'svcsource-new.Translator' | translate}}</strong></h4>
               <img src="{{vm.selectedTranslatorImage}}" width="42" height="24"/>
               <select id="translators" ng-model="vm.selectedTranslator" ng-options="trans as trans.keng__id for trans in vm.allTranslators" 
                       ng-change="vm.translatorChanged()">
-                  <option value="">-- choose translator --</option>
+                  <option value="">{{:: 'svcsource-new.chooseTranslator' | translate}}</option>
               </select>
           </div>
 
           <div class="col-md-12" ng-show="vm.showNameAndDescription">
               <p></p>
-              <h4>Choose a name (and optional description) for your Source</h4>
+              <h4>{{:: 'svcsource-new.nameDescriptionInstructionsMsg' | translate}}</h4>
               <p></p>
               <form class="form-horizontal">
                   <div class="form-group">
-                      <label class="col-md-2 control-label" for="textInput">Name</label>
+                      <label class="col-md-2 control-label" for="textInput">{{:: 'svcsource-new.Name' | translate}}</label>
                       <div class="col-md-6">
                         <input type="text" ng-model="vm.svcSourceName" class="form-control">
                       </div>
                       <div class="col-md-4"></div>
                   </div>
                   <div class="form-group">
-                      <label class="col-md-2 control-label" for="textInput">Description</label>
+                      <label class="col-md-2 control-label" for="textInput">{{:: 'svcsource-new.Description' | translate}}</label>
                       <div class="col-md-6">
                         <input type="text" ng-model="vm.svcSourceDescription" class="form-control">
                       </div>
@@ -47,9 +47,9 @@
           </div>
 
           <div class="col-md-12">
-              <input type="submit" class="btn btn-primary" value="Save" ng-click="vm.onCreateSvcSourceClicked()"
+              <input type="submit" class="btn btn-primary" value="{{:: 'svcsource-new.Save' | translate}}" ng-click="vm.onCreateSvcSourceClicked()"
                                    ng-disabled="vm.canCreateSvcSource() !== true || vmmain.selectedPage.id !== 'svcsource-new'"/>
-              <input type="button" class="btn btn-default" value="Cancel" ng-click="vmmain.selectPage('datasource-summary')"
+              <input type="button" class="btn btn-default" value="{{:: 'svcsource-new.Cancel' | translate}}" ng-click="vmmain.selectPage('datasource-summary')"
                                    ng-disabled="vmmain.selectedPage.id !== 'svcsource-new'"/>
           </div>
         </div>


### PR DESCRIPTION
Here are the translation changes for the source pages.  Dan, looks like I did things a little different than you.  I guess either merge this and fix, or you can cancel this PR and pull the changes to your local and redo...
- the main difference is that you referenced the shared namespace directly from your pages.  I created keys for the pages and referenced the shared namespace in the json file.  Your way is shorter.
- also I was not quite finished with datasourceSummaryController.  The toolbar sort and filter buttons still need to be translated.