### PR TITLE
Translate filter does not handle asynchronous loading

### DIFF
--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/content/css/styles.less
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/content/css/styles.less
@@ -187,6 +187,11 @@
     margin-right: -20px;
 }
 
+#dataservice-summary-updating {
+    padding-left: 10px;
+    padding-top: 10px;
+}
+
 #ds-summary-container, #ds-summary-table, #dataserviceToolbar,
 #svcsource-summary-container, #svcsource-summary-table, #svcsourceToolbar {
     margin-right: 0;

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-clone.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-clone.html
@@ -5,17 +5,17 @@
             <div class="row">
                 <div class="col-sm-9">
                     <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}} '{{vmmain.selectedDataservice().keng__id}}'</span></h2>
-                    <h3>{{:: 'dataservice-clone.instructionsMsg' | translate}}</h3>
+                    <h3 translate="dataservice-clone.instructionsMsg"></h3>
                     <form class="form-horizontal">
                         <div class="form-group">
-                            <label class="col-md-2 control-label" for="textInput">{{:: 'dataservice-clone.Name' | translate}}</label>
+                            <label class="col-md-2 control-label" for="textInput" translate="dataservice-clone.Name"></label>
                             <div class="col-md-6">
                               <input type="text" ng-model="nameVar" class="form-control">
                             </div>
                         </div>
                     </form>
-                    <button class="btn btn-primary" ng-click="vm.onCloneDataServiceClicked(vmmain.selectedDataservice().keng__id, nameVar)" ng-class="{active:vmmain.selectedPage.id == 'dataservice-clone'}">{{:: 'dataservice-clone.Create' | translate}}</button>
-                    <button class="btn btn-default" ng-click="vmmain.selectPage('dataservice-summary')" ng-class="{active:vmmain.selectedPage.id == 'dataservice-clone'}">{{:: 'dataservice-clone.Cancel' | translate}}</button>
+                    <button class="btn btn-primary" ng-click="vm.onCloneDataServiceClicked(vmmain.selectedDataservice().keng__id, nameVar)" ng-class="{active:vmmain.selectedPage.id == 'dataservice-clone'}" translate="dataservice-clone.Create"></button>
+                    <button class="btn btn-default" ng-click="vmmain.selectPage('dataservice-summary')" ng-class="{active:vmmain.selectedPage.id == 'dataservice-clone'}" translate="dataservice-clone.Cancel"></button>
                 </div>
             </div>
         </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-edit.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-edit.html
@@ -4,25 +4,25 @@
         <div class="row">
             <div class="col-sm-9">
                 <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}} '{{vmmain.selectedDataservice().keng__id}}'</span></h2>
-                <h3>{{:: 'dataservice-edit.instructionsMsg' | translate}}</h3>
+                <h3 translate="dataservice-edit.instructionsMsg"></h3>
                 <form name="dsForm" class="form-horizontal">
                     <div class="col-md-5">
-                        <h4><strong>{{:: 'shared.Sources' | translate}}</strong></h4>
+                        <h4><strong translate="shared.Sources"></strong></h4>
                         <service-source-list selection="{{vm.initialSourceName}}"></service-source-list>
                     </div>
                     <div class="col-md-5">
-                        <h4><strong>{{:: 'shared.Tables' | translate}}</strong></h4>
+                        <h4><strong translate="shared.Tables"></strong></h4>
                         <model-table-list selection="{{vm.initialSourceTableName}}"></model-table-list>
                     </div>
                     <div class="col-md-12"></div>
                     <div class="form-group">
-                        <label class="col-md-2 control-label" style="margin-top: 20px" for="textInput">{{:: 'shared.Name' | translate}}</label>
+                        <label class="col-md-2 control-label" style="margin-top: 20px" for="textInput" translate="shared.Name"></label>
                         <div class="col-md-6" style="margin-top: 20px" >
                           <input type="text" readonly="readonly" ng-model="vm.serviceName" ng-init="vm.serviceName=vmmain.selectedDataservice().keng__id" class="form-control">
                         </div>
                     </div>
                     <div class="form-group">
-                        <label class="col-md-2 control-label" for="textInput">{{:: 'shared.Description' | translate}}</label>
+                        <label class="col-md-2 control-label" for="textInput" translate="shared.Description"></label>
                         <div class="col-md-6">
                           <input type="text" ng-model="vm.serviceDescription" ng-init="vm.serviceDescription=vmmain.selectedDataservice().tko__description" class="form-control">
                         </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-export.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-export.html
@@ -15,7 +15,7 @@
                     -->
                 <div pf-wizard-step step-title="{{:: 'dataservice-export.exportTypeStepTitle' | translate}}"
                         step-id="export-type">
-                    <h1>{{:: 'dataservice-export.instructionsMsg' | translate}}</h1>
+                    <h1 translate="dataservice-export.instructionsMsg"></h1>
 
                     <form class="ds-import-export-storage-types-form">
                         <div ng-repeat="storageType in vm.storageTypes">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-import.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-import.html
@@ -15,7 +15,7 @@
                     -->
                 <div pf-wizard-step step-title="{{:: 'dataservice-import.importTypeStepTitle' | translate}}"
                         step-id="import-source">
-                    <h1>{{:: 'dataservice-import.instructionsMsg' | translate}}</h1>
+                    <h1 translate="dataservice-import.instructionsMsg"></h1>
 
                     <form class="ds-import-export-storage-types-form">
                         <div ng-repeat="storageType in vm.storageTypes">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-navbar.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-navbar.html
@@ -4,15 +4,15 @@
 <div id="dsb-vertical-nav">
     <div id="dsb-nav-item-dataservices" class="dsb-nav-item" ng-click="vmmain.selectNavItem('dataservice-summary')" body-click="vmmain.selectNavItem(null);">
         <span class="fa fa-fw {{vmmain.page('dataservice-summary').icon}}"></span>
-        <div>{{:: 'shared.DataServices' | translate}}</div>
+        <div translate="shared.DataServices"></div>
     </div>
     <div id="ds-nav-item-sources" class="dsb-nav-item" ng-click="vmmain.selectNavItem('datasource-summary')" body-click="vmmain.selectNavItem(null);">
         <span class="fa fa-fw {{vmmain.page('datasource-summary').icon}}"></span>
-        <div>{{:: 'shared.Sources' | translate}}</div>
+        <div translate="shared.Sources"></div>
     </div>
     <div id="dsb-nav-item-dashboard" class="dsb-nav-item" ng-click="vmmain.selectPage('dataservice-home')" body-click="vmmain.selectNavItem(null);">
         <span class="fa fa-fw {{vmmain.page('dataservice-home').icon}}"></span>
-        <div>{{:: 'shared.Dashboard' | translate}}</div>
+        <div translate="shared.Dashboard"></div>
     </div>
     <div class="dsb-nav-item-filler">
     </div>
@@ -20,9 +20,9 @@
     <!-- detail menus -->
     <div id="dsb-vertical-nav-details" ng-switch="vmmain.selectedNavItem" ng-show="vmmain.navItemSelected()">
         <div id="dsb-nav-detail-dataservices" class="dsb-nav-detail-item" ng-switch-when="dataservice-summary">
-            <h3>{{:: 'shared.DataServices' | translate}}</h3>
-            <p class="description">{{:: 'dataservice-navbar.dataServiceActionsMsg' | translate}}</p>
-            <h4 class="heading">{{:: 'dataservice-navbar.DataServiceActions' | translate}}</h4>
+            <h3 translate="shared.DataServices"></h3>
+            <p class="description" translate="dataservice-navbar.dataServiceActionsMsg"></p>
+            <h4 class="heading" translate="dataservice-navbar.DataServiceActions"></h4>
             <div ng-repeat="page in vmmain.pages(['dataservice-summary', 'dataservice-new', 'dataservice-import'])">
                 <div class="action">
                     <a ng-click="vmmain.selectPage(page.id)"><span class="fa fa-fw {{page.icon}}"></span><span>{{page.title}}</span></a>
@@ -30,9 +30,9 @@
             </div>
         </div>
         <div id="dsb-nav-detail-mappings" class="dsb-nav-detail-item" ng-switch-when="datasource-summary">
-            <h3>{{:: 'shared.Sources' | translate}}</h3>
-            <p class="description">{{:: 'dataservice-navbar.sourceActionsMsg' | translate}}</p>
-            <h4 class="heading">{{:: 'dataservice-navbar.SourceActions' | translate}}</h4>
+            <h3 translate="shared.Sources"></h3>
+            <p class="description" translate="dataservice-navbar.sourceActionsMsg"></p>
+            <h4 class="heading" translate="dataservice-navbar.SourceActions"></h4>
             <div ng-repeat="page in vmmain.pages(['datasource-summary', 'svcsource-new', 'svcsource-import'])">
                 <div class="action">
                     <a ng-click="vmmain.selectPage(page.id)"><span class="fa fa-fw {{page.icon}}"></span><span>{{page.title}}</span></a>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-new.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-new.html
@@ -4,7 +4,7 @@
     <div id="dataservice-new-nosources" ng-show="vm.hasSources==false" class="col-md-10 row">
         <div class="row">
             <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
-            <p>{{:: 'dataservice-new.configureSourceMsg' | translate}}
+            <p translate="dataservice-new.configureSourceMsg">
                 <a href ng-click="vmmain.selectPage('svcsource-new')"><span class="fa fa-fw {{vmmain.page('svcsource-new').icon}}"></span><span>{{vmmain.page('svcsource-new').title}}</span></a></p>
         </div>
     </div>
@@ -12,31 +12,31 @@
     <div id="dataservice-new-controls" ng-show="vm.hasSources==true" class="col-md-10 row">
         <div class="col-sm-9 row">
             <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
-            <h4>{{:: 'dataservice-new.instructionsMsg' | translate}} 
+            <h4 translate="dataservice-new.instructionsMsg">
                 <a href ng-click="vmmain.selectPage('svcsource-new')"><span class="fa fa-fw {{vmmain.page('svcsource-new').icon}}"></span><span>{{vmmain.page('svcsource-new').title}}</span></a>
             </h4>
             <div class="col-md-5">
-                <h4><strong>{{:: 'shared.Sources' | translate}}</strong></h4>
+                <h4><strong translate="shared.Sources"></strong></h4>
                 <service-source-list></service-source-list>
             </div>
             <div class="col-md-5">
-                <h4><strong>{{:: 'shared.Tables' | translate}}</strong></h4>
+                <h4><strong translate="shared.Tables"></strong></h4>
                 <model-table-list></model-table-list>
             </div>
             <div class="col-md-12" ng-show="vm.showNameAndDescription">
                 <p></p>
-                <h4>{{:: 'dataservice-new.inputFieldsHelpMsg' | translate}}</h4>
+                <h4 translate="dataservice-new.inputFieldsHelpMsg"></h4>
                 <p></p>
                 <form class="form-horizontal">
                     <div class="form-group">
-                        <label class="col-md-2 control-label" for="textInput">{{:: 'shared.Name' | translate}}</label>
+                        <label class="col-md-2 control-label" for="textInput" translate="shared.Name"></label>
                         <div class="col-md-6">
                           <input type="text" ng-model="vm.serviceName" class="form-control">
                         </div>
                         <div class="col-md-4"></div>
                     </div>
                     <div class="form-group">
-                        <label class="col-md-2 control-label" for="textInput">{{:: 'shared.Description' | translate}}</label>
+                        <label class="col-md-2 control-label" for="textInput" translate="shared.Description"></label>
                         <div class="col-md-6">
                           <input type="text" ng-model="vm.serviceDescription" class="form-control">
                         </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-summary.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-summary.html
@@ -5,7 +5,7 @@
         <div class="row">
             <h2 ng-bind-html=":: 'dataservice-summary.welcomeMsg' | translate"></h2>
             <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
-            <p>{{:: 'dataservice-summary.createSourceMsg' | translate}}
+            <p translate="dataservice-summary.createSourceMsg">
                <a href ng-click="vmmain.selectPage('svcsource-new')"><span class="fa fa-fw {{vmmain.page('svcsource-new').icon}}"></span><span>{{vmmain.page('svcsource-new').title}}</span></a>
                <br>
                {{:: 'dataservice-summary.importDataServiceMsg' | translate}}
@@ -19,7 +19,7 @@
         <div class="row">
             <h2 ng-bind-html=":: 'dataservice-summary.welcomeMsg' | translate"></h2>
             <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
-            <p>{{:: 'dataservice-summary.createDataServiceMsg' | translate}}
+            <p translate="dataservice-summary.createDataServiceMsg">
                <a href ng-click="vmmain.selectPage('dataservice-new')"><span class="fa fa-fw {{vmmain.page('dataservice-new').icon}}"></span><span>{{vmmain.page('dataservice-new').title}}</span></a>
                <br>
                {{:: 'dataservice-summary.importDataServiceMsg' | translate}}
@@ -36,7 +36,7 @@
 
         <div id="dataservice-summary-updating" ng-show="vm.dsLoading==true || vm.sourcesLoading==true" class="col-md-10 row">
             <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
-            <span class="sr-only">{{:: 'shared.loadingProgressMsg' | translate}}</span>
+            <span class="sr-only" translate="shared.loadingProgressMsg"></span>
         </div>
 
         <div class="ds-summary-results-container" ng-show="vm.dsLoading==false && vm.sourcesLoading==false && vm.hasServices==true">
@@ -61,7 +61,7 @@
                                 <div class="list-view-pf-additional-info-item" uib-tooltip="{{:: 'dataservice-summary.connectionsNumberToolTip' | translate}}">
                                     <span class="fa fa-cog"></span>
                                     <strong>{{item.connections}}</strong>
-                                    <span>{{item.connections === 1 ? 'Connection' : 'Connections'}}</span>
+                                    <span>{{item.connections === 1 ? 'shared.Connection' : 'shared.Connections' | translate}}</span>
                                 </div>
                             </div>
                         </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasource-summary.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasource-summary.html
@@ -5,7 +5,7 @@
         <div class="row">
             <h2 ng-bind-html=":: 'datasource-summary.welcomeMsg' | translate"></h2>
             <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
-            <p>{{:: 'datasource-summary.noSourcesInstructionsMsg' | translate}}
+            <p translate="datasource-summary.noSourcesInstructionsMsg">
             <a href ng-click="vmmain.selectPage('svcsource-new')"><span class="fa fa-fw {{vmmain.page('svcsource-new').icon}}"></span><span>{{vmmain.page('svcsource-new').title}}</span></a>
             </p>
         </div>
@@ -20,7 +20,7 @@
 
         <div id="svcsource-summary-updating" ng-show="vm.srcLoading==true">
             <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
-            <span class="sr-only">{{:: 'datasource-summary.Loading' | translate}}</span>
+            <span class="sr-only" translate="datasource-summary.Loading"></span>
         </div>
 
         <div class="svcsource-summary-results-container" ng-show="vm.srcLoading==false && vm.hasSources==true">
@@ -64,7 +64,7 @@
 
             <div class="svcsource-summary-results-ddl" ng-show="vm.srcLoading==false && vm.getServiceSources().length>0 && vm.displayDdl==true">
                 <div class="svcsource-summary-results-ddl-titlebar">
-                    <h5 class="svcsource-summary-results-ddl-titlebar-title">{{:: 'datasource-summary.sourceSchema' | translate}}</h5>
+                    <h5 class="svcsource-summary-results-ddl-titlebar-title" translate="datasource-summary.sourceSchema"></h5>
                     <h5 class="svcsource-summary-results-ddl-titlebar-close" ng-click="vm.displayDdl = false">X</h5>
                 </div>
                 <div ui-codemirror="{ onLoad : vm.ddlEditorLoaded }" ng-model="vm.selectedSourceDDL" ui-codemirror-opts="vm.ddlEditorOptions">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-clone.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-clone.html
@@ -1,7 +1,7 @@
 <div class="container-fluid" ng-controller="SvcSourceCloneController as vm">
     <div id="svcsource-clone" ng-show="vm.cloneVdbInProgress==true" class="col-md-10 row">
         <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
-        <span class="sr-only">{{:: 'svcsource-clone.Loading' | translate}}</span>
+        <span class="sr-only" translate="svcsource-clone.Loading"></span>
     </div>
     
     <div id="svcsource-clone-controls" ng-show="vm.cloneVdbInProgress==false" class="col-md-10 row">
@@ -11,14 +11,14 @@
           <h3>&nbsp;&nbsp;{{:: 'svcsource-clone.instructionsMsg' | translate}}</h3>
           <form class="form-horizontal">
               <div class="form-group">
-                  <label class="col-md-2 control-label" for="textInput">{{:: 'svcsource-clone.Name' | translate}}</label>
+                  <label class="col-md-2 control-label" for="textInput" translate="svcsource-clone.Name"></label>
                   <div class="col-md-6">
                     <input type="text" ng-model="nameVar" class="form-control">
                   </div>
               </div>
           </form>
-          <button class="btn btn-primary" ng-click="vm.onCloneSvcSourceClicked(vmmain.selectedServiceSource().keng__id, nameVar)" ng-class="{active:vmmain.selectedPage.id == 'svcsource-clone'}">{{:: 'svcsource-clone.Create' | translate}}</button>
-          <button class="btn btn-default" ng-click="vmmain.selectPage('datasource-summary')" ng-class="{active:vmmain.selectedPage.id == 'svcsource-clone'}">{{:: 'svcsource-clone.Cancel' | translate}}</button>
+          <button class="btn btn-primary" ng-click="vm.onCloneSvcSourceClicked(vmmain.selectedServiceSource().keng__id, nameVar)" ng-class="{active:vmmain.selectedPage.id == 'svcsource-clone'}" translate="svcsource-clone.Create"></button>
+          <button class="btn btn-default" ng-click="vmmain.selectPage('datasource-summary')" ng-class="{active:vmmain.selectedPage.id == 'svcsource-clone'}" translate="svcsource-clone.Cancel"></button>
         </div>
       </div>
     </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-edit.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-edit.html
@@ -1,21 +1,21 @@
 <div class="container-fluid" ng-controller="SvcSourceEditController as vm">
     <div id="svcsource-edit-updating" ng-show="vm.transLoading==true || vm.updateAndDeployInProgress==true" class="col-md-10 row">
         <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
-        <span class="sr-only">{{:: 'svcsource-edit.Loading' | translate}}</span>
+        <span class="sr-only" translate="svcsource-edit.Loading"></span>
     </div>
     
     <div id="svcsource-edit-controls" ng-show="vm.transLoading==false && vm.updateAndDeployInProgress==false" class="col-md-10 row">
       <div class="row">
         <div class="col-md-11">
             <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
-            <h4>{{:: 'svcsource-edit.instructionsMsg' | translate}}</h4>
+            <h4 translate="svcsource-edit.instructionsMsg"></h4>
             <form class="form-horizontal">
                 <div class="col-md-5">
-                    <h4><strong>{{:: 'svcsource-edit.Connections' | translate}}</strong></h4>
+                    <h4><strong translate="svcsource-edit.Connections"></strong></h4>
                     <connection-list selection="{{vm.initialConnectionName}}"></connection-list>
                 </div>
                 <div class="col-md-5">
-                    <h4><strong>{{:: 'svcsource-edit.Translator' | translate}}</strong></h4>
+                    <h4><strong translate="svcsource-edit.Translator"></strong></h4>
                     <img src="{{vm.selectedTranslatorImage}}" width="42" height="24"/>
                     <select id="translators" ng-model="vm.selectedTranslator" ng-options="trans as trans.keng__id for trans in vm.allTranslators"
                                              ng-change="vm.translatorChanged()">
@@ -24,13 +24,13 @@
                 </div>
                 <div class="col-md-12"></div>
                 <div class="form-group" style="margin-top: 20px">
-                    <label class="col-md-2 control-label" for="textInput">{{:: 'svcsource-edit.Name' | translate}}</label>
+                    <label class="col-md-2 control-label" for="textInput" translate="svcsource-edit.Name"></label>
                     <div class="col-md-6">
                         <input type="text" readonly="readonly" ng-model="vm.svcSourceName" ng-init="vm.svcSourceName=vmmain.selectedServiceSource().keng__id" class="form-control">
                     </div>
                 </div>
                 <div class="form-group">
-                    <label class="col-md-2 control-label" for="textInput">{{:: 'svcsource-edit.Description' | translate}}</label>
+                    <label class="col-md-2 control-label" for="textInput" translate="svcsource-edit.Description"></label>
                     <div class="col-md-6">
                         <input type="text" ng-model="vm.svcSourceDescription" ng-init="vm.svcSourceDescription=vmmain.selectedServiceSource().vdb__description" class="form-control">
                     </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-new.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-new.html
@@ -1,40 +1,40 @@
 <div class="container-fluid" ng-controller="SvcSourceNewController as vm">
     <div id="svcsource-new-updating" ng-show="vm.createAndDeployInProgress==true" class="col-md-10 row">
         <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
-        <span class="sr-only">{{:: 'svcsource-new.Loading' | translate}}</span>
+        <span class="sr-only" translate="svcsource-new.Loading"></span>
     </div>
     
     <div id="svcsource-new-controls" ng-show="vm.createAndDeployInProgress==false" class="col-md-10 row">
       <div class="col-sm-9 row">
           <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
-          <h4>{{:: 'svcsource-new.instructionsMsg' | translate}}</h4>
+          <h4 translate="svcsource-new.instructionsMsg"></h4>
           <div class="col-md-5">
-              <h4><strong>{{:: 'svcsource-new.Connections' | translate}}</strong></h4>
+              <h4><strong translate="svcsource-new.Connections"></strong></h4>
               <connection-list></connection-list>
           </div>
           <div class="col-md-5" ng-show="vm.showTranslator">
-              <h4><strong>{{:: 'svcsource-new.Translator' | translate}}</strong></h4>
+              <h4><strong translate="svcsource-new.Translator"></strong></h4>
               <img src="{{vm.selectedTranslatorImage}}" width="42" height="24"/>
               <select id="translators" ng-model="vm.selectedTranslator" ng-options="trans as trans.keng__id for trans in vm.allTranslators" 
                       ng-change="vm.translatorChanged()">
-                  <option value="">{{:: 'svcsource-new.chooseTranslator' | translate}}</option>
+                  <option value="" translate="svcsource-new.chooseTranslator"></option>
               </select>
           </div>
 
           <div class="col-md-12" ng-show="vm.showNameAndDescription">
               <p></p>
-              <h4>{{:: 'svcsource-new.nameDescriptionInstructionsMsg' | translate}}</h4>
+              <h4 translate="svcsource-new.nameDescriptionInstructionsMsg"></h4>
               <p></p>
               <form class="form-horizontal">
                   <div class="form-group">
-                      <label class="col-md-2 control-label" for="textInput">{{:: 'svcsource-new.Name' | translate}}</label>
+                      <label class="col-md-2 control-label" for="textInput" translate="svcsource-new.Name"></label>
                       <div class="col-md-6">
                         <input type="text" ng-model="vm.svcSourceName" class="form-control">
                       </div>
                       <div class="col-md-4"></div>
                   </div>
                   <div class="form-group">
-                      <label class="col-md-2 control-label" for="textInput">{{:: 'svcsource-new.Description' | translate}}</label>
+                      <label class="col-md-2 control-label" for="textInput" translate="svcsource-new.Description"></label>
                       <div class="col-md-6">
                         <input type="text" ng-model="vm.svcSourceDescription" class="form-control">
                       </div>


### PR DESCRIPTION
* In the same manner as $translate (see 7a87903e1), the translate filter
  does not allow for asynchronous loading of translation files, especially
  if the translation selected does not exist and the fallback is used.

* Replacing the filter with the directive allows for asynchronous handling
  and reduces the number of watch expressions (see docs at
  https://angular-translate.github.io/docs/#/guide/05_using-translate-directive)