### PR TITLE
Downgrade angular-bootstrap to 0.14

### DIFF
--- a/vdb-bench-assembly/bower.json
+++ b/vdb-bench-assembly/bower.json
@@ -24,7 +24,7 @@
     "hawtio-preferences": "~2.0.3",
     "hawtio-template-cache": "~2.0.3",
     "hawtio-forms": "~2.0.0",
-    "angular-bootstrap": "~1.0.0",
+    "angular-bootstrap": "~0.14.0",
     "restangular": "~1.5.1",
     "angular-ui-codemirror": "~0.3.0",
     "angular-pretty-xml": "~0.1.1",
@@ -56,7 +56,6 @@
     "jquery": "^2.0",
     "angular-dashboard-framework": "^0.11.0",
     "bootstrap": "~3.3.5",
-    "angular-bootstrap": "~1.0.0",
     "angular-route": "~1.5",
     "angular": "~1.5",
     "patternfly": "~3.6",
@@ -67,6 +66,7 @@
     "datatables-colreorder": "~1.3.2",
     "moment": ">=2.9.0",
     "jquery-ui": ">=1.9",
-    "d3": "^3.4"
+    "d3": "^3.4",
+    "angular-bootstrap": "^0.14.3"
   }
 }

--- a/vdb-bench-assembly/index.html
+++ b/vdb-bench-assembly/index.html
@@ -15,6 +15,7 @@
     <!-- inject-vendor:css -->
 
     <link rel="stylesheet" href="libs/bootstrap/dist/css/bootstrap.css" />
+    <link rel="stylesheet" href="libs/bootstrap/dist/css/bootstrap-theme.css" />
     <link rel="stylesheet" href="libs/patternfly/dist/css/patternfly.css" />
     <link rel="stylesheet" href="libs/patternfly/dist/css/patternfly-additions.css" />
     <link rel="stylesheet" href="libs/codemirror/lib/codemirror.css" />


### PR DESCRIPTION
* 1.0.0 removes the deprecated directive names, eg. modal, that were
  replaced by the uib prefix equivalents, eg. uib-modal.

* hawtio modules still use version 0.13 and retain the original directive
  names so upgrading causes errors in the browser. Cannot upgrade without
  hawtio upgrading first.