### PR TITLE
adds jdbc connection filtering

### DIFF
--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -35,6 +35,7 @@
         "PasswordLabel" : "Password:",
         "Remove" : "Remove",
         "Save" : "Save",
+        "Schemas" : "Schemas",
         "Search" : "Search",
         "Source" : "Source",
         "Sources" : "Sources",
@@ -318,6 +319,14 @@
     	"inlineFramesNotSupportedMsg" : "Sorry your browser doesn't support inline frames."
     },
 
+    "jdbcFilterOptions" : {
+        "noContent" : "No Content",
+        "notJdbcMsg" : "'{{connName}}' is not a JDBC Connection",
+        "noTables" : "No Tables",
+        "optionMsg" : "Filter options for connection '{{connName}}'",
+        "tableFetchNoConnectionErrorMsg" : "Error fetching tables - null connection"
+    },
+
     "modelTableList" : {
         "connectionFailedErrorMsg" : "Failed to get connection: \n{{error}}",
         "getTablesErrorMsg" : "Failed to get Tables. \n{{errorMsg}}"
@@ -347,6 +356,7 @@
         "Cancel" : "@:shared.Cancel",
         "Connections" : "@:shared.Connections",
         "Description" : "@:shared.Description",
+        "filterConnection" : "Filter Connection",
         "instructionsMsg" : "Reconfigure an existing Source:",
         "Loading" : "@:shared.loadingProgressMsg",
         "Name" : "@:shared.Name",
@@ -363,6 +373,7 @@
         "chooseTranslator" : "-- choose translator --",
         "Connections" : "@:shared.Connections",
         "Description" : "@:shared.Description",
+        "filterConnection" : "Filter Connection",
         "instructionsMsg" : "Start configuring a new Source by selecting one of your available Connection definitions.",
         "Loading" : "@:shared.loadingProgressMsg",
         "nameDescriptionInstructionsMsg" : "Choose a name (and optional description) for your Source",
@@ -381,7 +392,8 @@
         "sourceUpdateFailedMsg" : "Failed to update the source.",
         "sourceDeployFailedMsg" : "Failed to deploy the source.",
         "sourceModelCreateFailedMsg" : "Failed to create the source model.",
-        "sourceModelConnectionCreateFailedMsg" : "Failed to create the source model connection."
+        "sourceModelConnectionCreateFailedMsg" : "Failed to create the source model connection.",
+        "sourceModelConnectionUpdateFailedMsg" : "Failed to update the source model connection."
     },
 
     "svcSourceNewController" : {

--- a/vdb-bench-assembly/bower.json
+++ b/vdb-bench-assembly/bower.json
@@ -36,6 +36,7 @@
     "angular-translate-loader-static-files": "~2.13.0",
     "angularUtils-pagination": "angular-utils-pagination#~0.9.2",
     "angular-dashboard-framework": "^0.11.0",
+    "angular-tree-control" : "~0.2.28",
     "adf-structures-base": "^0.1.1",
     "d3pie": "^0.1.9",
     "angular-file-saver": "^1.1.1",

--- a/vdb-bench-assembly/index.html
+++ b/vdb-bench-assembly/index.html
@@ -28,6 +28,8 @@
     <link rel="styleSheet" href="libs/angular-ui-grid/ui-grid.css"/>
     <link rel="stylesheet" href="libs/angular-wizard/dist/angular-wizard.min.css"/>
     <link rel="stylesheet" href="libs/angular-ui-select/dist/select.min.css"/>
+    <link rel="stylesheet" href="libs/angular-tree-control/css/tree-control.css"/>
+    <link rel="stylesheet" href="libs/angular-tree-control/css/tree-control-attribute.css"/>
 
     <!-- endinject -->
 
@@ -95,6 +97,7 @@
     <script src="libs/angular-ui-grid/ui-grid.min.js"></script>
     <script src="libs/angular-translate/angular-translate.js"></script>
     <script src="libs/angular-translate-loader-static-files/angular-translate-loader-static-files.js"></script>
+    <script src="libs/angular-tree-control/angular-tree-control.js"></script>
     <script src="libs/abdmob/x2js/xml2json.min.js"></script>
     <script src="libs/angular-pageslide-directive/dist/angular-pageslide-directive.min.js"></script>
 
@@ -139,6 +142,7 @@
     <script src="plugins/vdb-bench-widgets/vdbList.js"></script>
     <script src="plugins/vdb-bench-widgets/serviceSourceList.js"></script>
     <script src="plugins/vdb-bench-widgets/modelTableList.js"></script>
+    <script src="plugins/vdb-bench-widgets/jdbcFilterOptions.js"></script>
     <script src="plugins/vdb-bench-widgets/connectionList.js"></script>
     <script src="plugins/vdb-bench-widgets/vdbVisualize.js"></script>
     <script src="plugins/vdb-bench-widgets/fileImportControl.js"></script>

--- a/vdb-bench-assembly/plugins/vdb-bench-core/ConnectionSelectionService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/ConnectionSelectionService.js
@@ -23,6 +23,7 @@
         conn.deploymentConnectionName = null;
         conn.deploymentSuccess = false;
         conn.deploymentMessage = null;
+        conn.filterProperties = [];
 
         /*
          * Service instance to be returned
@@ -62,7 +63,7 @@
             }
 
             // Removes any outdated selection
-            service.selectConnection(null);
+            service.selectConnection(null, true);
         }
 
         function sortByKey(array, key) {
@@ -127,6 +128,20 @@
         };
 
         /*
+         * Get the connection with the requested name
+         */
+        service.getConnection = function(connName) {
+            var result = null;
+            for (var i = 0; i < conn.connections.length; ++i) {
+                if(conn.connections[i].keng__id === connName) {
+                    result = conn.connections[i];
+                    break;
+                }
+            }
+            return result;
+        };
+
+        /*
          * Get the connection statue
          */
         service.getConnectionState = function(connection) {
@@ -136,14 +151,16 @@
         /*
          * Select the given connection
          */
-        service.selectConnection = function(connection) {
+        service.selectConnection = function(connection, broadcast) {
             //
             // Set the selected connection
             //
             conn.connection = connection;
 
             // Useful for broadcasting the selected connection has been updated
-            $rootScope.$broadcast("selectedConnectionChanged", conn.connection);
+            if(broadcast) {
+                $rootScope.$broadcast("selectedConnectionChanged");
+            }
         };
 
         /*
@@ -151,6 +168,39 @@
          */
         service.selectedConnection = function() {
             return conn.connection;
+        };
+
+        /*
+         * Resets the filter properties to defaults
+         */
+        service.resetFilterProperties = function() {
+            conn.filterProperties = [{ "name": "importer.TableTypes",
+                                       "value": "TABLE"},
+                                     { "name": "importer.UseFullSchemaName",
+                                       "value": "false"},
+                                     { "name": "importer.UseQualifiedName",
+                                       "value": "false"},
+                                     { "name": "importer.UseCatalogName",
+                                       "value": "false"}];
+        };
+
+        /*
+         * Adds the specified filter property
+         */
+        service.addFilterProperty = function(propName, propValue) {
+            if(angular.isDefined(propValue) && propValue!==null && propValue.length>0 ) {
+                conn.filterProperties.push({ 
+                    "name" : propName,
+                    "value": propValue
+                });
+            }
+        };
+
+        /*
+         * return selected connection filter properties
+         */
+        service.selectedConnectionFilterProperties = function() {
+            return conn.filterProperties;
         };
 
         /*

--- a/vdb-bench-assembly/plugins/vdb-bench-core/SvcSourceSelectionService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/SvcSourceSelectionService.js
@@ -28,6 +28,7 @@
         svcSrc.editSourceConnectionNameSelection = null;
         svcSrc.editSourceConnectionJndiSelection = null;
         svcSrc.editSourceTranslatorNameSelection = null;
+        svcSrc.editSourceInfo = [];
 
         /*
          * Service instance to be returned
@@ -262,45 +263,18 @@
         };
 
         /*
-         * Set the selected connection name for the editor
+         * Set info about the service source being edited.
+         * [connectionName :
          */
-        service.setEditSourceConnectionNameSelection = function(connectionName) {
-            svcSrc.editSourceConnectionNameSelection = connectionName;
+        service.setEditSourceInfo = function(sourceInfo) {
+            svcSrc.editSourceInfo = sourceInfo;
         };
 
         /*
-         * Returns the selected connection name for the editor
+         * Returns the info about the service source being edited.
          */
-        service.getEditSourceConnectionNameSelection = function() {
-            return svcSrc.editSourceConnectionNameSelection;
-        };
-
-        /*
-         * Set the selected connection jndi for the editor
-         */
-        service.setEditSourceConnectionJndiSelection = function(connectionJndi) {
-            svcSrc.editSourceConnectionJndiSelection = connectionJndi;
-        };
-
-        /*
-         * Returns the selected connection jndi for the editor
-         */
-        service.getEditSourceConnectionJndiSelection = function() {
-            return svcSrc.editSourceConnectionJndiSelection;
-        };
-
-        /*
-         * Set the selected translator name for the editor
-         */
-        service.setEditSourceTranslatorNameSelection = function(translatorName) {
-            svcSrc.editSourceTranslatorNameSelection = translatorName;
-        };
-
-        /*
-         * Returns the selected translator name for the editor
-         */
-        service.getEditSourceTranslatorNameSelection = function() {
-            return svcSrc.editSourceTranslatorNameSelection;
+        service.getEditSourceInfo = function() {
+            return svcSrc.editSourceInfo;
         };
 
         /*

--- a/vdb-bench-assembly/plugins/vdb-bench-core/TranslatorSelectionService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/TranslatorSelectionService.js
@@ -42,7 +42,30 @@
             "teiid" : "plugins/vdb-bench-core/content/img/Teiid_dv_logos_70x40.png",
             "ws" : "plugins/vdb-bench-core/content/img/WebService_dv_logos_70x40.png"
         };
-        
+
+        var raTranslators = ["simpledb", 
+                             "accumulo", 
+                             "solr",
+                             "cassandra",
+                             "file",
+                             "google-spreadsheet",
+                             "infinispan-cache-dsl",
+                             "infinispan-cache",
+                             "jpa2",
+                             "ldap",
+                             "loopback",
+                             "excel",
+                             "mongodb",
+                             "map-cache",
+                             "odata",
+                             "odata4",
+                             "olap",
+                             "salesforce",
+                             "salesforce-34",
+                             "ws",
+                             "sap-gateway",
+                             "sap-nw-gateway"];
+
         /*
          * Service instance to be returned
          */
@@ -167,9 +190,20 @@
 
         /*
          * Get the translators
+         * includeRA : 'true' to include ResourceAdapter translators, 'false' to exclude.
          */
-        service.getTranslators = function() {
-            return tran.translators;
+        service.getTranslators = function(includeRA) {
+            if(includeRA) {
+                return tran.translators;
+            }
+            // JDBC only
+            var transJdbcOnly = [];
+            for( var i = 0; i < tran.translators.length; i++) {
+                if( raTranslators.indexOf(tran.translators[i].keng__id) < 0 ) {
+                    transJdbcOnly.push(tran.translators[i]);
+                }
+            }
+            return transJdbcOnly;
         };
 
         /*

--- a/vdb-bench-assembly/plugins/vdb-bench-core/constants.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/constants.js
@@ -59,6 +59,7 @@
             TRANSLATORS: '/VdbTranslators',
             TABLES: '/Tables',
             COLUMNS: '/Columns',
+            JDBC_CATALOG_SCHEMA: '/JdbcCatalogSchema',
             SERVICE_VDB_FOR_SINGLE_TABLE: 'ServiceVdbForSingleTable',
             SERVICE_VIEW_TABLES: 'serviceViewTables',
             SOURCE_VDB_MATCHES: 'sourceVdbMatches',

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/connections/connectionSummaryController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/connections/connectionSummaryController.js
@@ -235,7 +235,7 @@
          * Handle listView and cardView selection
          */
         var handleSelect = function (item, e) {
-            ConnectionSelectionService.selectConnection(item);
+            ConnectionSelectionService.selectConnection(item, true);
             
             // Actions disabled unless one is selected
             var itemsSelected = vm.listConfig.selectedItems;

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-navbar.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-navbar.html
@@ -2,15 +2,15 @@
 </div>
 
 <div id="dsb-vertical-nav">
-    <div id="dsb-nav-item-dataservices" class="dsb-nav-item" ng-click="vmmain.selectNavItem('dataservice-summary')" body-click="vmmain.selectNavItem(null);">
+    <div id="dsb-nav-item-dataservices" class="dsb-nav-item {{vmmain.dataserviceNav}}" ng-click="vmmain.selectNavItem('dataservice-summary')" body-click="vmmain.selectNavItem(null);">
         <span class="fa fa-fw {{vmmain.page('dataservice-summary').icon}}"></span>
         <div translate="shared.DataServices"></div>
     </div>
-    <div id="ds-nav-item-sources" class="dsb-nav-item" ng-click="vmmain.selectNavItem('datasource-summary')" body-click="vmmain.selectNavItem(null);">
+    <div id="ds-nav-item-sources" class="dsb-nav-item {{vmmain.datasourceNav}}" ng-click="vmmain.selectNavItem('datasource-summary')" body-click="vmmain.selectNavItem(null);">
         <span class="fa fa-fw {{vmmain.page('datasource-summary').icon}}"></span>
         <div translate="shared.Sources"></div>
     </div>
-    <div id="dsb-nav-item-dashboard" class="dsb-nav-item" ng-click="vmmain.selectPage('dataservice-home')" body-click="vmmain.selectNavItem(null);">
+    <div id="dsb-nav-item-dashboard" class="dsb-nav-item {{vmmain.homeNav}}" ng-click="vmmain.selectPage('dataservice-home')" body-click="vmmain.selectNavItem(null);">
         <span class="fa fa-fw {{vmmain.page('dataservice-home').icon}}"></span>
         <div translate="shared.Dashboard"></div>
     </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservicePageController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservicePageController.js
@@ -57,6 +57,10 @@
                                                             ConnectionSelectionService, SvcSourceSelectionService, DSPageService) {
         var vm = this;
 
+        vm.dataserviceNav = "";
+        vm.datasourceNav = "";
+        vm.homeNav = "";
+
         /*
          * When a data service is currently being deployed
          */
@@ -84,8 +88,33 @@
         };
 
         vm.selectPage = function(pageId) {
+            if(pageId === DSPageService.SERVICESOURCE_NEW_PAGE) {
+                ConnectionSelectionService.resetFilterProperties();
+            }
             vm.selectedPage = DSPageService.page(pageId);
+            setNavActiveState(vm.selectedPage);
         };
+
+        function setNavActiveState(page) {
+            vm.dataserviceNav = "";
+            vm.datasourceNav = "";
+            vm.homeNav = "";
+            var activeNav = "";
+            // No parent
+            if(page.parent===null) {
+                activeNav = page.id;
+            // Parent defines active nav
+            } else {
+                activeNav = page.parent;
+            }
+            if(activeNav === 'dataservice-summary') {
+                vm.dataserviceNav = "active";
+            } else if(activeNav === 'datasource-summary') {
+                vm.datasourceNav = "active";
+            } else if(activeNav === 'dataservice-home') {
+                vm.homeNav = "active";
+            }
+        }
 
         vm.selectedPageCrumbs = function() {
             return DSPageService.pageCrumbs(vm.selectedPage);

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-edit.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-edit.html
@@ -9,37 +9,60 @@
         <div class="col-md-11">
             <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
             <h4 translate="svcsource-edit.instructionsMsg"></h4>
-            <form class="form-horizontal">
-                <div class="col-md-5">
-                    <h4><strong translate="svcsource-edit.Connections"></strong></h4>
-                    <connection-list selection="{{vm.initialConnectionName}}"></connection-list>
-                </div>
-                <div class="col-md-5">
-                    <h4><strong translate="svcsource-edit.Translator"></strong></h4>
-                    <img src="{{vm.selectedTranslatorImage}}" width="42" height="24"/>
-                    <select id="translators" ng-model="vm.selectedTranslator" ng-options="trans as trans.keng__id for trans in vm.allTranslators"
-                                             ng-change="vm.translatorChanged()">
-                        <option value="">-- choose translator --</option>
-                    </select>
-                </div>
-                <div class="col-md-12"></div>
-                <div class="form-group" style="margin-top: 20px">
-                    <label class="col-md-2 control-label" for="textInput" translate="svcsource-edit.Name"></label>
-                    <div class="col-md-6">
-                        <input type="text" readonly="readonly" ng-model="vm.svcSourceName" ng-init="vm.svcSourceName=vmmain.selectedServiceSource().keng__id" class="form-control">
+            <div class="col-md-5">
+                <h4><strong translate="svcsource-edit.Connections"></strong></h4>
+                <connection-list selection="{{vm.initialConnectionName}}" hide-resource-adapters=true></connection-list>
+            </div>
+            <div class="col-md-5">
+                <h4><strong translate="svcsource-edit.Translator"></strong></h4>
+                <img src="{{vm.selectedTranslatorImage}}" width="42" height="24"/>
+                <select id="translators" ng-model="vm.selectedTranslator" ng-options="trans as trans.keng__id for trans in vm.allTranslators"
+                                         ng-change="vm.translatorChanged()">
+                    <option value="">-- choose translator --</option>
+                </select>
+            </div>
+
+            <!--  Filter Checkbox -->
+            <div class="col-md-12" ng-show="vm.selectedJdbcConnection !== null && vm.selectedTranslator !== null">
+                <form>
+                    <input type="checkbox" ng-model="vm.filterSchema" ng-true-value=true ng-false-value=false ng-change="vm.filterCheckboxChanged()">
+                    <h4 style="display:inline"><strong translate="svcsource-edit.filterConnection"></strong></h4><h4>
+                </form>
+            </div>
+
+            <!--  JDBC Filter Options -->
+            <div class="col-md-12" ng-show="vm.filterSchema">
+                <jdbc-filter-options></jdbc-filter-options>
+            </div>
+
+            <div class="col-md-12">
+                <p></p>
+                <h4 translate="svcsource-new.nameDescriptionInstructionsMsg"></h4>
+                <p></p>
+                <form class="form-horizontal">
+                    <div class="form-group" style="margin-top: 20px">
+                        <label class="col-md-2 control-label" for="textInput" translate="svcsource-edit.Name"></label>
+                        <div class="col-md-6">
+                            <input type="text" readonly="readonly" ng-model="vm.svcSourceName" ng-init="vm.svcSourceName=vmmain.selectedServiceSource().keng__id" class="form-control">
+                        </div>
                     </div>
-                </div>
-                <div class="form-group">
-                    <label class="col-md-2 control-label" for="textInput" translate="svcsource-edit.Description"></label>
-                    <div class="col-md-6">
-                        <input type="text" ng-model="vm.svcSourceDescription" ng-init="vm.svcSourceDescription=vmmain.selectedServiceSource().vdb__description" class="form-control">
+                    <div class="form-group">
+                        <label class="col-md-2 control-label" for="textInput" translate="svcsource-edit.Description"></label>
+                        <div class="col-md-6">
+                            <input type="text" ng-model="vm.svcSourceDescription" ng-init="vm.svcSourceDescription=vmmain.selectedServiceSource().vdb__description" class="form-control">
+                        </div>
                     </div>
-                </div>
-            </form>
-            <input type="submit" class="btn btn-primary" value="{{:: 'svcsource-edit.Save' | translate}}" ng-click="vm.onEditSvcSourceClicked()"
-                                              ng-disabled="vm.canUpdateSvcSource() !== true || vmmain.selectedPage.id !== 'svcsource-edit'"/>
-            <input type="button" class="btn btn-default" value="{{:: 'svcsource-edit.Cancel' | translate}}" ng-click="vmmain.selectPage('datasource-summary')"
-                                              ng-disabled="vmmain.selectedPage.id !== 'svcsource-edit'"/>
+                </form>
+            </div>
+            <div>
+                <p></p>
+            </div>
+            <div class="col-md-12">
+                <input type="submit" class="btn btn-primary" value="{{:: 'svcsource-edit.Save' | translate}}" ng-click="vm.onEditSvcSourceClicked()"
+                                                  ng-disabled="vm.canUpdateSvcSource() !== true || vmmain.selectedPage.id !== 'svcsource-edit'"/>
+                <input type="button" class="btn btn-default" value="{{:: 'svcsource-edit.Cancel' | translate}}" ng-click="vmmain.selectPage('datasource-summary')"
+                                                  ng-disabled="vmmain.selectedPage.id !== 'svcsource-edit'"/>
+            </div>
         </div>
       </div>
     </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-new.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-new.html
@@ -10,7 +10,7 @@
           <h4 translate="svcsource-new.instructionsMsg"></h4>
           <div class="col-md-5">
               <h4><strong translate="svcsource-new.Connections"></strong></h4>
-              <connection-list></connection-list>
+              <connection-list hide-resource-adapters=true></connection-list>
           </div>
           <div class="col-md-5" ng-show="vm.showTranslator">
               <h4><strong translate="svcsource-new.Translator"></strong></h4>
@@ -19,6 +19,19 @@
                       ng-change="vm.translatorChanged()">
                   <option value="" translate="svcsource-new.chooseTranslator"></option>
               </select>
+          </div>
+
+          <!--  Filter Checkbox -->
+          <div class="col-md-12" ng-show="vm.selectedJdbcConnection !== null && vm.selectedTranslator !== null">
+              <form>
+                  <input type="checkbox" ng-model="vm.filterSchema" ng-true-value=true ng-false-value=false ng-change="vm.filterCheckboxChanged()">
+                  <h4 style="display:inline"><strong translate="svcsource-new.filterConnection"></strong></h4><h4>
+              </form>
+          </div>
+
+          <!--  JDBC Filter Options -->
+          <div class="col-md-12" ng-show="vm.filterSchema">
+              <jdbc-filter-options></jdbc-filter-options>
           </div>
 
           <div class="col-md-12" ng-show="vm.showNameAndDescription">
@@ -42,10 +55,9 @@
                   </div>
               </form>
           </div>
-          <div class="col-md-12">
+          <div>
               <p></p>
           </div>
-
           <div class="col-md-12">
               <input type="submit" class="btn btn-primary" value="{{:: 'svcsource-new.Save' | translate}}" ng-click="vm.onCreateSvcSourceClicked()"
                                    ng-disabled="vm.canCreateSvcSource() !== true || vmmain.selectedPage.id !== 'svcsource-new'"/>

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/connectionList.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/connectionList.html
@@ -5,6 +5,14 @@
     </div>
     
     <div class="pick-list-container">
+        <!-- Spinner when loading -->
+        <div ng-show="vm.connectionsLoading==true">
+            <i class="fa fa-spinner fa-spin fa-2x fa-fw"></i>
+        </div>
+        <!-- No Content Message -->
+        <div ng-show="vm.connectionsLoading==false && vm.items.length == 0">
+            <h4>No Connections</h4>
+        </div>
         <div class="pick-list-results">
             <div id="connectionList-table-row" class="list-view-container" ng-show="vm.connectionsLoading==false">
                 <div pf-list-view config="vm.listConfig" items="vm.items">

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/connectionList.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/connectionList.js
@@ -15,9 +15,11 @@
     function ConnectionList(config, syntax) {
         var directive = {
             restrict: 'E',
-            scope: {},
+            scope: true,
             bindToController: {
-                selection : '@'
+                selection : '@',
+                hideJdbc : '=',
+                hideResourceAdapters : '='
             },
             controller: ConnectionListController,
             controllerAs: 'vm',
@@ -44,7 +46,7 @@
             vm.connectionsLoading = loading;
             if(vm.connectionsLoading === false) {
                 vm.allItems = ConnectionSelectionService.getConnections();
-                vm.items = vm.allItems;
+                vm.items = filterItems(vm.allItems);
             }
         });
 
@@ -64,6 +66,29 @@
             vm.listConfig.selectedItems = selItems;
         }
         
+        function filterItems(all) {
+            // Determine from supplied 'hide' attributes which types to include
+            var showJdbc = true;
+            var showResourceAdapters = true;
+            if(angular.isDefined(vm.hideJdbc) && vm.hideJdbc===true) {
+                showJdbc = false;
+            }
+            if(angular.isDefined(vm.hideResourceAdapters) && vm.hideResourceAdapters===true) {
+                showResourceAdapters = false;
+            }
+            
+            var filteredItems = [];
+            if(angular.isDefined(all) && all!==null) {
+                for(var i = 0; i < all.length; ++i) {
+                    if( all[i].dv__type===true && showJdbc ) {
+                        filteredItems.push(all[i]);
+                    } else if( all[i].dv__type===false && showResourceAdapters ) {
+                        filteredItems.push(all[i]);
+                    }
+                }
+            }
+            return filteredItems;
+        }
         /**
          * Access to the collection of filtered connections
          */
@@ -84,9 +109,9 @@
         var handleSelect = function (item, e) {
             var itemsSelected = vm.listConfig.selectedItems;
             if(itemsSelected.length === 0) {
-                ConnectionSelectionService.selectConnection(null);
+                ConnectionSelectionService.selectConnection(null, true);
             } else {
-                ConnectionSelectionService.selectConnection(item);
+                ConnectionSelectionService.selectConnection(item, true);
             }
         };  
                 
@@ -107,7 +132,7 @@
          */
         vm.refresh = function() {
             vm.allItems = ConnectionSelectionService.getConnections();
-            vm.items = vm.allItems;
+            vm.items = filterItems(vm.allItems);
             
             // Set the selection (if specified)
             var selItems = [];
@@ -123,7 +148,7 @@
             }
             if(selItems.length==1) {
                 vm.listConfig.selectedItems = selItems;
-                ConnectionSelectionService.selectConnection(selItems[0]);
+                ConnectionSelectionService.selectConnection(selItems[0], true);
             }
         };
 

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/constants.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/constants.js
@@ -55,5 +55,17 @@
             TYPE_AHEAD: 'typeahead',
             CONTROLS: 'controls',
             TABS: 'tabs'
+        })
+        .constant('JDBC_FILTER', {
+            KEY_CATALOG: 'importer.catalog',
+            KEY_SCHEMA_PATTERN: 'importer.schemaPattern',
+            KEY_TABLE_NAME_PATTERN: 'importer.tableNamePattern',
+            BLANK: '',
+            CATALOG: 'Catalog',
+            SCHEMA: 'Schema',
+            TABLE: 'Table',
+            USER_NAME: 'user-name',
+            WILD_CARD: '%'
         });
+
 })();

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/content/css/styles.less
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/content/css/styles.less
@@ -338,3 +338,18 @@ body.ng-pageslide-body-closed::before {
     vertical-align: bottom;
 }
 
+.tree-control-results {
+    height: 190px;
+    overflow: auto;
+    line-height: 1.00;
+    padding-top: 0px;
+    padding-bottom: 0px;
+}
+
+.tree-control-container {
+    border: 1px solid #000000;
+    height: 200px;
+    min-height: 200px;
+    margin: 10px;
+    padding: 0;
+}

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/jdbcFilterOptions.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/jdbcFilterOptions.html
@@ -1,0 +1,105 @@
+<div>
+    <!--  Selection is not JDBC -->
+    <div class="row" ng-show="vm.jdbcConnectionSelected==false">
+        <div class="col-md-12" >
+            <h4 translate="jdbcFilterOptions.notJdbcMsg" translate-values="{connName: vm.selectedConn.keng__id}"></h4>
+        </div>
+    </div>
+    
+    <!--  Filter Option Controls -->
+    <div id="connection-msg" ng-show="vm.jdbcConnectionSelected==true">
+        <!-- Message -->
+        <div class="row">
+            <div class="col-md-12">
+                <h3 translate="jdbcFilterOptions.optionMsg" translate-values="{connName: vm.selectedConn.keng__id}"></h3>
+            </div>
+        </div>
+        <!--  -->
+        <!--  -->
+        <!-- Options resetting -->
+        <div class="row" ng-show="vm.optionsResetting==true">
+            <i class="fa fa-spinner fa-spin fa-2x fa-fw"></i>
+        </div>
+        <!--  -->
+        <!--  -->
+        <!-- Section titles -->
+        <div class="row" ng-show="vm.optionsResetting==false">
+            <div class="col-md-5" ng-show="vm.supportsCatalogOrSchema">
+                <h3 translate="shared.Schemas"></h3>
+            </div>
+            <div class="col-md-5">
+                <!-- Table Filter -->
+                <h3 class="col-md-3 pull-left" translate="shared.Tables"></h3>
+                <form>
+                    <div class="form-group">
+                        <div class="col-md-6">
+                            <input type="text" ng-model="vm.tableFilter" ng-init="vm.tableFilter" class="form-control">
+                        </div>
+                    </div>
+                </form>
+                <div class="col-md-1 pull-right">
+                    <button id="btn-refresh-tables" class="btn btn-xs fa fa-refresh" ng-click="vm.tableFilterRefresh()"></button>
+                </div>
+            </div>
+            <div class="col-md-2"></div>
+        </div>
+        <!--  -->
+        <!--  -->
+        <div class="row" ng-show="vm.optionsResetting==false">
+            <!-- Catalog-Schema Tree Control -->
+            <div class="tree-control-container col-md-5" ng-show="vm.supportsCatalogOrSchema">
+                <!-- Spinner when loading -->
+                <div ng-show="vm.treeLoading==true">
+                    <i class="fa fa-spinner fa-spin fa-2x fa-fw"></i>
+                </div>
+                <!-- No Content Message -->
+                <div ng-show="vm.treeLoading==false && vm.treedata.length == 0 && !vm.hasTreeFetchError">
+                    <h4 translate="jdbcFilterOptions.noContent"></h4>
+                </div>
+                <!-- Fetch Content Error Message -->
+                <div ng-show="vm.treeLoading==false && vm.hasTreeFetchError">
+                    <h4>{{vm.treeFetchErrorMsg}}</h4>
+                </div>
+                <div ng-show="vm.treeLoading==false">
+                    <!-- tree control for catalog and schema -->
+                    <div treecontrol="" class="tree-classic tree-control-results" tree-model="vm.treedata" expanded-nodes="vm.initialExpandedNodes" selected-node="vm.initialNodeSelection" on-selection="vm.setTreeSelection(node,selected)">
+                        {{node.name}}
+                    </div>
+                </div>
+            </div>
+            <!--  -->
+            <!--  -->
+            <!-- Table display area -->
+            <div class="col-md-5">
+                <!-- The table name pick list -->
+                <div class="pick-list-container">
+                    <!-- spinner while updating -->
+                    <div id="tableList-updating" ng-show="vm.tablesLoading==true" class="col-md-10 row">
+                        <i class="fa fa-spinner fa-spin fa-2x fa-fw"></i>
+                        <span class="sr-only" translate="shared.loadingProgressMsg"></span>
+                    </div>
+                    <!-- No Tables Message -->
+                   <div id="tableList-updating" ng-show="vm.tablesLoading==false && vm.tables.length == 0 && !vm.hasTableFetchError" class="col-md-10 row">
+                        <h4 translate="jdbcFilterOptions.noTables"></h4>
+                    </div>
+                    <!-- Fetch Table Error Message -->
+                    <div id="tableList-updating" ng-show="vm.tablesLoading==false && vm.hasTableFetchError" class="col-md-10 row">
+                        <h4>{{vm.tableFetchErrorMsg}}</h4>
+                    </div>
+                    <!--  Results -->
+                    <div class="pick-list-results">
+                        <div id="tableNameList-table-row" class="list-view-container" ng-show="vm.tablesLoading==false && vm.tables.length>0 && !vm.hasTableFetchError">
+                            <div pf-list-view config="vm.listConfig" items="vm.tables">
+                                <div class="list-view-pf-description">
+                                    <div class="list-group-item-heading">
+                                    {{item}}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/jdbcFilterOptions.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/jdbcFilterOptions.js
@@ -1,0 +1,411 @@
+(function () {
+    'use strict';
+
+    var pluginName = 'vdb-bench.widgets';
+    var pluginDirName = 'vdb-bench-widgets';
+
+    angular
+        .module(pluginName)
+        .directive('jdbcFilterOptions', JdbcFilterOptions);
+
+    JdbcFilterOptions.$inject = ['CONFIG', 'SYNTAX'];
+    JdbcFilterOptionsController.$inject = ['$scope', '$rootScope', '$document', '$translate', 'RepoRestService', 
+                                           'REST_URI', 'SYNTAX', 'JDBC_FILTER', 'ConnectionSelectionService'];
+
+    function JdbcFilterOptions(config, syntax) {
+        var directive = {
+            restrict: 'E',
+            scope: {},
+            controller: JdbcFilterOptionsController,
+            controllerAs: 'vm',
+            templateUrl: config.pluginDir + syntax.FORWARD_SLASH +
+                pluginDirName + syntax.FORWARD_SLASH +
+                'jdbcFilterOptions.html'
+        };
+
+        return directive;
+    }
+
+    function JdbcFilterOptionsController($scope, $rootScope, $document, $translate, RepoRestService, 
+                                         REST_URI, SYNTAX, JDBC_FILTER, ConnectionSelectionService) {
+        var vm = this;
+
+        vm.selectedConn = null;
+        vm.optionsResetting = false;
+        vm.jdbcConnectionSelected = false;
+        vm.initialNodeSelection = null;
+        vm.initialExpandedNodes = null;
+        vm.supportsCatalogOrSchema = true;
+        vm.tablesLoading = false;
+        vm.tables = [];
+        vm.allTables = [];
+        vm.hasTableFetchError = false;
+        vm.tableFetchErrorMsg = "";
+        vm.treedata = [];
+        vm.treeLoading = false;
+        vm.hasTreeFetchError = false;
+        vm.treeFetchErrorMsg = "";
+        vm.selectedTreeNode = null;
+        vm.catalogFilter = JDBC_FILTER.BLANK;
+        vm.schemaFilter = JDBC_FILTER.BLANK;
+        vm.tableFilter = JDBC_FILTER.WILD_CARD;
+
+        /*
+         * Set initial source selection
+         */
+        $document.ready(function () {
+            resetFilterOptions();
+        });
+
+        /*
+         * Request to reset the filters
+         */
+        $scope.$on('resetJdbcFilters', function (event) {
+            resetFilterOptions();
+        });
+
+        function resetFilterOptions() {
+            vm.optionsResetting = true;
+            vm.selectedConn = ConnectionSelectionService.selectedConnection();
+
+            // Initialize filters if available
+            var filterProperties = ConnectionSelectionService.selectedConnectionFilterProperties();
+            vm.catalogFilter = JDBC_FILTER.BLANK;
+            vm.schemaFilter = JDBC_FILTER.BLANK;
+            vm.tableFilter = JDBC_FILTER.WILD_CARD;
+            if(angular.isDefined(filterProperties) && filterProperties.length > 0) {
+                for(var key in filterProperties) {
+                    var propName = filterProperties[key].name;
+                    var propValue = filterProperties[key].value;
+                    if(propName==JDBC_FILTER.KEY_CATALOG) {
+                        vm.catalogFilter = propValue;
+                    } else if(propName==JDBC_FILTER.KEY_SCHEMA_PATTERN) {
+                        vm.schemaFilter = propValue;
+                    } else if(propName==JDBC_FILTER.KEY_TABLE_NAME_PATTERN) {
+                        vm.tableFilter = propValue;
+                    }
+                }
+            }
+            // Reset the filter patterns
+            updateFilterProperties(vm.catalogFilter,vm.schemaFilter,vm.tableFilter);
+
+            // Determine if the selected connection is jdbc
+            if(vm.selectedConn !== null && vm.selectedConn.dv__type === true) {
+                vm.jdbcConnectionSelected = true;
+                updateCatalogSchemaTree(vm.selectedConn);
+            } else {
+                vm.tables = [];
+                vm.allTables = [];
+                vm.treedata = [];
+                vm.jdbcConnectionSelected = false;
+                vm.optionsResetting = false;
+            }
+        }
+
+        // Builds the tree control data.  The tree control is expecting data in this form
+        //    	vm.treedata =
+        //    	[
+        //    	    { "name" : "Catalog1", "type" : "Catalog", "children" : [
+        //    	        { "name" : "Cat1Schema1", "type" : "Schema", "children" : [] },
+        //    	        { "name" : "Cat1Schema2", "type" : "Schema", "children" : [] }
+        //    	    ]},
+        //    	    { "name" : "Catalog2", "type" : "Catalog", "children" : [
+        //    	        { "name" : "Cat2Schema1", "type" : "Schema", "children" : [] },
+        //    	        { "name" : "Cat2Schema2", "type" : "Schema", "children" : [] }
+        //    	    ]},
+        //    	    { "name" : "Catalog3", "type" : "Catalog", "children" : [] }
+        //    	];
+        function updateCatalogSchemaTree(connection) {
+            vm.supportsCatalogOrSchema = true; // shows empty tree container while loading
+
+            // Update the catalog - schema tree
+            vm.tables = [];
+            vm.allTables = [];
+            vm.treeLoading = true;
+            vm.hasTreeFetchError = false;
+            try {
+                RepoRestService.getJdbcConnectionCatalogSchemaInfo( connection.keng__id ).then(
+                    function ( result ) {
+                        var hasCatalogs = false;
+                        if(result.length === 0) {
+                            vm.treedata = [];
+                            vm.supportsCatalogOrSchema = false;
+                        } else {
+                            var treeInfo = [];
+                            vm.supportsCatalogOrSchema = true;
+                            for (var r = 0; r < result.length; ++r) {
+                                var schemaKids = result[r].schemaNames;
+                                var kids = [];
+                                if(!angular.isUndefined(schemaKids) && result[r].schemaKids !== null) {
+                                    for(var i = 0; i < schemaKids.length; ++i) {
+                                        var kid = {
+                                            name : schemaKids[i],
+                                            type : JDBC_FILTER.SCHEMA,
+                                            parent : result[r].name,
+                                            children : []
+                                        };
+                                        kids.push(kid);
+                                    }
+                                }
+                                var resultItem = {
+                                    name : result[r].name,
+                                    type : result[r].type,
+                                    parent : null,
+                                    children : kids
+                                };
+                                if(result[r].type === JDBC_FILTER.CATALOG) {
+                                    hasCatalogs = true;
+                                }
+                                treeInfo.push(resultItem);
+                            }
+                            // filters available - use to set initial selections
+                            if(vm.catalogFilter!==JDBC_FILTER.BLANK || vm.schemaFilter!==JDBC_FILTER.BLANK) {
+                                determineExpandedAndSelectedNodesUsingFilters(treeInfo,vm.catalogFilter,vm.schemaFilter);
+                                updateTableListUsingSelections();
+                            } else {
+                                var userName = null;
+                                if(angular.isDefined(connection.keng__properties)) {
+                                    for(var key in connection.keng__properties) {
+                                        var propName = connection.keng__properties[key].name;
+                                        var propValue = connection.keng__properties[key].value;
+                                        if(propName==JDBC_FILTER.USER_NAME) {
+                                            userName = propValue;
+                                            break;
+                                        }
+                                    }
+                                }
+                                determineExpandedAndSelectedNodesUsingUsername(treeInfo, userName);
+                            }
+                            vm.treedata = treeInfo;
+                        }
+                        vm.optionsResetting = false;
+                        vm.treeLoading = false;
+
+                        if(vm.initialNodeSelection !== null && hasCatalogs === false) {
+                            vm.setTreeSelection(vm.initialNodeSelection, true);
+                        }
+                    },
+                    function (response) {
+                        vm.optionsResetting = false;
+                        vm.treeLoading = false;
+                        vm.treedata = [];
+                        vm.hasTreeFetchError = true;
+                        vm.treeFetchErrorMsg = RepoRestService.responseMessage(response);
+                    });
+            } catch (error) {
+                vm.optionsResetting = false;
+                vm.treeLoading = false;
+                vm.treedata = [];
+                vm.hasTreeFetchError = true;
+                vm.treeFetchErrorMsg = error.message;
+            } finally {
+            }
+        }
+
+        /**
+         * Determines the nodes to expand and the node selections in the tree
+         */
+        function determineExpandedAndSelectedNodesUsingFilters(treeInfo, catalogFilter, schemaFilter) {
+            vm.initialExpandedNodes = [];
+            vm.initialNodeSelection = null;
+            for (var r = 0; r < treeInfo.length; ++r) {
+                // Expand the catalogs
+                if(treeInfo[r].type === JDBC_FILTER.CATALOG) {
+                    if(angular.isDefined(catalogFilter) && catalogFilter !== null) {
+                        if(treeInfo[r].name.toUpperCase() === catalogFilter.toUpperCase()) {
+                            vm.initialExpandedNodes.push(treeInfo[r]);
+                            if(angular.isDefined(treeInfo[r].children) && treeInfo[r].children.length>0) {
+                                for(var c = 0; c <treeInfo[r].children.length; ++c) {
+                                    if(treeInfo[r].children[c].name.toUpperCase() === schemaFilter.toUpperCase()) {
+                                        vm.initialNodeSelection = treeInfo[r].children[c];
+                                        break;
+                                    }
+                                }
+                            } else if(treeInfo[r].name.toUpperCase() === catalogFilter.toUpperCase()){
+                                vm.initialNodeSelection = treeInfo[r];
+                            }
+                        }
+                    }
+                } else if(treeInfo[r].type === JDBC_FILTER.SCHEMA) {
+                    if(angular.isDefined(schemaFilter) && schemaFilter !== null) {
+                        if(treeInfo[r].name.toUpperCase() === schemaFilter.toUpperCase()) {
+                            vm.initialNodeSelection = treeInfo[r];
+                        }
+                    }
+                }
+            }
+        }
+
+        /**
+         * Determines the nodes to expand and the node selections in the tree
+         */
+        function determineExpandedAndSelectedNodesUsingUsername(treeInfo, userName) {
+            vm.initialExpandedNodes = [];
+            vm.initialNodeSelection = null;
+            for (var r = 0; r < treeInfo.length; ++r) {
+                // Expand the catalogs
+                if(treeInfo[r].type === JDBC_FILTER.CATALOG) {
+                    if(angular.isDefined(userName) && userName !== null) {
+                        if(treeInfo[r].name.toUpperCase() === userName.toUpperCase()) {
+                            vm.initialExpandedNodes.push(treeInfo[r]);
+                        }
+                    }
+                } else if(treeInfo[r].type === JDBC_FILTER.SCHEMA) {
+                    if(angular.isDefined(userName) && userName !== null) {
+                        if(treeInfo[r].name.toUpperCase() === userName.toUpperCase()) {
+                            vm.initialNodeSelection = treeInfo[r];
+                        }
+                    }
+                }
+            }
+        }
+        
+        /**
+         * Set the tree selection when node is selected
+         */
+        vm.setTreeSelection = function(theNode, isSelected) {
+            vm.selectedTreeNode = theNode;
+            vm.catalogFilter = JDBC_FILTER.BLANK;
+            vm.schemaFilter = JDBC_FILTER.BLANK;
+
+            // If this is a leaf node, update the tables list
+            if( angular.isDefined(vm.selectedTreeNode) && vm.selectedTreeNode!==null && vm.selectedTreeNode.children.length===0 && isSelected) {
+                // Catalog and Schema Filter based on node selection
+                if(vm.selectedTreeNode.type === JDBC_FILTER.SCHEMA) {
+                    vm.schemaFilter = vm.selectedTreeNode.name;
+                    if(vm.selectedTreeNode.parent !== null) {
+                        vm.catalogFilter = vm.selectedTreeNode.parent;
+                    }
+                } else if(vm.selectedTreeNode.type === JDBC_FILTER.CATALOG) {
+                    vm.catalogFilter = vm.selectedTreeNode.name;
+                }
+                updateFilterProperties(vm.catalogFilter, vm.schemaFilter, vm.tableFilter);
+                // Update the table list
+                updateTableListUsingSelections();
+            } else {
+                updateFilterProperties(vm.catalogFilter, vm.schemaFilter, vm.tableFilter);
+                vm.allTables = [];
+                vm.tables = [];
+            }
+        };
+
+        function updateTableListUsingSelections() {
+            // Update the table list
+            var tblFilter = JDBC_FILTER.BLANK;
+            if(vm.tableFilter === null || vm.tableFilter === JDBC_FILTER.BLANK) {
+                tblFilter = JDBC_FILTER.WILD_CARD;
+            } else {
+                tblFilter = vm.tableFilter;
+            }
+            updateTableNames(vm.catalogFilter, vm.schemaFilter, tblFilter, vm.selectedConn);
+        }
+
+        function updateTableNames(catFilter, schFilter, tblFilter, connection) {
+            vm.hasTableFetchError = false;
+            vm.tableFetchErrorMsg = "";
+            vm.tablesLoading = true;
+            if(connection === null) {
+                vm.allTables = [];
+                vm.tables = [];
+                vm.tablesLoading = false;
+                vm.hasTableFetchError = true;
+                vm.tableFetchErrorMsg = $translate.instant('jdbcFilterOptions.tableFetchNoConnectionErrorMsg');
+                return;
+            }
+
+            // Update the tables using the Repo scratch object
+            try {
+                RepoRestService.getJdbcConnectionTables( catFilter, schFilter, tblFilter, connection.keng__id ).then(
+                    function ( result ) {
+                        var tableNames = [];
+                        var i = 1;
+                        var tableKey = 'Table'+i;
+                        var tableName = result.Information[tableKey];
+                        while ( !angular.isUndefined(tableName) && tableName !== null) {
+                            tableNames.push(tableName);
+                            i++;
+                            tableKey = 'Table'+i;
+                            tableName = result.Information[tableKey];
+                        }                        
+                        vm.allTables = tableNames;
+                        vm.tables = vm.allTables;
+                        vm.tablesLoading = false;
+                    },
+                    function (response) {
+                        vm.hasTableFetchError = true;
+                        vm.tableFetchErrorMsg = RepoRestService.responseMessage(response);
+                        vm.tablesLoading = false;
+                    });
+            } catch (error) {
+                vm.tablesLoading = false;
+                vm.hasTableFetchError = true;
+                vm.tableFetchErrorMsg = error.message;
+            } finally {
+            }
+        }
+
+        function updateFilterProperties(catalog, schemaPattern, tablePattern) {
+            // Basic properties
+            ConnectionSelectionService.resetFilterProperties();
+
+            // Add catalog pattern
+            if(catalog!==null) {
+                ConnectionSelectionService.addFilterProperty(JDBC_FILTER.KEY_CATALOG, catalog);
+            }
+
+            // Add schema Pattern
+            if(schemaPattern!==null) {
+                ConnectionSelectionService.addFilterProperty(JDBC_FILTER.KEY_SCHEMA_PATTERN, schemaPattern);
+            }
+
+            // Add table Pattern
+            var tblPattern = JDBC_FILTER.BLANK;
+            if(tablePattern===null || tablePattern.length===0) {
+                tblPattern = JDBC_FILTER.WILD_CARD;
+            } else {
+                tblPattern = tablePattern;
+            }
+            ConnectionSelectionService.addFilterProperty(JDBC_FILTER.KEY_TABLE_NAME_PATTERN, tablePattern);
+        }
+
+        /**
+         * handler for refresh of filter text
+         */
+        vm.tableFilterRefresh = function() {
+            updateFilterProperties(vm.catalogFilter, vm.schemaFilter, vm.tableFilter);
+            updateTableListUsingSelections();
+        };
+
+        /**
+         * Filter checkbox selection changed.
+         */
+        vm.filterCheckboxChanged = function( ) {
+            updateCatalogSchemaTree(vm.selectedConn);
+        };
+
+        /**
+         * Access to the collection of filtered data services
+         */
+        vm.getTables = function() {
+            return vm.tables;
+        };
+
+        /**
+         * Access to the collection of filtered data services
+         */
+        vm.getAllTables = function() {
+            return vm.allTables;
+        };
+
+        /**
+         * List Configuration
+         */
+        vm.listConfig = {
+          showSelectBox: false,
+          multiSelect: true,
+          checkDisabled: false
+        };
+
+    }
+
+})();

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/vdb-bench.widgets.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/vdb-bench.widgets.js
@@ -18,6 +18,7 @@
         'ngFileSaver',
         'ui.grid',
         'pageslide-directive',
+        'treeControl',
 
         /*
          * Everybody has access to these.


### PR DESCRIPTION
Adds filtering control for jdbc connections
- jdbcFilterOptions - adds directive for JDBC connection filtering.  The user selections set the importer.catalog, schemaPattern and tableNamePattern properties for the service sources.
- RepositoryRestService - adds functions for getting the necessary jdbc info from komodo teiid.
- svcsource-edit.hmtl / svcsource-new.html pages and controllers - incorporates the jdbcFilterOptions directive into the pages.
- connectionList - add attributes so user can choose to hide jdbc or resourceAdapter connections if desired
- TranslatorSelectionService - adds array of known resourceAdapter translators and adds capability to filter them out of the translator list.  DSB initial release will only support JDBC