### PR TITLE
Page help framework

### DIFF
--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -92,10 +92,7 @@
         "createSourceMsg" : "A Data Service is created using one or more Sources. To create your first Source, click ",
         "importDataServiceMsg" : "You can also import an existing Data Service. To import a Data Service, click ",
         "serviceVdbToolTip" : "The name of the service VDB of this dataservice",
-        "welcomeMsg" : "Welcome to the <strong>Data Services Builder</strong>!",
-        "help" : {
-            "page" : "<div><h1><span class=\"fa fa-table\">Data Service Summary</h1><p>Help goes here ...</p></div>"
-        }
+        "welcomeMsg" : "Welcome to the <strong>Data Services Builder</strong>!"
     },
 
     "dataservice-test" : {
@@ -315,6 +312,10 @@
 
     "git-preferences-config" : {
         "tabTitle" : "Git Repository Configurations"
+    },
+    
+    "HelpService" : {
+    	"inlineFramesNotSupportedMsg" : "Sorry your browser doesn't support inline frames."
     },
 
     "modelTableList" : {

--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -5,6 +5,7 @@
         "BrowseMsg" : "Browse...",
         "Cancel" : "Cancel",
         "changedConnectionFailedMsg" : "Failed to get connection: \n{{errorMsg}}",
+        "Close" : "Close",
         "Connection" : "Connection",
         "Connections" : "Connections",
         "Copy" : "Copy",
@@ -91,7 +92,10 @@
         "createSourceMsg" : "A Data Service is created using one or more Sources. To create your first Source, click ",
         "importDataServiceMsg" : "You can also import an existing Data Service. To import a Data Service, click ",
         "serviceVdbToolTip" : "The name of the service VDB of this dataservice",
-        "welcomeMsg" : "Welcome to the <strong>Data Services Builder</strong>!"
+        "welcomeMsg" : "Welcome to the <strong>Data Services Builder</strong>!",
+        "help" : {
+            "page" : "<div><h1><span class=\"fa fa-table\">Data Service Summary</h1><p>Help goes here ...</p></div>"
+        }
     },
 
     "dataservice-test" : {

--- a/vdb-bench-assembly/bower.json
+++ b/vdb-bench-assembly/bower.json
@@ -31,6 +31,7 @@
     "angular": "~1.5",
     "angular-animate": "~1.5.5",
     "angular-route": "~1.5.5",
+    "angular-pageslide-directive": "~2.1.1",
     "angular-translate": "~2.13.0",
     "angular-translate-loader-static-files": "~2.13.0",
     "angularUtils-pagination": "angular-utils-pagination#~0.9.2",

--- a/vdb-bench-assembly/index.html
+++ b/vdb-bench-assembly/index.html
@@ -96,6 +96,7 @@
     <script src="libs/angular-translate/angular-translate.js"></script>
     <script src="libs/angular-translate-loader-static-files/angular-translate-loader-static-files.js"></script>
     <script src="libs/abdmob/x2js/xml2json.min.js"></script>
+    <script src="libs/angular-pageslide-directive/dist/angular-pageslide-directive.min.js"></script>
 
     <!-- dependencies for angular-dashboard-framework -->
     <script src="libs/Sortable/Sortable.js"></script>
@@ -144,6 +145,7 @@
     <script src="plugins/vdb-bench-widgets/sqlControl.js"></script>
     <script src="plugins/vdb-bench-widgets/fileInputHandler.js"></script>
     <script src="plugins/vdb-bench-widgets/gitCredentialsControl.js"></script>
+    <script src="plugins/vdb-bench-widgets/pageHelpControl.js"></script>
     <!-- endinject -->
 
     <!-- vdb-bench-wksp-mgmt -->

--- a/vdb-bench-assembly/plugins/vdb-bench-core/HelpService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/HelpService.js
@@ -14,9 +14,9 @@
         .module(pluginName)
         .factory('HelpService', HelpService);
 
-    HelpService.$inject = ['SYNTAX'];
+    HelpService.$inject = ['$translate', 'SYNTAX'];
 
-    function HelpService(SYNTAX) {
+    function HelpService($translate, SYNTAX) {
         /*
          * Service instance to be returned
          */
@@ -35,6 +35,13 @@
                 return SYNTAX.EMPTY_STRING;
 
             return service[context];
+        };
+
+        /*
+         * Obtain the <div> for the help page for the specified translation identifier.
+         */
+        service.pageHelpFor = function( translationId ) {
+            return $translate.instant( translationId );
         };
 
         return service;

--- a/vdb-bench-assembly/plugins/vdb-bench-core/HelpService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/HelpService.js
@@ -14,13 +14,14 @@
         .module(pluginName)
         .factory('HelpService', HelpService);
 
-    HelpService.$inject = ['$translate', 'SYNTAX'];
+    HelpService.$inject = ['SYNTAX'];
 
-    function HelpService($translate, SYNTAX) {
+    function HelpService(SYNTAX) {
         /*
          * Service instance to be returned
          */
         var service = {
+            'dataservice-summary': "https://www.redhat.com",
             'ds-test-endpoint-search': "'<p>This url is formed using the odata specification. It can be copied into a new browser window to return the results in xml format.</p><p>Click the Search button to display the results in a formatted table.</p>'",
             'ds-test-select': "'<p>Choose the view from which results should be sought.</p><p>Select a limit to curtail the number of results returned</p>'",
             'ds-test-columns': "Select the columns to be included in the results.",
@@ -38,10 +39,10 @@
         };
 
         /*
-         * Obtain the <div> for the help page for the specified translation identifier.
+         * Obtain the help page for the specified page identifier.
          */
-        service.pageHelpFor = function( translationId ) {
-            return $translate.instant( translationId );
+        service.getHelpPageUrl = function( pageId ) {
+        	return service[ pageId ];
         };
 
         return service;

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-summary.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-summary.html
@@ -48,7 +48,7 @@
                 <h1>
                     <span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span>
                     {{vmmain.selectedPage.title}}
-                    <page-help-control help-id="dataservice-summary.help.page" />
+                    <page-help-control help-id="dataservice-summary" />
                 </h1>
             </div>
         </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-summary.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-summary.html
@@ -43,8 +43,14 @@
     </div>
 
     <div id="ds-summary-table" class="col-md-10 row">
-        <div class="row col-md-10" ng-show="vm.dsLoading==true || vm.sourcesLoading==true || vm.hasServices==true">
-            <h2><span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPage.title}}</span></h2>
+        <div class="row col-md-12" ng-show="vm.dsLoading==true || vm.sourcesLoading==true || vm.hasServices==true">
+            <div class="page-header">
+                <h1>
+                    <span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span>
+                    {{vmmain.selectedPage.title}}
+                    <page-help-control help-id="dataservice-summary.help.page" />
+                </h1>
+            </div>
         </div>
         <div pf-toolbar id="dataserviceToolbar" config="vm.toolbarConfig" ng-show="vm.dsLoading==true || vm.sourcesLoading==true || vm.hasServices==true"></div>
 

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/content/css/styles.less
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/content/css/styles.less
@@ -292,3 +292,49 @@ svg {
     margin: 10px;
     padding: 0;
 }
+
+/*
+ * Classes page help component
+ */
+.ng-pageslide {
+    background: #eee;
+}
+
+body.ng-pageslide-body-open::before {
+    content: '.';
+    display: block;
+    position: absolute;
+    top: 0;
+    background-color: rgb(0,0,0);
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 1;
+    opacity: 0.5;
+    transition: opacity 1s;
+    opacity: 0.5;
+    pointer-events: all;
+}
+
+body.ng-pageslide-body-closed::before {
+    transition: opacity 1s;
+    content: '.';
+    display: block;
+    position: absolute;
+    top: 0;
+    background-color: rgb(0,0,0);
+    left: 0;
+    right: 0;
+    bottom: 0;
+    z-index: 1;
+    opacity: 0;
+    pointer-events: none;
+}
+
+.page-help-icon {
+    float: right;
+    font-size: 22px;
+    text-decoration: none !important;
+    vertical-align: bottom;
+}
+

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/pageHelpControl.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/pageHelpControl.html
@@ -1,0 +1,8 @@
+<a class="page-help-icon pficon-help" href="" ng-click="vm.togglePageHelp()">
+    <div pageslide ps-open="vm.showPageHelp" ps-size="25%" ps-key-listener="true">
+        <div style="padding:20px">
+            <div id="page-help-content" ng-bind-html="vm.getPageHelp()" />
+            <button class="btn" ng-click="vm.togglePageHelp()" translate="shared.Close" />
+        </div>
+    </div>
+</a>

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/pageHelpControl.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/pageHelpControl.html
@@ -1,7 +1,9 @@
 <a class="page-help-icon pficon-help" href="" ng-click="vm.togglePageHelp()">
-    <div pageslide ps-open="vm.showPageHelp" ps-size="25%" ps-key-listener="true">
+    <div pageslide ps-open="vm.showPageHelp" height="80vh" ps-size="40%" ps-key-listener="true">
         <div style="padding:20px">
-            <div id="page-help-content" ng-bind-html="vm.getPageHelp()" />
+            <iframe width="100%" height="600" ng-src="{{vm.getHelpPageUrl()}}">
+            	{{ 'HelpService.inlineFramesNotSupportedMsg' | translate }}
+            </iframe>
             <button class="btn" ng-click="vm.togglePageHelp()" translate="shared.Close" />
         </div>
     </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/pageHelpControl.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/pageHelpControl.js
@@ -25,9 +25,9 @@
         return directive;
     }
 
-    PageHelpController.$inject = [ 'HelpService' ];
+    PageHelpController.$inject = [ '$sce', 'HelpService' ];
 
-    function PageHelpController( helpService ) {
+    function PageHelpController( $sce, helpService ) {
         var vm = this;
 
         // flag to show/hide page help
@@ -37,8 +37,8 @@
         	vm.showPageHelp = !vm.showPageHelp;
         };
         
-        vm.getPageHelp = function() {
-            return helpService.pageHelpFor( vm.helpId );
+        vm.getHelpPageUrl = function() {
+            return  $sce.trustAsResourceUrl( helpService.getHelpPageUrl( vm.helpId ) );
         };
     }
 })();

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/pageHelpControl.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/pageHelpControl.js
@@ -1,0 +1,44 @@
+(function () {
+    'use strict';
+
+    var pluginName = 'vdb-bench.widgets';
+    var pluginDirName = 'vdb-bench-widgets';
+
+    angular.module( pluginName )
+           .directive( 'pageHelpControl', PageHelpControl );
+
+    PageHelpControl.$inject = [ 'CONFIG', 'SYNTAX' ];
+
+    function PageHelpControl( config, syntax ) {
+        var directive = {
+            restrict: 'E', // used as element only
+            replace: true, // replaces the <page-help-control> tag with the template
+            scope: {},
+            bindToController: {
+                helpId: '@'
+            },
+            controller: PageHelpController,
+            controllerAs: 'vm',
+            templateUrl: config.pluginDir + syntax.FORWARD_SLASH + pluginDirName + syntax.FORWARD_SLASH + 'pageHelpControl.html',
+        };
+
+        return directive;
+    }
+
+    PageHelpController.$inject = [ 'HelpService' ];
+
+    function PageHelpController( helpService ) {
+        var vm = this;
+
+        // flag to show/hide page help
+        vm.showPageHelp = false;
+
+        vm.togglePageHelp = function() {
+        	vm.showPageHelp = !vm.showPageHelp;
+        };
+        
+        vm.getPageHelp = function() {
+            return helpService.pageHelpFor( vm.helpId );
+        };
+    }
+})();

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/vdb-bench.widgets.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/vdb-bench.widgets.js
@@ -17,6 +17,7 @@
         'prettyXml',
         'ngFileSaver',
         'ui.grid',
+        'pageslide-directive',
 
         /*
          * Everybody has access to these.


### PR DESCRIPTION
- Created widget that includes an icon that when clicked displays the page help.
- pageslide directive is used to display contents of a specified URL.
- the data service summary page, with data services, is the only page that currently has the page help widget installed in it. When its page help icon is clicked, it currently shows redhat.com.
- when displaying the data service summary page, the outline of the help page is seen before the page loads. Not sure why this is happening.
- see commit messages for a bit more detail
