### PR TITLE
Fix for file import control button

### DIFF
--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/fileImportControl.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/fileImportControl.html
@@ -8,7 +8,8 @@
     <div ng-show="! vm.inProgress">
         <div class="import-control-title" translate="fileImportControl.selectFileMsg" />
         <div class="import-control-button">
-            <label class="btn btn-primary" translate="shared.BrowseMsg">
+            <label class="btn btn-primary">
+                <span translate="shared.BrowseMsg"></span>
                 <input ng-model="fileToImport" type="file" style="display: none;" file-input-handler="vm.importFile">
             </label>
             <button class="btn" ng-click="vm.cancel()" ng-show="vm.displayCancel()" translate="shared.Cancel"></button>


### PR DESCRIPTION
Seems that translate directive does not transclude the contents of the element but replaces it with its translated content. This is a problemfor elements that already contain child-elements.

Looks like the translation is still correctly produced but using the <span>, the <input> child-element is preserved. I don't know whether this is the only example of this.