### PR TITLE
Changes the position of the help icon

### DIFF
--- a/vdb-bench-assembly/app/vdb-bench-app.js
+++ b/vdb-bench-assembly/app/vdb-bench-app.js
@@ -33,7 +33,6 @@ var App;
                     .then(function (response) {
                         return response.data;
                     }, function (response) {
-                        console.log(response);
                         return response;
                     });
         };

--- a/vdb-bench-assembly/gulpfile.js
+++ b/vdb-bench-assembly/gulpfile.js
@@ -159,7 +159,10 @@ gulp.task('connect', ['watch'], function () {
         staticAssets: [{
             path: '/ds-builder',
             dir: '.'
-    }],
+        }, {
+            path: '/ds-builder-help',
+            dir: '../vdb-bench-doc/target' // For this to resolve the vdb-bench-doc project should be compiled first
+        }],
         liveReload: {
             enabled: false
         }

--- a/vdb-bench-assembly/plugins/vdb-bench-core/HelpService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/HelpService.js
@@ -14,12 +14,11 @@
         .module(pluginName)
         .factory('HelpService', HelpService);
 
-    HelpService.$inject = ['SYNTAX'];
+    HelpService.$inject = ['SYNTAX', 'CONFIG', 'RepoSelectionService', '$location'];
 
-    function HelpService(SYNTAX) {
-        var HELP_PAGE_DIR = "../../ds-builder-help/";
-        var PAGE_NOT_FOUND = "page-not-found";
-    	
+    function HelpService(SYNTAX, CONFIG, RepoSelectionService, $location) {
+        var PAGE_NOT_FOUND = "PAGE_NOT_FOUND";
+
         /*
          * Service instance to be returned
          */
@@ -44,6 +43,32 @@
         	'svcsource-new': "svcsource-new-help.html",
         };
 
+        service.defaultHostUrl = function() {
+            var protocol = $location.protocol();
+            var host = $location.host();
+            var port = $location.port();
+            var baseUrl = CONFIG.help.baseUrl;
+
+             return protocol +
+                SYNTAX.COLON + SYNTAX.FORWARD_SLASH + SYNTAX.FORWARD_SLASH +
+                host + SYNTAX.COLON + port + baseUrl;
+        };
+
+        function init() {
+            service.setHostUrl(service.defaultHostUrl());
+        }
+
+        /**
+         * Allow the base url of the host hosting the help files
+         * to be changed if required.
+         */
+        service.setHostUrl = function(url) {
+            if (! url.endsWith(SYNTAX.FORWARD_SLASH))
+                url = url + SYNTAX.FORWARD_SLASH;
+
+            service.hostUrl = url;
+        };
+
         /*
          * Obtain the help page for the specified page identifier.
          */
@@ -57,9 +82,11 @@
             if ( _.isEmpty( htmlFileName ) ) {
                 return service.getHelpPageUrl( PAGE_NOT_FOUND );
             }
-            
-            return ( HELP_PAGE_DIR + htmlFileName );
+
+            return ( service.hostUrl + htmlFileName );
         };
+
+        init();
 
         return service;
     }

--- a/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
@@ -13,10 +13,11 @@
 
     RepoRestService.$inject = ['CONFIG', 'SYNTAX', 'REST_URI', 'VDB_SCHEMA',
                                              'VDB_KEYS', 'RepoSelectionService', 'Restangular',
-                                             '$http', '$q', '$base64', 'CredentialService', '$interval'];
+                                             '$http', '$q', '$base64', 'CredentialService', '$interval',
+                                             '$location'];
 
     function RepoRestService(CONFIG, SYNTAX, REST_URI, VDB_SCHEMA, VDB_KEYS, RepoSelectionService,
-                                            Restangular, $http, $q, $base64, CredentialService, $interval) {
+                                            Restangular, $http, $q, $base64, CredentialService, $interval, $location) {
 
         /*
          * Service instance to be returned
@@ -27,7 +28,7 @@
         service.cachedServices = {};
 
         function url(repo) {
-            return CONFIG.restScheme +
+            return CONFIG.rest.protocol +
                         SYNTAX.COLON + SYNTAX.FORWARD_SLASH + SYNTAX.FORWARD_SLASH +
                         repo.host + SYNTAX.COLON + repo.port + repo.baseUrl;
         }

--- a/vdb-bench-assembly/plugins/vdb-bench-core/RepositorySelectionService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/RepositorySelectionService.js
@@ -12,15 +12,15 @@
         .module('vdb-bench.core')
         .factory('RepoSelectionService', RepoSelectionService);
 
-    RepoSelectionService.$inject = ['CONFIG', '$rootScope', 'StorageService'];
+    RepoSelectionService.$inject = ['CONFIG', '$rootScope', 'StorageService', '$location'];
 
-    function RepoSelectionService(config, $rootScope, StorageService) {
+    function RepoSelectionService(config, $rootScope, StorageService, $location) {
 
         var defaultWorkspace = {
             name: 'default',
-            host: 'localhost',
-            port: config.restPort,
-            baseUrl: config.baseRestUrl
+            host: $location.host(),
+            port: config.rest.port,
+            baseUrl: config.rest.baseUrl
         };
 
         var repos;
@@ -164,9 +164,9 @@
                 if (!exists)
                     newRepo = {
                         name: testName,
-                        host: 'localhost',
-                        port: 8080,
-                        baseUrl: config.baseUrl
+                        host: defaultWorkspace.host,
+                        port: defaultWorkspace.port,
+                        baseUrl: defaultWorkspace.baseUrl
                     };
                 else
                     index++;

--- a/vdb-bench-assembly/plugins/vdb-bench-core/constants.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/constants.js
@@ -6,15 +6,17 @@
 
         // Global configuration properties
         .constant('CONFIG', {
-            appTitle: 'Vdb-Bench',
-            version: '0.0.1',
-            restScheme: 'https', // The protocol used to serve the REST API
-            restPort: 8443, // The port used to serve the REST API
-            baseRestUrl: '/vdb-builder/v1',
-            baseUrl: '/vdb-bench',
             pluginDir: 'plugins',
             contentDir: 'content',
-            imagesDir: 'img'
+            imagesDir: 'img',
+            rest: {
+                protocol: 'https',
+                port: 8443,
+                baseUrl: '/vdb-builder/v1'
+            },
+            help: {
+                baseUrl: '/ds-builder-help'
+            }
         })
 
         .constant('SYNTAX', {

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/content/css/styles.less
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/content/css/styles.less
@@ -24,6 +24,11 @@
     margin-right: 0;
 }
 
+#dataservice-home-container {
+    padding-right: 1em;
+    padding-top: 2em;
+}
+
 .ds-navbar-container {
     float: left;
     width: 6%;
@@ -165,7 +170,6 @@
 .dsb-breadcrumbs {
     background: white;
     border-bottom: 1px solid #ccc;
-    margin-bottom: 10px;
 }
 
 .dsb-breadcrumbs .breadcrumb {
@@ -202,15 +206,26 @@
     width: 100%;
 }
 
+.ds-page-content {
+    margin-top: 0;
+}
+
+.ds-page-title {
+    margin-left: 1em;
+    margin-right: 1em;
+    margin-top: 1em;
+    margin-bottom: 0.5em;
+}
+
 .ds-summary-results {
-    margin-top: 10px;
+    margin-top: 0.5em;
 }
 
 .ds-summary-results .list-group-item,
 .svcsource-summary-results .list-group-item,
 .ds-summary-results .list-group-item:first-child,
 .svcsource-summary-results .list-group-item:first-child {
-    margin-bottom: 5px;
+    margin-bottom: 0.25em;
     border-top: 1px solid #39a5dc;
 }
 
@@ -227,18 +242,18 @@
 
 .ds-summary-results .list-view-pf-main-info,
 .svcsource-summary-results .list-view-pf-main-info {
-    padding-top: 10px;
-    padding-bottom: 10px;
+    padding-top: 0.5em;
+    padding-bottom: 0.5em;
 }
 
 .ds-summary-results .list-view-pf-actions,
 .svcsource-summary-results .list-view-pf-actions {
-    margin-top: 10px;
-    margin-bottom: 10px;
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
 }
 
 .svcsource-summary-results-container {
-    margin-top: 10px;
+    margin-top: 0.5em;
     display: flex;
     width: 100%;
 }
@@ -255,7 +270,7 @@
     flex-direction: column;
     min-width: 28%;
     max-width: 28%;
-    padding-right: 20px;
+    padding-right: 1em;
 }
 
 .svcsource-summary-results-ddl-titlebar {
@@ -291,7 +306,7 @@
 //
 #ds-test-header h1 {
     float: left;
-    margin-top: 5px;
+    margin-top: 0.25em;
 }
 
 #ds-test-header button {
@@ -339,8 +354,8 @@
     bottom: 0;
     left: 0;
     margin: 0;
-    padding: 20px 0 0;
-    height: 30px;
+    padding: 1em 0 0;
+    height: 1.5em;
     list-style: none;
     padding-bottom: 3em;
 }
@@ -441,9 +456,9 @@
 }
 
 .odata-exp-where-group-row {
-    padding-top: 5px;
-    padding-left: 5px !important;
-    padding-right: 5px !important;
+    padding-top: 0.25em;
+    padding-left: 0.25em !important;
+    padding-right: 0.25em !important;
 }
 
 .odata-exp-where-group .ui-select-toggle,
@@ -464,8 +479,8 @@
 
 .odata-exp-column-group,
 .odata-exp-order-by-group {
-    margin-left: 20px;
-    margin-right: 20px;
+    margin-left: 1em;
+    margin-right: 1em;
 }
 
 .odata-exp-order-by-group-row {

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-clone.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-clone.html
@@ -1,12 +1,5 @@
 <div id="outer" class="outer-wrapper">
 	<div id="dataservice-clone-container" class="container-fluid" ng-controller="DSCloneController as vm">
-	    <div class="row">
-	        <page-help-control 
-	            icon="{{vmmain.selectedPage.icon}}" 
-	            title="{{vmmain.selectedPage.title}} '{{vmmain.selectedDataservice().keng__id}}'" 
-	            help-id="dataservice-clone"
-	            container-id="outer" />
-	    </div>
 	    <h2 translate="dataservice-clone.instructionsMsg"></h2>
 	    <form class="row form-horizontal">
 	        <div class="form-group">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-edit.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-edit.html
@@ -2,13 +2,6 @@
 	<div id="dataservice-edit-container" class="container-fluid" ng-controller="DSEditController as vm">
 	
 	    <div id="dsEdit-edit-controls" ng-show="vm.svcSourcesLoading==false" class="row">
-	        <div class="row col-md-12">
-	            <page-help-control 
-	                icon="{{vmmain.selectedPage.icon}}" 
-	                title="{{vmmain.selectedPage.title}} '{{vmmain.selectedDataservice().keng__id}}'" 
-	                help-id="dataservice-edit"
-	                container-id="outer" />
-	        </div>
 	        <h3 translate="dataservice-edit.instructionsMsg"></h3>
 	        <form name="dsForm" class="form-horizontal">
 	            <div class="col-md-6">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-export.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-export.html
@@ -1,14 +1,6 @@
 <div id="outer" class="outer-wrapper">
 	<div div="dataservice-export-container" class="container-fluid" ng-controller="DSImportExportController as vm">
 	    <div class="row">
-	        <page-help-control 
-	            icon="pficon-import"
-	            title="{{:: 'dataservice-export.wizardTitle' | translate}}" 
-	            help-id="dataservice-export" 
-	            container-id="outer"/>
-	    </div>
-	
-	    <div class="row">
 	        <div class="wizard-pf-container">
 	            <div pf-wizard title=""
 	                    on-finish="vmmain.selectPage('dataservice-summary',null)"

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-home.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-home.html
@@ -1,12 +1,5 @@
 <div id="dataservice-home-container" >
 	<div ng-controller="DSHomeController as vm">
-	    <div class="row">
-	        <page-help-control 
-	            icon="" 
-	            title="" 
-	            help-id="dataservice-home"
-	            container-id="dataservice-home-container" />
-	    </div>
 	    <adf-dashboard name="dv-home-dashboard"
 	                            collapsible="true"
 	                            structure="6-6"

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-import.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-import.html
@@ -1,14 +1,6 @@
 <div id="outer" class="outer-wrapper">
 	<div id="dataservice-import-container" class="container-fluid" ng-controller="DSImportExportController as vm">
 	    <div class="row">
-	        <page-help-control 
-	            icon="pficon-import"
-	            title="{{:: 'dataservice-import.wizardTitle' | translate}}" 
-	            help-id="dataservice-import"
-	            container-id="outer"/>
-	    </div>
-	
-	    <div class="row">
 	        <div class="wizard-pf-container">
 	            <div pf-wizard title=""
 	                    on-finish="vmmain.selectPage('dataservice-summary',null)"

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-main.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-main.html
@@ -17,6 +17,20 @@
         </div>
 
         <!-- page content -->
-        <ng-include src="vmmain.selectedPage.template"></ng-include>
+        <div id="dataservice-page-content-outer">
+            <div>
+                <page-help-control
+	                help-id="{{vmmain.selectedPageHelpId()}}"
+	                container-id="dataservice-page-content-outer" />
+            </div>
+
+            <div id="dataservice-page-content-inner" class="ds-page-content">
+                <h2 class="ds-page-title" ng-show="vmmain.selectedPage.showTitle!==false">
+                    <span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPageTitle()}}</span>
+                </h2>
+
+                <ng-include src="vmmain.selectedPage.template"></ng-include>
+            </div>
+        </div>
     </div>
 </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-new.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-new.html
@@ -4,13 +4,6 @@
 	    <!-- Content shown if No Sources yet -->
 	    <div id="dataservice-new-nosources" ng-show="vm.hasSources==false" class="col-md-10 row">
 	        <div class="row">
-	            <div class="row col-md-12">
-	                <page-help-control 
-	                    icon="{{vmmain.selectedPage.icon}}" 
-	                    title="{{vmmain.selectedPage.title}}" 
-	                    help-id="dataservice-new"
-	                    container-id="outer" />
-	            </div>
 	            <div>
 	                <span translate="dataservice-new.configureSourceMsg" />
 	                    <a href ng-click="vmmain.selectPage('svcsource-new')">
@@ -22,13 +15,6 @@
 	    </div>
 	    
 	    <div id="dataservice-new-controls" ng-show="vm.hasSources==true" class="row">
-	        <div class="row">
-	            <page-help-control 
-	                icon="{{vmmain.selectedPage.icon}}" 
-	                title="{{vmmain.selectedPage.title}}" 
-	                help-id="dataservice-new"
-	                container-id="outer" />
-	        </div>
 	        <h4>
 	            <span translate="dataservice-new.instructionsMsg" />
 	                <a href ng-click="vmmain.selectPage('svcsource-new')">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-summary.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-summary.html
@@ -5,13 +5,6 @@
 	    <div id="dataservice-summary-nosources" ng-show="vm.dsLoading==false && vm.sourcesLoading==false && vm.hasSources==false && vm.hasServices==false" class="col-md-12 row">
 	        <div class="row">
 	            <h2 ng-bind-html=":: 'dataservice-summary.welcomeMsg' | translate"></h2>
-	            <div>
-	                <page-help-control
-	                    icon="{{vmmain.selectedPage.icon}}" 
-	                    title="{{vmmain.selectedPage.title}}" 
-	                    help-id="dataservice-summary-empty"
-	                    container-id="outer" />
-	            </div>
 	            <p>
 	                <span translate="dataservice-summary.createSourceMsg" />
 	                <a href ng-click="vmmain.selectPage('svcsource-new')">
@@ -32,13 +25,6 @@
 	    <div id="dataservice-summary-noservices" ng-show="vm.dsLoading==false && vm.sourcesLoading==false && vm.hasSources==true && vm.hasServices==false" class="col-md-12 row">
 	        <div class="row">
 	            <h2 ng-bind-html=":: 'dataservice-summary.welcomeMsg' | translate"></h2>
-	            <div>
-	                <page-help-control
-	                    icon="{{vmmain.selectedPage.icon}}" 
-	                    title="{{vmmain.selectedPage.title}}" 
-	                    help-id="dataservice-summary-no-service"
-	                    container-id="outer" />
-	            </div>
 	            <p>
 	                <span translate="dataservice-summary.createDataServiceMsg" />
 	                <a href ng-click="vmmain.selectPage('dataservice-new')">
@@ -56,13 +42,6 @@
 	    </div>
 	
 	    <div id="ds-summary-table" class="col-md-10 row">
-	        <div class="row col-md-12" ng-show="vm.dsLoading==true || vm.sourcesLoading==true || vm.hasServices==true">
-	            <page-help-control
-	                icon="{{vmmain.selectedPage.icon}}" 
-	                title="{{vmmain.selectedPage.title}}" 
-	                help-id="dataservice-summary"
-	                container-id="outer" />
-	        </div>
 	        <div pf-toolbar id="dataserviceToolbar" config="vm.toolbarConfig" ng-show="vm.dsLoading==true || vm.sourcesLoading==true || vm.hasServices==true"></div>
 	
 	        <div id="dataservice-summary-updating" ng-show="vm.dsLoading==true || vm.sourcesLoading==true" class="col-md-10 row">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-test.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-test.html
@@ -10,14 +10,6 @@
 	        <span class="sr-only"></span>{{:: 'shared.loadingProgressMsg' | translate}}
 	    </div>
 	
-	    <div ng-show="vm.dsDeploymentInProgress==false" class="col-md-12 row">
-	        <page-help-control 
-	            icon="{{vmmain.selectedPage.icon}}" 
-	            title="{{vmmain.selectedPage.title}} '{{vmmain.selectedDataservice().keng__id}}'" 
-	            help-id="dataservice-test"
-	            container-id="dataservice-test-container" />
-	    </div>
-	
 	    <div ng-show="vm.dsDeploymentInProgress==false && vm.dsDeploymentSuccess==false" class="row">
 	        <div class="col-sm-12">
 	            <h3 translate="dataservice-test.failedDeploymentMsg"></h3>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservicePageController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservicePageController.js
@@ -92,6 +92,9 @@
                 ConnectionSelectionService.resetFilterProperties();
             }
             vm.selectedPage = DSPageService.page(pageId);
+            DSPageService.setCustomTitle(pageId, null);
+            DSPageService.setCustomHelpId(pageId, null);
+
             setNavActiveState(vm.selectedPage);
         };
 
@@ -131,7 +134,20 @@
             if (_.isEmpty(vm.selectedPage))
                 return '';
 
+            if (vm.selectedPage.customTitle)
+                return vm.selectedPage.customTitle;
+
             return vm.selectedPage.title;
+        };
+
+        vm.selectedPageHelpId = function() {
+            if (_.isEmpty(vm.selectedPage))
+                return '';
+
+            if (vm.selectedPage.customHelpId)
+                return vm.selectedPage.customHelpId;
+
+            return vm.selectedPage.helpId;
         };
 
         /*

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasource-summary.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasource-summary.html
@@ -5,13 +5,6 @@
 	    <div id="svcsource-summary-nosources" ng-show="vm.srcLoading==false && vm.hasSources==false" class="col-md-12 row">
 	        <div class="row">
 	            <h2 ng-bind-html=":: 'datasource-summary.welcomeMsg' | translate"></h2>
-	            <div class="row col-md-12">
-	                <page-help-control 
-	                    icon="{{vmmain.selectedPage.icon}}" 
-	                    title="{{vmmain.selectedPage.title}}" 
-	                    help-id="datasource-summary"
-	                    container-id="outer" />
-	            </div>
 	            <p>
 	                <span translate="datasource-summary.noSourcesInstructionsMsg" />
 	                <a href ng-click="vmmain.selectPage('svcsource-new')">
@@ -21,14 +14,7 @@
 	            </p>
 	        </div> 
 	    </div>
-	
-	    <div class="col-md-12 row" ng-show="vm.srcLoading==true || vm.hasSources==true">
-	        <page-help-control 
-	            icon="{{vmmain.selectedPage.icon}}" 
-	            title="{{vmmain.selectedPage.title}}" 
-	            help-id="datasource-summary"
-	            container-id="outer" />
-	    </div>
+
 	    <div id="svcsource-summary-table" class="col-md-12 row">
 	        <div pf-toolbar id="svcsourceToolbar" config="vm.toolbarConfig" ng-show="vm.srcLoading==true || vm.hasSources==true"></div>
 	

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceCloneController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceCloneController.js
@@ -8,11 +8,17 @@
         .module(pluginName)
         .controller('SvcSourceCloneController', SvcSourceCloneController);
 
-    SvcSourceCloneController.$inject = ['$scope', '$rootScope', '$translate', 'RepoRestService', 'SvcSourceSelectionService'];
+    SvcSourceCloneController.$inject = ['$scope', '$rootScope', '$translate', 'RepoRestService', 'SvcSourceSelectionService', 'DSPageService'];
 
-    function SvcSourceCloneController($scope, $rootScope, $translate, RepoRestService, SvcSourceSelectionService) {
+    function SvcSourceCloneController($scope, $rootScope, $translate, RepoRestService, SvcSourceSelectionService, DSPageService) {
         var vm = this;
         vm.cloneVdbInProgress = false;
+
+        /*
+         * Set a custom title to the page including the service source's id
+         */
+        var page = DSPageService.page(DSPageService.CLONE_DATASERVICE_PAGE);
+        DSPageService.setCustomTitle(page.id, page.title + " '" + SvcSourceSelectionService.selectedServiceSource().keng__id + "'");
 
         /*
          * When loading finishes on copy / deploy

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-clone.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-clone.html
@@ -6,13 +6,6 @@
 	    </div>
 	    
 	    <div id="svcsource-clone-controls" ng-show="vm.cloneVdbInProgress==false" class="col-md-12 row">
-	          <div class="row col-md-12">
-	            <page-help-control 
-	              icon="{{vmmain.selectedPage.icon}}" 
-	              title="{{vmmain.selectedPage.title}} '{{vmmain.selectedServiceSource().keng__id}}'" 
-	              help-id="svcsource-clone"
-	              container-id="outer" />
-	          </div>
 	      <div class="row">
 	          <h3>&nbsp;&nbsp;{{:: 'svcsource-clone.instructionsMsg' | translate}}</h3>
 	          <form class="form-horizontal">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-edit.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-edit.html
@@ -6,13 +6,6 @@
 	    </div>
 	    
 	    <div id="svcsource-edit-controls" ng-show="vm.transLoading==false && vm.updateAndDeployInProgress==false" class="row">
-	          <div class="row col-md-12">
-	            <page-help-control 
-	              icon="{{vmmain.selectedPage.icon}}" 
-	              title="{{vmmain.selectedPage.title}}" 
-	              help-id="svcsource-edit"
-	              container-id="outer" />
-	          </div>
 	            <h4 translate="svcsource-edit.instructionsMsg"></h4>
 	            <div class="col-md-8">
 	                <h4><strong translate="svcsource-edit.Connections"></strong></h4>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-import.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-import.html
@@ -1,11 +1,5 @@
 <div id="outer" class="outer-wrapper">
 	<div id="svcsource-import-container" class="container-fluid" ng-controller="SvcSourceImportController as vm">
-	    <div class="row col-md-12">
-	        <page-help-control icon="{{vmmain.selectedPage.icon}}" 
-	                           title="{{vmmain.selectedPage.title}}" 
-	                           help-id="svcsource-import"
-	                           container-id="outer" />
-	    </div>
 	    <h3>&nbsp;&nbsp;{{:: 'svcsource-import.instructionsMsg' | translate}}</h3>
 	    <!-- Show the import dialog when importing -->
 	    <div ng-init="vm.onImportSvcSourceClicked()" ng-show="!vm.init && vm.showImport">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-new.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-new.html
@@ -6,13 +6,6 @@
 	    </div>
 	    
 	    <div id="svcsource-new-controls" ng-show="vm.createAndDeployInProgress==false" class="row">
-	      <div class="row col-md-12">
-	        <page-help-control 
-	          icon="{{vmmain.selectedPage.icon}}" 
-	          title="{{vmmain.selectedPage.title}}" 
-	          help-id="svcsource-new"
-	          container-id="outer" />
-	      </div>
 	      <h4 translate="svcsource-new.instructionsMsg"></h4>
 	      <div class="col-md-8">
 	          <h4><strong translate="svcsource-new.Connections"></strong></h4>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsCloneController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsCloneController.js
@@ -8,10 +8,16 @@
         .module(pluginName)
         .controller('DSCloneController', DSCloneController);
 
-    DSCloneController.$inject = ['$rootScope', '$translate', 'RepoRestService', 'DSSelectionService'];
+    DSCloneController.$inject = ['$rootScope', '$translate', 'RepoRestService', 'DSSelectionService', 'DSPageService'];
 
-    function DSCloneController($rootScope, $translate, RepoRestService, DSSelectionService) {
+    function DSCloneController($rootScope, $translate, RepoRestService, DSSelectionService, DSPageService) {
         var vm = this;
+
+        /*
+         * Set a custom title to the page including the data service's id
+         */
+        var page = DSPageService.page(DSPageService.CLONE_DATASERVICE_PAGE);
+        DSPageService.setCustomTitle(page.id, page.title + " '" + DSSelectionService.selectedDataService().keng__id + "'");
 
         /**
          * Event handler for clicking the clone button

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsEditController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsEditController.js
@@ -9,12 +9,18 @@
         .controller('DSEditController', DSEditController);
 
     DSEditController.$inject = ['$scope', '$rootScope', '$document', '$translate', 'REST_URI', 'SYNTAX', 'RepoRestService', 'DSSelectionService', 
-                                'SvcSourceSelectionService', 'TableSelectionService'];
+                                'SvcSourceSelectionService', 'TableSelectionService', 'DSPageService'];
 
     function DSEditController($scope, $rootScope, $document, $translate, REST_URI, SYNTAX, RepoRestService, DSSelectionService, 
-                               SvcSourceSelectionService, TableSelectionService) {
+                               SvcSourceSelectionService, TableSelectionService, DSPageService) {
         var vm = this;
         
+        /*
+         * Set a custom title to the page including the data service's id
+         */
+        var page = DSPageService.page(DSPageService.EDIT_DATASERVICE_PAGE);
+        DSPageService.setCustomTitle(page.id, page.title + " '" + DSSelectionService.selectedDataService().keng__id + "'");
+
         vm.svcSourcesLoading = SvcSourceSelectionService.isLoading();
         vm.svcSources = SvcSourceSelectionService.getServiceSources();
         vm.initialSourceName = null;

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsPageService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsPageService.js
@@ -90,7 +90,9 @@
         pages[service.DS_HOME_PAGE] = {
             id: service.DS_HOME_PAGE,
             title: $translate.instant('dsPageService.homeTitle'),
+            showTitle: false,
             icon: 'fa-dashboard',
+            helpId: service.DS_HOME_PAGE,
             parent: null,
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
@@ -100,6 +102,7 @@
             id: service.DATASERVICE_SUMMARY_PAGE,
             title: $translate.instant('shared.WhatSummary', {what: $translate.instant('shared.DataService')}),
             icon: 'fa-table',
+            helpId: service.DATASERVICE_SUMMARY_PAGE,
             parent: null,
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
@@ -109,6 +112,7 @@
             id: service.NEW_DATASERVICE_PAGE,
             title: $translate.instant('shared.NewWhat', {what: $translate.instant('shared.DataService')}),
             icon: 'fa-plus',
+            helpId: service.NEW_DATASERVICE_PAGE,
             parent: service.DATASERVICE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
@@ -117,7 +121,9 @@
         pages[service.IMPORT_DATASERVICE_PAGE] = {
             id: service.IMPORT_DATASERVICE_PAGE,
             title: $translate.instant('shared.ImportWhat', {what: $translate.instant('shared.DataService')}),
+            showTitle: false,
             icon: 'pficon-import',
+            helpId: service.IMPORT_DATASERVICE_PAGE,
             parent: service.DATASERVICE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
@@ -126,7 +132,9 @@
         pages[service.EXPORT_DATASERVICE_PAGE] = {
             id: service.EXPORT_DATASERVICE_PAGE,
             title: $translate.instant('shared.ExportWhat', {what: $translate.instant('shared.DataService')}),
+            showTitle: false,
             icon: 'pficon-export',
+            helpId: service.EXPORT_DATASERVICE_PAGE,
             parent: service.DATASERVICE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
@@ -136,6 +144,7 @@
             id: service.EDIT_DATASERVICE_PAGE,
             title: $translate.instant('shared.EditWhat', {what: $translate.instant('shared.DataService')}),
             icon: 'pficon-edit',
+            helpId: service.EDIT_DATASERVICE_PAGE,
             parent: service.DATASERVICE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
@@ -145,6 +154,7 @@
             id: service.CLONE_DATASERVICE_PAGE,
             title: $translate.instant('shared.CopyWhat', {what: $translate.instant('shared.DataService')}),
             icon: 'fa-copy',
+            helpId: service.CLONE_DATASERVICE_PAGE,
             parent: service.DATASERVICE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
@@ -154,6 +164,7 @@
             id: service.TEST_DATASERVICE_PAGE,
             title: $translate.instant('dsPageService.testDataServiceTitle'),
             icon: 'pficon-running',
+            helpId: service.TEST_DATASERVICE_PAGE,
             parent: service.DATASERVICE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
@@ -162,6 +173,7 @@
         pages[service.CONNECTION_SUMMARY_PAGE] = {
             id: service.CONNECTION_SUMMARY_PAGE,
             title: $translate.instant('shared.WhatSummary', {what: $translate.instant('shared.Connection')}),
+            helpId: service.CONNECTION_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
                             'connections' + syntax.FORWARD_SLASH +
@@ -170,6 +182,7 @@
         pages[service.NEW_CONNECTION_PAGE] = {
             id: service.NEW_CONNECTION_PAGE,
             title: $translate.instant('shared.NewWhat', {what: $translate.instant('shared.Connection')}),
+            helpId: service.NEW_CONNECTION_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
                             'connections' + syntax.FORWARD_SLASH +
@@ -186,6 +199,7 @@
         pages[service.EDIT_CONNECTION_PAGE] = {
             id: service.EDIT_CONNECTION_PAGE,
             title: $translate.instant('shared.EditWhat', {what: $translate.instant('shared.Connection')}),
+            helpId: service.EDIT_CONNECTION_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
                             'connections' + syntax.FORWARD_SLASH +
@@ -194,6 +208,7 @@
         pages[service.CLONE_CONNECTION_PAGE] = {
             id: service.CLONE_CONNECTION_PAGE,
             title: $translate.instant('shared.CopyWhat', {what: $translate.instant('shared.Connection')}),
+            helpId: service.CLONE_CONNECTION_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
                             'connections' + syntax.FORWARD_SLASH +
@@ -203,6 +218,7 @@
             id: service.SERVICESOURCE_SUMMARY_PAGE,
             title: $translate.instant('shared.WhatSummary', {what: $translate.instant('shared.Source')}),
             icon: 'fa-database',
+            helpId: service.SERVICESOURCE_SUMMARY_PAGE,
             parent: null,
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
@@ -213,6 +229,7 @@
             id: service.SERVICESOURCE_NEW_PAGE,
             title: $translate.instant('dsPageService.configureSourceTitle'),
             icon: 'pficon-settings',
+            helpId: service.SERVICESOURCE_NEW_PAGE,
             parent: service.SERVICESOURCE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
@@ -223,6 +240,7 @@
             id: service.SERVICESOURCE_EDIT_PAGE,
             title: $translate.instant('shared.EditWhat', {what: $translate.instant('shared.Source')}),
             icon: 'pficon-edit',
+            helpId: service.SERVICESOURCE_EDIT_PAGE,
             parent: service.SERVICESOURCE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
@@ -233,6 +251,7 @@
             id: service.SERVICESOURCE_CLONE_PAGE,
             title: $translate.instant('shared.CopyWhat', {what: $translate.instant('shared.Source')}),
             icon: 'fa-copy',
+            helpId: service.SERVICESOURCE_CLONE_PAGE,
             parent: service.SERVICESOURCE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
@@ -243,6 +262,7 @@
             id: service.SERVICESOURCE_IMPORT_PAGE,
             title: $translate.instant('shared.ImportWhat', {what: $translate.instant('shared.Source')}),
             icon: 'pficon-import',
+            helpId: service.SERVICESOURCE_IMPORT_PAGE,
             parent: service.SERVICESOURCE_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
@@ -252,6 +272,7 @@
         pages[service.IMPORT_DRIVER_PAGE] = {
             id: service.IMPORT_DRIVER_PAGE,
             title: $translate.instant('shared.ImportWhat', {what: $translate.instant('shared.Driver')}),
+            helpId: service.IMPORT_DRIVER_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
                             'connections' + syntax.FORWARD_SLASH +
@@ -296,6 +317,36 @@
             }
 
             return crumbs;
+        };
+
+        service.setCustomTitle = function(pageId, title) {
+           var page = service.page(pageId);
+            if (_.isEmpty(page))
+                return;
+
+            if (title === null || _.isEmpty(title)) {
+                delete page.customTitle;
+                return;
+            }
+
+            page.customTitle = title;
+        };
+
+        /**
+         * Adds custom helpId should a different id be required
+         * rather than the standard page version
+         */
+        service.setCustomHelpId = function(pageId, helpId) {
+           var page = service.page(pageId);
+            if (_.isEmpty(page))
+                return;
+
+            if (helpId === null || _.isEmpty(helpId)) {
+                delete page.customHelpId;
+                return;
+            }
+
+            page.customHelpId = helpId;
         };
 
         return service;

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsSummaryController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsSummaryController.js
@@ -8,9 +8,11 @@
         .module(pluginName)
         .controller('DSSummaryController', DSSummaryController);
 
-    DSSummaryController.$inject = ['$scope', '$rootScope', '$translate', 'RepoRestService', 'REST_URI', 'SYNTAX', 'DSSelectionService', 'SvcSourceSelectionService', 'DownloadService', 'pfViewUtils'];
+    DSSummaryController.$inject = ['$scope', '$rootScope', '$translate', 'RepoRestService', 'REST_URI', 'SYNTAX', 'DSSelectionService',
+                                                        'SvcSourceSelectionService', 'DownloadService', 'pfViewUtils', 'DSPageService'];
 
-    function DSSummaryController($scope, $rootScope, $translate, RepoRestService, REST_URI, SYNTAX, DSSelectionService, SvcSourceSelectionService, DownloadService, pfViewUtils) {
+    function DSSummaryController($scope, $rootScope, $translate, RepoRestService, REST_URI, SYNTAX, DSSelectionService,
+                                                        SvcSourceSelectionService, DownloadService, pfViewUtils, DSPageService) {
         var vm = this;
 
         vm.dsLoading = DSSelectionService.isLoading();
@@ -22,6 +24,17 @@
         vm.allItems = DSSelectionService.getDataServices();
         vm.items = vm.allItems;
 
+        function setHelpId() {
+            var page = DSPageService.page(DSPageService.DATASERVICE_SUMMARY_PAGE);
+
+            if (! vm.hasServices && ! vm.hasSources)
+                DSPageService.setCustomHelpId(page.id, "dataservice-summary-empty");
+            else if (! vm.hasServices && vm.hasSources)
+                DSPageService.setCustomHelpId(page.id, "dataservice-summary-no-service");
+            else
+                DSPageService.setCustomHelpId(page.id, null);
+        }
+
         /*
          * When the data services have been loaded
          */
@@ -32,6 +45,8 @@
            } else {
                 vm.hasServices = false;
            }
+
+            setHelpId();
         });
         
         /*
@@ -44,6 +59,8 @@
             } else {
                 vm.hasSources = false;
             }
+
+            setHelpId();
         });
 
         /**

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsTestController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsTestController.js
@@ -10,10 +10,18 @@
         .module(pluginName)
         .controller('DSTestController', DSTestController);
 
-    DSTestController.$inject = ['$scope', '$translate', 'CONFIG', 'SYNTAX', 'RepoSelectionService', 'DSSelectionService', 'RepoRestService', '$interval'];
+    DSTestController.$inject = ['$scope', '$translate', 'CONFIG', 'SYNTAX', 'RepoSelectionService', 'DSSelectionService',
+                                                'RepoRestService', 'DSPageService', '$interval'];
 
-    function DSTestController($scope, $translate, CONFIG, SYNTAX, RepoSelectionService, DSSelectionService, RepoRestService, $interval) {
+    function DSTestController($scope, $translate, CONFIG, SYNTAX, RepoSelectionService, DSSelectionService,
+                                                RepoRestService, DSPageService, $interval) {
         var vm = this;
+
+        /*
+         * Set a custom title to the page including the data service's id
+         */
+        var page = DSPageService.page(DSPageService.TEST_DATASERVICE_PAGE);
+        DSPageService.setCustomTitle(page.id, page.title + " '" + DSSelectionService.selectedDataService().keng__id + "'");
 
         var EQUALS = $translate.instant('dsTestController.condition.equals');
         var NOT_EQUALS = $translate.instant('dsTestController.condition.notEquals');

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/content/css/styles.less
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/content/css/styles.less
@@ -331,11 +331,21 @@ body.ng-pageslide-body-closed::before {
     pointer-events: none;
 }
 
+.page-help-icon-container {
+    position:absolute;
+    top: 1em;
+    right: 1em;
+}
+
 .page-help-icon {
     float: right;
     font-size: 22px;
     text-decoration: none !important;
     vertical-align: bottom;
+}
+
+.page-help-slide-container {
+    padding: 0;
 }
 
 .tree-control-results {

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/pageHelpControl.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/pageHelpControl.html
@@ -1,11 +1,8 @@
-<div class="page-header">
-    <h1>
-        <span class="fa fa-fw {{vm.icon}}"></span>
-        {{vm.title}}
+<div class="page-help-icon-container">
         <a class="page-help-icon pficon-help" href="" ng-click="vm.togglePageHelp()">
             <div pageslide ps-open="vm.showPageHelp" ps-size="40%" ps-key-listener="true" ps-container="{{ vm.containerId }}">
-                <div style="padding:20px">
-                    <iframe id="iframe" frameborder="1" scrolling="yes" width="100%" height="600" ng-src="{{vm.getHelpPageUrl()}}" frameborder="5" >
+                <div class="page-help-slide-container">
+                    <iframe id="help-iframe" frameborder="1" scrolling="yes" width="100%" height="600" ng-src="{{vm.helpPageUrl}}" frameborder="5" >
             	        {{ 'HelpService.inlineFramesNotSupportedMsg' | translate }}
                     </iframe>
                     <div class="row">
@@ -16,5 +13,4 @@
                 </div>
             </div>
         </a>
-    </h1>
 </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/pageHelpControl.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/pageHelpControl.js
@@ -15,11 +15,8 @@
             replace: true, // replaces the <page-help-control> tag with the template
             scope: {},
             bindToController: {
-                icon: '@',
-                title: '@',
                 helpId: '@',
                 containerId: '@'
-
             },
             controller: PageHelpController,
             controllerAs: 'vm',
@@ -39,14 +36,11 @@
 
         vm.togglePageHelp = function() {
         	vm.showPageHelp = !vm.showPageHelp;
-        };
-        
-        vm.getHelpPageUrl = function() {
-        	if ( vm.showPageHelp ) {
-                return  $sce.trustAsResourceUrl( helpService.getHelpPageUrl( vm.helpId ) );
-        	}
-        	
-        	return "";
+            if ( vm.showPageHelp )
+                vm.helpPageUrl = $sce.trustAsResourceUrl( helpService.getHelpPageUrl( vm.helpId ) );
+//                vm.helpPageUrl = $sce.trustAsResourceUrl('http://www.phantomjinx.co.uk');
+        	else
+                vm.helpPageUrl = '';
         };
     }
 })();


### PR DESCRIPTION
This seeks to address the issues previously discussed. Please review and get back to me with thoughts.

ScreenGrab: http://phantomjinx.co.uk/stuff/ds-summary-help-icon-move.png

* dataservice-main.html
 * Adds the page-help-icon to the data-service main container and uses an
   absolute position to enforce its right-hand side position.
 * Only 1 entry of the page-help-icon helps keep it consistent across all
   the pages
 * Separates the title from the help icon but includes the title here for
   ensuring each page is again consistent

* dataservicePageController
 * When getting the page title, if there is a custom title then use that,
   otherwise return the standard title. This allows the existing behaviour
   of appending the dataservice id to the end of the title
 * On changing the page, delete the custom title

* dsPageService
 * Adds standard helpIds into page metadata
 * Provides setter for custom helpIds should it be required
 * Provides setter for custom title should it be required

* svcSourceCloneController.js
* dsCloneController.js
* dsEditController.js
* dsTestController.js
 * Adds a custom title on loading of the page

* HelpService
 * Slightly off-topic to rest of commit but avoids an infinite loop. If a
   page is not found then the getHelpPageUrl() calls itself with the
   PAGE-NOT-FOUND key. Unfortunately, this is not found so the function is
   stuck infinitely calling itself.