### PR TITLE
fix issues with previous PR and rework summary actions

### DIFF
--- a/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
@@ -1077,6 +1077,11 @@
                                 successCallback();
                                 $interval.cancel(promise);
                                 return;
+                            } else if (vdb.failed) {
+                                if (failCallback) {
+                                    failCallback("Failed");
+                                }
+                                $interval.cancel(promise);
                             }
                         }
                     },

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-summary.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-summary.html
@@ -52,7 +52,8 @@
 	        <div class="ds-summary-results-container" ng-show="vm.dsLoading==false && vm.sourcesLoading==false && vm.hasServices==true">
 	            <div class="ds-summary-results">
 	                <div class="col-md-12 list-view-container" ng-if="vm.viewType == 'listView'">
-	                    <div pf-list-view config="vm.listConfig" items="vm.getDataServices()" menu-actions="vm.menuActions">
+                        <!--  <div pf-list-view config="vm.listConfig" items="vm.getDataServices()" menu-actions="vm.menuActions"> -->
+                        <div pf-list-view config="vm.listConfig" items="vm.getDataServices()">
 	                        <div class="list-view-pf-left">
 	                            <span class="fa fa-table list-view-pf-icon-sm"></span>
 	                        </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasource-summary.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasource-summary.html
@@ -26,7 +26,8 @@
 	        <div class="svcsource-summary-results-container" ng-show="vm.srcLoading==false && vm.hasSources==true">
 	            <div class="svcsource-summary-results">
 	                <div class="col-md-12 list-view-container" ng-if="vm.viewType == 'listView'">
-	                    <div pf-list-view config="vm.listConfig" items="vm.getServiceSources()" menu-actions="vm.menuActions">
+                        <!--  <div pf-list-view config="vm.listConfig" items="vm.getServiceSources()" menu-actions="vm.menuActions"> -->
+                        <div pf-list-view config="vm.listConfig" items="vm.getServiceSources()">
 	                        <div class="list-view-pf-left">
 	                            <span class="fa fa-database list-view-pf-icon-sm"></span>
 	                        </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasourceSummaryController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasourceSummaryController.js
@@ -489,12 +489,6 @@
         vm.actionsConfig = {
           primaryActions: [
             {
-              name: $translate.instant('datasourceSummaryController.actionNameRefresh'),
-              title: $translate.instant('datasourceSummaryController.actionTitleRefresh'),
-              actionFn: refreshClicked,
-              isDisabled: false
-            },
-            {
               name: $translate.instant('datasourceSummaryController.actionNameNew'),
               title: $translate.instant('datasourceSummaryController.actionTitleNew'),
               actionFn: newSvcSourceClicked,
@@ -507,43 +501,61 @@
               isDisabled: true
             },
             {
-              name: $translate.instant('datasourceSummaryController.actionNameDelete'),
-              title: $translate.instant('datasourceSummaryController.actionTitleDelete'),
-              actionFn: deleteSvcSourceClicked,
-              isDisabled: true
-            }
-          ],
-          moreActions: [
-            {
-              name: $translate.instant('datasourceSummaryController.actionNameExport'),
-              title: $translate.instant('datasourceSummaryController.actionTitleExport'),
-              actionFn: exportSvcSourceClicked,
-              isDisabled: true
-            },
-            {
               name: $translate.instant('datasourceSummaryController.actionNameCopy'),
               title: $translate.instant('datasourceSummaryController.actionTitleCopy'),
               actionFn: cloneSvcSourceClicked,
               isDisabled: true
             },
             {
-              isSeparator: true
-            },
-            {
-              name: $translate.instant('datasourceSummaryController.actionNameImport'),
-              title: $translate.instant('datasourceSummaryController.actionTitleImport'),
-              actionFn: importSvcSourceClicked,
-              isDisabled: false
-            },
-            {
-              isSeparator: true
+              name: $translate.instant('datasourceSummaryController.actionNameDelete'),
+              title: $translate.instant('datasourceSummaryController.actionTitleDelete'),
+              actionFn: deleteSvcSourceClicked,
+              isDisabled: true
             },
             {
               name: $translate.instant('datasourceSummaryController.actionNameDisplayDdl'),
               title: $translate.instant('datasourceSummaryController.actionTitleDisplayDdl'),
               actionFn: showHideDDLClicked,
               isDisabled: false
+            },
+            {
+              name: $translate.instant('datasourceSummaryController.actionNameRefresh'),
+              title: $translate.instant('datasourceSummaryController.actionTitleRefresh'),
+              actionFn: refreshClicked,
+              isDisabled: false
             }
+          ],
+          moreActions: [
+//            {
+//              name: $translate.instant('datasourceSummaryController.actionNameExport'),
+//              title: $translate.instant('datasourceSummaryController.actionTitleExport'),
+//              actionFn: exportSvcSourceClicked,
+//              isDisabled: true
+//            },
+//            {
+//              name: $translate.instant('datasourceSummaryController.actionNameCopy'),
+//              title: $translate.instant('datasourceSummaryController.actionTitleCopy'),
+//              actionFn: cloneSvcSourceClicked,
+//              isDisabled: true
+//            },
+//            {
+//              isSeparator: true
+//            },
+//            {
+//              name: $translate.instant('datasourceSummaryController.actionNameImport'),
+//              title: $translate.instant('datasourceSummaryController.actionTitleImport'),
+//              actionFn: importSvcSourceClicked,
+//              isDisabled: false
+//            },
+//            {
+//              isSeparator: true
+//            },
+//            {
+//              name: $translate.instant('datasourceSummaryController.actionNameDisplayDdl'),
+//              title: $translate.instant('datasourceSummaryController.actionTitleDisplayDdl'),
+//              actionFn: showHideDDLClicked,
+//              isDisabled: false
+//            }
           ],
           actionsInclude: true
         };

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceEditController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceEditController.js
@@ -244,7 +244,8 @@
                             },
                             function (response) {
                                 var sourceUpdateFailedMsg = $translate.instant('svcSourceEditController.sourceUpdateFailedMsg');
-                                throw RepoRestService.newRestException(sourceUpdateFailedMsg + "\n" + RepoRestService.responseMessage(response));
+                                alert(sourceUpdateFailedMsg + "\n" + RepoRestService.responseMessage(response));
+                                SvcSourceSelectionService.refresh('datasource-summary');
                             });
                 // Connection was not changed, we can update the existing VdbModel and VdbModelSource
                 } else {
@@ -254,7 +255,8 @@
                             },
                             function (response) {
                                 var sourceUpdateFailedMsg = $translate.instant('svcSourceEditController.sourceUpdateFailedMsg');
-                                throw RepoRestService.newRestException(sourceUpdateFailedMsg + "\n" + RepoRestService.responseMessage(response));
+                                alert(sourceUpdateFailedMsg + "\n" + RepoRestService.responseMessage(response));
+                                SvcSourceSelectionService.refresh('datasource-summary');
                             });
                 }
             } catch (error) {} finally {
@@ -274,12 +276,14 @@
                     function (resp) {
                         SvcSourceSelectionService.setLoading(false);
                         var sourceUpdateFailedMsg = $translate.instant('svcSourceEditController.sourceUpdateFailedMsg');
-                        throw RepoRestService.newRestException(sourceUpdateFailedMsg + "\n" + RepoRestService.responseMessage(resp));
+                        alert(sourceUpdateFailedMsg + "\n" + RepoRestService.responseMessage(resp));
+                        SvcSourceSelectionService.refresh('datasource-summary');
                     });
             } catch (error) {
                 SvcSourceSelectionService.setLoading(false);
                 var sourceUpdateFailedMsg = $translate.instant('svcSourceEditController.sourceUpdateFailedMsg');
-                throw RepoRestService.newRestException(sourceUpdateFailedMsg + "\n" + error);
+                alert(sourceUpdateFailedMsg + "\n" + error);
+                SvcSourceSelectionService.refresh('datasource-summary');
             }
         }
 
@@ -316,12 +320,14 @@
                         SvcSourceSelectionService.setDeploying(false, vdbName, false, RepoRestService.responseMessage(response));
                         SvcSourceSelectionService.setLoading(false);
                         var sourceDeployFailedMsg = $translate.instant('svcSourceEditController.sourceDeployFailedMsg');
-                        throw RepoRestService.newRestException(sourceDeployFailedMsg + "\n" + RepoRestService.responseMessage(response));
+                        alert(sourceDeployFailedMsg + "\n" + RepoRestService.responseMessage(response));
+                        SvcSourceSelectionService.refresh('datasource-summary');
                     });
             } catch (error) {
                 SvcSourceSelectionService.setLoading(false);
                 var sourceDeployFailedMsg = $translate.instant('svcSourceEditController.sourceDeployFailedMsg');
-                throw RepoRestService.newRestException(sourceDeployFailedMsg + "\n" + error);
+                alert(sourceDeployFailedMsg + "\n" + error);
+                SvcSourceSelectionService.refresh('datasource-summary');
             }
         }
         
@@ -340,12 +346,14 @@
                     function (resp) {
                         SvcSourceSelectionService.setLoading(false);
                         var sourceModelCreateFailedMsg = $translate.instant('svcSourceEditController.sourceModelCreateFailedMsg');
-                        throw RepoRestService.newRestException(sourceModelCreateFailedMsg + "\n" + RepoRestService.responseMessage(resp));
+                        alert(sourceModelCreateFailedMsg + "\n" + RepoRestService.responseMessage(resp));
+                        SvcSourceSelectionService.refresh('datasource-summary');
                     });
             } catch (error) {
                 SvcSourceSelectionService.setLoading(false);
                 var sourceModelCreateFailedMsg = $translate.instant('svcSourceEditController.sourceModelCreateFailedMsg');
-                throw RepoRestService.newRestException(sourceModelCreateFailedMsg + "\n" + error);
+                alert(sourceModelCreateFailedMsg + "\n" + error);
+                SvcSourceSelectionService.refresh('datasource-summary');
             }
         }
 
@@ -362,12 +370,14 @@
                     function (resp) {
                         SvcSourceSelectionService.setLoading(false);
                         var sourceModelConnectionCreateFailedMsg = $translate.instant('svcSourceEditController.sourceModelConnectionCreateFailedMsg');
-                        throw RepoRestService.newRestException(sourceModelConnectionCreateFailedMsg + "\n" + RepoRestService.responseMessage(resp));
+                        alert(sourceModelConnectionCreateFailedMsg + "\n" + RepoRestService.responseMessage(resp));
+                        SvcSourceSelectionService.refresh('datasource-summary');
                     });
             } catch (error) {
                 SvcSourceSelectionService.setLoading(false);
                 var sourceModelConnectionCreateFailedMsg = $translate.instant('svcSourceEditController.sourceModelConnectionCreateFailedMsg');
-                throw RepoRestService.newRestException(sourceModelConnectionCreateFailedMsg + "\n" + error);
+                alert(sourceModelConnectionCreateFailedMsg + "\n" + error);
+                SvcSourceSelectionService.refresh('datasource-summary');
             }
         }
 
@@ -384,12 +394,14 @@
                     function (resp) {
                         SvcSourceSelectionService.setLoading(false);
                         var sourceUpdateFailedMsg = $translate.instant('svcSourceEditController.sourceModelConnectionUpdateFailedMsg');
-                        throw RepoRestService.newRestException(sourceUpdateFailedMsg + "\n" + RepoRestService.responseMessage(response));
+                        alert(sourceUpdateFailedMsg + "\n" + RepoRestService.responseMessage(response));
+                        SvcSourceSelectionService.refresh('datasource-summary');
                     });
             } catch (error) {
                 SvcSourceSelectionService.setLoading(false);
                 var sourceUpdateFailedMsg = $translate.instant('svcSourceEditController.sourceModelConnectionUpdateFailedMsg');
-                throw RepoRestService.newRestException(sourceUpdateFailedMsg + "\n" + RepoRestService.responseMessage(response));
+                alert(sourceUpdateFailedMsg + "\n" + RepoRestService.responseMessage(response));
+                SvcSourceSelectionService.refresh('datasource-summary');
             }
         }
 

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceNewController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceNewController.js
@@ -124,12 +124,14 @@
                     function (resp) {
                         SvcSourceSelectionService.setLoading(false);
                         var sourceCreateFailedMsg = $translate.instant('svcSourceNewController.sourceCreateFailedMsg');
-                        throw RepoRestService.newRestException(sourceCreateFailedMsg + "\n" + RepoRestService.responseMessage(resp));
+                        alert(sourceCreateFailedMsg + "\n" + RepoRestService.responseMessage(resp));
+                        SvcSourceSelectionService.refresh('datasource-summary');
                     });
             } catch (error) {
                 SvcSourceSelectionService.setLoading(false);
                 var sourceCreateFailedMsg = $translate.instant('svcSourceNewController.sourceCreateFailedMsg');
-                throw RepoRestService.newRestException(sourceCreateFailedMsg + "\n" + error);
+                alert(sourceCreateFailedMsg + "\n" + error);
+                SvcSourceSelectionService.refresh('datasource-summary');
             }
         }
 
@@ -148,12 +150,14 @@
                     function (resp) {
                         SvcSourceSelectionService.setLoading(false);
                         var sourceModelCreateFailedMsg = $translate.instant('svcSourceNewController.sourceModelCreateFailedMsg');
-                        throw RepoRestService.newRestException(sourceModelCreateFailedMsg + "\n" + RepoRestService.responseMessage(resp));
+                        alert(sourceModelCreateFailedMsg + "\n" + RepoRestService.responseMessage(resp));
+                        SvcSourceSelectionService.refresh('datasource-summary');
                     });
             } catch (error) {
                 SvcSourceSelectionService.setLoading(false);
                 var sourceModelCreateFailedMsg = $translate.instant('svcSourceNewController.sourceModelCreateFailedMsg');
-                throw RepoRestService.newRestException(sourceModelCreateFailedMsg + "\n" + error);
+                alert(sourceModelCreateFailedMsg + "\n" + error);
+                SvcSourceSelectionService.refresh('datasource-summary');
             }
         }
 
@@ -170,12 +174,14 @@
                     function (resp) {
                         SvcSourceSelectionService.setLoading(false);
                         var sourceModelConnectionCreateFailedMsg = $translate.instant('svcSourceNewController.sourceModelConnectionCreateFailedMsg');
-                        throw RepoRestService.newRestException(sourceModelConnectionCreateFailedMsg + "\n" + RepoRestService.responseMessage(resp));
+                        alert(sourceModelConnectionCreateFailedMsg + "\n" + RepoRestService.responseMessage(resp));
+                        SvcSourceSelectionService.refresh('datasource-summary');
                     });
             } catch (error) {
                 SvcSourceSelectionService.setLoading(false);
                 var sourceModelConnectionCreateFailedMsg = $translate.instant('svcSourceNewController.sourceModelConnectionCreateFailedMsg');
-                throw RepoRestService.newRestException(sourceModelConnectionCreateFailedMsg + "\n" + error);
+                alert(sourceModelConnectionCreateFailedMsg + "\n" + error);
+                SvcSourceSelectionService.refresh('datasource-summary');
             }
         }
 
@@ -210,18 +216,21 @@
                             RepoRestService.pollForActiveVdb(vdbName, successCallback, failCallback);
                         } else {
                             SvcSourceSelectionService.setDeploying(false, vdbName, false, result.Information.ErrorMessage1);
+                            SvcSourceSelectionService.refresh('dataservice-summary');
                         }
                    },
                     function (response) {
                         SvcSourceSelectionService.setDeploying(false, vdbName, false, RepoRestService.responseMessage(response));
                         SvcSourceSelectionService.setLoading(false);
                         var sourceDeployFailedMsg = $translate.instant('svcSourceNewController.sourceDeployFailedMsg');
-                        throw RepoRestService.newRestException(sourceDeployFailedMsg + "\n" + RepoRestService.responseMessage(response));
+                        alert(sourceDeployFailedMsg + "\n" + RepoRestService.responseMessage(response));
+                        SvcSourceSelectionService.refresh('datasource-summary');
                     });
             } catch (error) {
                 SvcSourceSelectionService.setLoading(false);
                 var sourceDeployFailedMsg = $translate.instant('svcSourceNewController.sourceDeployFailedMsg');
-                throw RepoRestService.newRestException(sourceDeployFailedMsg + "\n" + error);
+                alert(sourceDeployFailedMsg + "\n" + error);
+                SvcSourceSelectionService.refresh('datasource-summary');
             }
         }
 

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsSummaryController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsSummaryController.js
@@ -421,9 +421,9 @@
               isDisabled: true
             },
             {
-              name: $translate.instant('shared.Test'),
-              title: $translate.instant('shared.TestWhat', {what: $translate.instant('shared.DataService')}),
-              actionFn: deployDataServiceClicked,
+              name: $translate.instant('shared.Copy'),
+              title: $translate.instant('shared.CopyWhat', {what: $translate.instant('shared.DataService')}),
+              actionFn: cloneDataServiceClicked,
               isDisabled: true
             },
             {
@@ -431,30 +431,42 @@
               title: $translate.instant('shared.DeleteWhat', {what: $translate.instant('shared.DataService')}),
               actionFn: deleteDataServiceClicked,
               isDisabled: true
-            }
-          ],
-          moreActions: [
+            },
+            {
+              name: $translate.instant('shared.Test'),
+              title: $translate.instant('shared.TestWhat', {what: $translate.instant('shared.DataService')}),
+              actionFn: deployDataServiceClicked,
+              isDisabled: true
+            },
             {
               name: $translate.instant('shared.Export'),
               title: $translate.instant('shared.ExportWhat', {what: $translate.instant('shared.DataService')}),
               actionFn: exportDataServiceClicked,
               isDisabled: true
-            },
-            {
-              name: $translate.instant('shared.Copy'),
-              title: $translate.instant('shared.CopyWhat', {what: $translate.instant('shared.DataService')}),
-              actionFn: cloneDataServiceClicked,
-              isDisabled: true
-            },
-            {
-              isSeparator: true
-            },
-            {
-              name: $translate.instant('shared.Import'),
-              title: $translate.instant('shared.ImportWhat', {what: $translate.instant('shared.DataService')}),
-              actionFn: importDataServiceClicked,
-              isDisabled: false
             }
+          ],
+          moreActions: [
+//            {
+//              name: $translate.instant('shared.Export'),
+//              title: $translate.instant('shared.ExportWhat', {what: $translate.instant('shared.DataService')}),
+//              actionFn: exportDataServiceClicked,
+//              isDisabled: true
+//            },
+//            {
+//              name: $translate.instant('shared.Copy'),
+//              title: $translate.instant('shared.CopyWhat', {what: $translate.instant('shared.DataService')}),
+//              actionFn: cloneDataServiceClicked,
+//              isDisabled: true
+//            },
+//            {
+//              isSeparator: true
+//            },
+//            {
+//              name: $translate.instant('shared.Import'),
+//              title: $translate.instant('shared.ImportWhat', {what: $translate.instant('shared.DataService')}),
+//              actionFn: importDataServiceClicked,
+//              isDisabled: false
+//            }
           ],
           actionsInclude: true
         };

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/EditWizardService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/EditWizardService.js
@@ -160,8 +160,13 @@
          * Add a source table
          */
         service.addSourceTable = function(source, sourceTable) {
-            wiz.sources.push(source);
-            wiz.sourceTables.push(sourceTable);
+            if( wiz.sourceTables.length===0 ) {
+                wiz.sources.push(source);
+                wiz.sourceTables.push(sourceTable);
+            } else if ( wiz.sourceTables.length===1 && ( source !== wiz.sources[0] || sourceTable !== wiz.sourceTables[0] ) ) {
+                wiz.sources.push(source);
+                wiz.sourceTables.push(sourceTable);
+            }
         };
 
         /*


### PR DESCRIPTION
- Fix error handling on datasource new/edit pages.  An alert is now displayed on error - once the alert is ok'd the page changes to the summary page.
- RestRepositoryService.pollForActiveVdb - added handling for failed VDB.
- EditWizardService - disallow adding duplicate tables to the list; disallow adding more than 2 tables to the list.
- Reworked Data Service and Data Source summary page actions - eliminated 'kababs'.  Barry reviewed.