### PR TITLE
TEIIDTOOLS-64: Removes hawtio built-in preference tabs

### DIFF
--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/config.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/config.js
@@ -48,6 +48,14 @@
                         }
                     )
                    .build());
+
+        //
+        // Removes the built-in hawtio preference tabs
+        //
+        if (preferencesRegistry.tabs) {
+            delete preferencesRegistry.tabs['Console Logging'];
+            delete preferencesRegistry.tabs.Reset;
+        }
     }
 
     hawtioPluginLoader.addModule(pluginName);


### PR DESCRIPTION
* Removes the hawtio preference tabs (Console Logging, Reset) from the
  preferences page since they are irrelevant and confusing.