### PR TITLE
TEIIDTOOLS-64: Moves the preferences page into dataservices plugin

### DIFF
--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -168,7 +168,8 @@
     "dsPageService" : {
         "configureSourceTitle" : "Configure Data Source",
         "homeTitle" : "@:shared.Dashboard",
-        "testDataServiceTitle" : "Test Data Service"
+        "testDataServiceTitle" : "Test Data Service",
+        "preferencesTitle" : "Preferences"
     },
 
     "dsSummaryController" : {

--- a/vdb-bench-assembly/index.html
+++ b/vdb-bench-assembly/index.html
@@ -206,6 +206,7 @@
     <script src="plugins/vdb-bench-dataservice/dsImportExportController.js"></script>
     <script src="plugins/vdb-bench-dataservice/dsNewController.js"></script>
     <script src="plugins/vdb-bench-dataservice/dsTestController.js"></script>
+    <script src="plugins/vdb-bench-dataservice/dsPrefController.js"></script>
     <script src="plugins/vdb-bench-dataservice/config.js"></script>
     <script src="plugins/vdb-bench-dataservice/connections/connectionSummaryController.js"></script>
     <script src="plugins/vdb-bench-dataservice/connections/connectionNewController.js"></script>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/config.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/config.js
@@ -56,6 +56,12 @@
             delete preferencesRegistry.tabs['Console Logging'];
             delete preferencesRegistry.tabs.Reset;
         }
+
+        //
+        // Removes the html for rendering the preferences link in the user menu
+        // Not required since we have a page preferences of our own
+        //
+        $templateCache.put("plugins/preferences/html/menuItem.html","");
     }
 
     hawtioPluginLoader.addModule(pluginName);

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/content/css/styles.less
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/content/css/styles.less
@@ -192,6 +192,20 @@
     margin-right: -20px;
 }
 
+.pref-page-icon {
+    float: right;
+    font-size: 22px;
+    text-decoration: none !important;
+    vertical-align: bottom;
+}
+
+.pref-page-icon-container {
+    position:absolute;
+    top: 1em;
+    right: 3em;
+    margin-right: 1em;
+}
+
 #dataservice-summary-updating {
     padding-left: 10px;
     padding-top: 10px;
@@ -619,4 +633,26 @@
     margin-bottom: 5px;
     width: 50px;
     height: 40px;
+}
+
+#ds-pref-container {
+    margin-top: 3em;
+}
+
+.ds-pref-title {
+    margin-left: 0.5em;
+}
+
+.ds-pref-category {
+    font-weight: bold;
+}
+
+#ds-pref-exit {
+    margin-top: 1em;
+    margin-bottom: 0.5em;
+}
+
+.prefs-page-help-control {
+    position: relative;
+    top: -4em;
 }

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-main.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-main.html
@@ -18,7 +18,14 @@
 
         <!-- page content -->
         <div id="dataservice-page-content-outer">
-            <div>
+
+            <div ng-show="! vmmain.isPreferencePage()">
+                <div class="pref-page-icon-container">
+                    <a class="pref-page-icon pficon-settings" href="" ng-click="vmmain.openPreferences()"></a>
+                </div>
+            </div>
+
+            <div ng-show="! vmmain.isPreferencePage()">
                 <page-help-control
 	                help-id="{{vmmain.selectedPageHelpId()}}"
 	                container-id="dataservice-page-content-outer" />

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservicePageController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservicePageController.js
@@ -93,6 +93,8 @@
             } else if(pageId == DSPageService.NEW_DATASERVICE_PAGE) {
                 EditWizardService.init(null,null);
             }
+
+            vm.prevPageId = vm.selectedPageId();
             vm.selectedPage = DSPageService.page(pageId);
             DSPageService.setCustomTitle(pageId, null);
             DSPageService.setCustomHelpId(pageId, null);
@@ -130,6 +132,20 @@
                 return '';
 
             return vm.selectedPage.id;
+        };
+
+        vm.previousPageId = function() {
+            if (_.isEmpty(vm.prevPageId))
+                return '';
+
+            return vm.prevPageId;
+        };
+
+        vm.isPreferencePage = function() {
+            if (_.isEmpty(vm.selectedPage))
+                return false;
+
+            return vm.selectedPageId() === DSPageService.DS_PREFERENCE_PAGE;
         };
 
         vm.selectedPageTitle = function() {
@@ -179,6 +195,13 @@
         vm.getConnectionState = function (conn) {
             return ConnectionSelectionService.getConnectionState(conn);
         };
+
+        /*
+         * Navigate to the preferences page
+         */
+         vm.openPreferences = function () {
+             vm.selectPage(DSPageService.DS_PREFERENCE_PAGE);
+         };
 
         vm.selectPage(DSPageService.DATASERVICE_SUMMARY_PAGE);
     }

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/ds-preference-page.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/ds-preference-page.html
@@ -1,0 +1,25 @@
+<div id="outer" class="outer-wrapper" ng-controller="DSPrefController as vm">
+    <div id="ds-pref-container" class="container-fluid">
+        <div class="row">
+            <div class="col-sm-8 col-md-9 col-sm-push-4 col-md-push-3">
+                <h2 class="ds-page-title" ng-show="vm.hasPanel()">
+                    <span class="{{vmmain.selectedPage.icon}}"></span>
+                    <span class="ds-pref-title">{{vm.pref}}</span>
+                </h2>
+                <div ng-include="vm.getPrefs(vm.pref)"></div>
+            </div>
+            <div class="col-sm-4 col-md-3 col-sm-pull-8 col-md-pull-9 sidebar-pf sidebar-pf-left">
+                <div class="nav-category">
+                    <ul class="ds-pref-category nav nav-pills nav-stacked">
+                        <li ng-repeat="name in vm.names" ng-class="vm.active(name)">
+                            <a href="" ng-click="vm.setPanel(name)">{{name}}</a>
+                        </li>
+                    </ul>
+                </div>
+                <div id="ds-pref-exit">
+                    <button class="btn btn-default btn-primary" ng-click="vm.exitPreferences()">Return</button>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsPageService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsPageService.js
@@ -22,6 +22,7 @@
          */
         var service = {
             DS_HOME_PAGE: 'dataservice-home',
+            DS_PREFERENCE_PAGE: 'ds-preference-page',
             DATASERVICE_SUMMARY_PAGE: 'dataservice-summary',
             NEW_DATASERVICE_PAGE: 'dataservice-new',
             IMPORT_DATASERVICE_PAGE: 'dataservice-import',
@@ -51,13 +52,14 @@
          */
         $rootScope.$on('$translateChangeSuccess', function () {
             pages[service.DS_HOME_PAGE].title = $translate.instant('dsPageService.homeTitle');
-            pages[service.DATASERVICE_SUMMARY_PAGE].title = $translate.instant('shared.WhatSummary', 
+            pages[service.DS_PREFERENCE_PAGE].title = $translate.instant('dsPageService.preferencesTitle');
+            pages[service.DATASERVICE_SUMMARY_PAGE].title = $translate.instant('shared.WhatSummary',
                                                                                {what: $translate.instant('shared.DataService')});
             pages[service.NEW_DATASERVICE_PAGE].title = $translate.instant('shared.NewWhat',
                                                                            {what: $translate.instant('shared.DataService')});
             pages[service.IMPORT_DATASERVICE_PAGE].title = $translate.instant('shared.ImportWhat',
                                                                               {what: $translate.instant('shared.DataService')});
-            pages[service.EXPORT_DATASERVICE_PAGE].title = $translate.instant('shared.ExportWhat', 
+            pages[service.EXPORT_DATASERVICE_PAGE].title = $translate.instant('shared.ExportWhat',
                                                                               {what: $translate.instant('shared.DataService')});
             pages[service.EDIT_DATASERVICE_PAGE].title = $translate.instant('shared.EditWhat',
                                                                             {what: $translate.instant('shared.DataService')});
@@ -97,6 +99,17 @@
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
                             service.DS_HOME_PAGE + syntax.DOT + syntax.HTML
+        };
+        pages[service.DS_PREFERENCE_PAGE] = {
+            id: service.DS_PREFERENCE_PAGE,
+            title: $translate.instant('dsPageService.preferencesTitle'),
+            showTitle: false,
+            icon: 'pficon-settings',
+            helpId: service.DS_PREFERENCE_PAGE,
+            parent: null,
+            template: config.pluginDir + syntax.FORWARD_SLASH +
+                            pluginDirName + syntax.FORWARD_SLASH +
+                            service.DS_PREFERENCE_PAGE + syntax.DOT + syntax.HTML
         };
         pages[service.DATASERVICE_SUMMARY_PAGE] = {
             id: service.DATASERVICE_SUMMARY_PAGE,

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsPrefController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsPrefController.js
@@ -1,0 +1,71 @@
+(function () {
+    'use strict';
+
+    var pluginName = 'vdb-bench.dataservice';
+    var pluginDirName = 'vdb-bench-dataservice';
+
+    angular
+        .module(pluginName)
+        .controller('DSPrefController', DSPrefController);
+
+    DSPrefController.$inject = ['$scope', 'preferencesRegistry'];
+
+    function DSPrefController($scope, preferencesRegistry) {
+        var vm = this;
+        var panels = preferencesRegistry.getTabs();
+
+        vm.names = sortNames(_.keys(panels));
+
+        $scope.$watch(function () {
+            panels = preferencesRegistry.getTabs();
+            vm.names = sortNames(_.keys(panels));
+            Core.$apply($scope);
+        });
+
+        vm.exitPreferences = function() {
+            $scope.vmmain.selectPage($scope.vmmain.previousPageId());
+        };
+
+        vm.setPanel = function (name) {
+            vm.pref = name;
+        };
+
+        vm.hasPanel = function() {
+            return ! _.isEmpty(vm.pref);
+        };
+
+        vm.active = function (name) {
+            if (name === vm.pref) {
+                return 'active';
+            }
+            return '';
+        };
+
+        vm.getPrefs = function (pref) {
+            var panel = panels[pref];
+            if (panel) {
+                return panel.template;
+            }
+            return undefined;
+        };
+
+        /**
+         * Sort the preference by names (and ensure Reset is last).
+         * @param names  the names
+         * @returns {any} the sorted names
+         */
+        function sortNames(names) {
+            return names.sort(function (a, b) {
+                return a.localeCompare(b);
+            });
+        }
+
+        //
+        // Select the first tab in the list-style
+        //
+        if (! _.isEmpty(vm.names)) {
+            vm.setPanel(vm.names[0]);
+        }
+    }
+
+})();

--- a/vdb-bench-assembly/plugins/vdb-bench-git-prefs/git-preferences.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-git-prefs/git-preferences.html
@@ -1,22 +1,13 @@
 <div id="outer" class="outer-wrapper">
 
     <!-- page content -->
-    <div id="dataservice-page-content-outer">
-        <div>
-            <page-help-control
-             help-id="git-preferences"
-             container-id="outer" />
-        </div>
 
-        <div id="dataservice-page-content-inner" class="ds-page-content">
-            <h2 class="ds-page-title" ng-show="vmmain.selectedPage.showTitle!==false">
-                <span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPageTitle()}}</span>
-            </h2>
-
-            <ng-include src="vmmain.selectedPage.template"></ng-include>
-        </div>
+    <div class="prefs-page-help-control">
+        <page-help-control
+            help-id="git-preferences"
+            container-id="outer" />
     </div>
-    
+
     <!--
         edit: controls display of +/- buttons for repositories
         show-name: controls display of Name text box

--- a/vdb-bench-assembly/plugins/vdb-bench-teiid-prefs/teiid-preferences.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-teiid-prefs/teiid-preferences.html
@@ -1,22 +1,11 @@
 <div id="outer" class="outer-wrapper" ng-controller="TeiidPrefsController as vm">
 
-<!-- page content -->
-         <!-- page content -->
-        <div id="dataservice-page-content-outer">
-            <div>
-                <page-help-control
-	                help-id="teiid-preferences"
-	                container-id="outer" />
-            </div>
-
-            <div id="dataservice-page-content-inner" class="ds-page-content">
-                <h2 class="ds-page-title" ng-show="vmmain.selectedPage.showTitle!==false">
-                    <span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPageTitle()}}</span>
-                </h2>
-
-                <ng-include src="vmmain.selectedPage.template"></ng-include>
-            </div>
-        </div>
+    <!-- page content -->
+    <div class="prefs-page-help-control">
+        <page-help-control
+            help-id="teiid-preferences"
+            container-id="outer" />
+    </div>
 
     <div id="teiid-pref-progress-bar" ng-show="vm.loading">
         <uib-progressbar class="progress-striped active" value="dynamic" type="info"></uib-progressbar>
@@ -27,7 +16,8 @@
     </p>
 
     <div ng-show="! vm.loading">
-        <form class="form-horizontal" ng-submit="vm.submitCredentials()">
+
+        <form class="form-horizontal">
 
             <div id="teiid-pref-administration" class="panel panel-default">
                 <div class="panel-heading">
@@ -38,21 +28,29 @@
                     <div class="control-group row">
                         <label class="control-label col-sm-2" for="adminUser" translate="shared.UserNameLabel"></label>
                         <div class="controls col-sm-9">
-                            <input type="text" id="teiid-pref-adminUser" class="form-control" ng-model="vm.teiid.adminUser" placeholder="{{:: 'teiid-preferences.adminUserNamePlaceholder' | translate}}" required>
+                            <input type="text" id="teiid-pref-adminUser" class="form-control" ng-model="vm.teiid.adminUser"
+                                placeholder="{{:: 'teiid-preferences.adminUserNamePlaceholder' | translate}}"
+                                required ng-blur="vm.submitCredentials()">
                         </div>
                     </div>
 
                     <div class="control-group row">
                         <label class="control-label col-sm-2" for="adminPasswd" translate="shared.PasswordLabel"></label>
                         <div class="controls col-sm-9">
-                            <input type="password" id="teiid-pref-adminPasswd" class="form-control" ng-model="vm.teiid.adminPasswd" placeholder="{{:: 'teiid-preferences.adminPasswordPlaceholder' | translate}}" required>
+                            <input type="password" id="teiid-pref-adminPasswd" class="form-control" ng-model="vm.teiid.adminPasswd"
+                                placeholder="{{:: 'teiid-preferences.adminPasswordPlaceholder' | translate}}"
+                                required ng-blur="vm.submitCredentials()">
                         </div>
                     </div>
 
                     <div class="teiid-pref-test-button row">
                         <div class=col-sm-2></div>
-                        <button class="btn btn-default col-sm-2" ng-click="vm.ping('admin')" translate="teiid-preferences.TestAdminConnection"></button>
-                        <span ng-class="vm.pingAdminResultStyleClass" class="teiid-pref-pingResult col-sm-7">{{vm.adminPingResult}}</span>
+                        <button class="btn btn-default col-sm-2" ng-click="vm.ping('admin')"
+                            translate="teiid-preferences.TestAdminConnection">
+                        </button>
+                        <span ng-class="vm.pingAdminResultStyleClass" class="teiid-pref-pingResult col-sm-7">
+                            {{vm.adminPingResult}}
+                        </span>
                     </div>
                 </div>
             </div>
@@ -68,36 +66,38 @@
                     <div class="control-group row">
                         <label class="control-label col-sm-2" for="jdbcUser" translate="shared.UserNameLabel"></label>
                         <div class="controls col-sm-9">
-                            <input type="text" id="teiid-pref-jdbcUser" class="form-control" ng-model="vm.teiid.jdbcUser" placeholder="{{:: 'teiid-preferences.jdbcUserNamePlaceholder' | translate}}" required>
+                            <input type="text" id="teiid-pref-jdbcUser" class="form-control" ng-model="vm.teiid.jdbcUser"
+                                placeholder="{{:: 'teiid-preferences.jdbcUserNamePlaceholder' | translate}}"
+                                required ng-blur="vm.submitCredentials()">
                         </div>
                     </div>
 
                     <div class="control-group row">
                         <label class="control-label col-sm-2" for="jdbcPasswd" translate="shared.PasswordLabel"></label>
                         <div class="controls col-sm-9">
-                            <input type="password" id="teiid-pref-jdbcPasswd" class="form-control" ng-model="vm.teiid.jdbcPasswd" placeholder="{{:: 'teiid-preferences.jdbcPasswordPlaceholder' | translate}}" required>
+                            <input type="password" id="teiid-pref-jdbcPasswd" class="form-control" ng-model="vm.teiid.jdbcPasswd"
+                                placeholder="{{:: 'teiid-preferences.jdbcPasswordPlaceholder' | translate}}"
+                                required ng-blur="vm.submitCredentials()">
                         </div>
                     </div>
 
                     <div class="control-group row">
                         <label class="control-label col-sm-2" for="jdbcSecure" translate="teiid-preferences.jdbcSecureLabel"></label>
                         <div class="controls col-sm-9">
-                            <input type="checkbox" id="teiid-pref-jdbcSecure" class="form-control" ng-model="vm.teiid.jdbcSecure">
+                            <input type="checkbox" id="teiid-pref-jdbcSecure" class="form-control"
+                                ng-model="vm.teiid.jdbcSecure" ng-blur="vm.submitCredentials()">
                         </div>
                     </div>
 
                     <div class="teiid-pref-test-button row">
                         <div class=col-sm-2></div>
-                        <button class="btn btn-default col-sm-2" ng-click="vm.ping('jdbc')" translate="teiid-preferences.TestJdbcConnection"></button>
-                        <span ng-class="vm.pingJdbcResultStyleClass" class="teiid-pref-pingResult col-sm-7">{{vm.jdbcPingResult}}</span>
+                        <button class="btn btn-default col-sm-2" ng-click="vm.ping('jdbc')"
+                            translate="teiid-preferences.TestJdbcConnection">
+                        </button>
+                        <span ng-class="vm.pingJdbcResultStyleClass" class="teiid-pref-pingResult col-sm-7">
+                            {{vm.jdbcPingResult}}
+                        </span>
                     </div>
-                </div>
-            </div>
-
-            <div class="row">
-                <div class=col-sm-2></div>
-                <div class="col-sm-10">
-                    <input class="teiid-pref-submit-btn" type="submit" value="Update">
                 </div>
             </div>
         </form>

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/gitCredentialsControl.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/gitCredentialsControl.html
@@ -26,9 +26,6 @@
                 <button id="btn-remove-repo" class="btn btn-xs btn-primary fa fa-minus" ng-click="vm.onRemoveClicked()"
                         ng-disabled="!vm.isRepoSelected() || vm.repoCount() == 1"></button>
             </div>
-            <div class="col-sm-4">
-                <button id="btn-save-repo" class="btn btn-lg btn-primary pull-right pficon-save" ng-click="vm.saveRepositories()"></button>
-            </div>
         </div>
     </div>
 
@@ -37,37 +34,49 @@
             <div class="form-group" ng-show="vm.showName">
                 <label class="control-label col-sm-2" for="git-repo-name" translate="shared.NameLabel"></label>
                 <div class="col-sm-10" uib-tooltip="{{:: 'gitCredentialsControl.help.repositoryName' | translate}}">
-                    <input type="text" class="form-control" id="git-repo-dest" ng-model="vm.selected.name" placeholder="{{:: 'gitCredentialsControl.repositoryNamePlaceholder' | translate}}" required>
+                    <input type="text" class="form-control" id="git-repo-dest" ng-model="vm.selected.name"
+                        placeholder="{{:: 'gitCredentialsControl.repositoryNamePlaceholder' | translate}}"
+                        required ng-blur="vm.saveRepositories()">
                 </div>
             </div>
             <div class="form-group">
                 <label class="control-label col-sm-2" for="git-repo-dest" translate="gitCredentialsControl.RepositoryUrlLabel"></label>
                 <div class="col-sm-10" uib-tooltip="{{:: 'gitCredentialsControl.help.repositoryUrl' | translate}}">
-                    <input type="text" class="form-control" id="git-repo-dest" ng-model="vm.selected.parameters['repo-path-property']" placeholder="{{:: 'gitCredentialsControl.repositoryUrlPlaceholder' | translate}}" required>
+                    <input type="text" class="form-control" id="git-repo-dest" ng-model="vm.selected.parameters['repo-path-property']"
+                        placeholder="{{:: 'gitCredentialsControl.repositoryUrlPlaceholder' | translate}}"
+                        required ng-blur="vm.saveRepositories()">
                 </div>
             </div>
             <div class="form-group">
                 <label class="control-label col-sm-2" for="git-repo-branch" translate="gitCredentialsControl.RepositoryBranchLabel"></label>
                 <div class="col-sm-10" uib-tooltip="{{:: 'gitCredentialsControl.help.repositoryBranch' | translate}}">
-                    <input type="text" class="form-control" id="git-repo-branch" ng-model="vm.selected.parameters['repo-branch-property']" placeholder="{{:: 'gitCredentialsControl.repositoryBranchPlaceholder' | translate}}">
+                    <input type="text" class="form-control" id="git-repo-branch" ng-model="vm.selected.parameters['repo-branch-property']"
+                        placeholder="{{:: 'gitCredentialsControl.repositoryBranchPlaceholder' | translate}}"
+                        ng-blur="vm.saveRepositories()">
                 </div>
             </div>
             <div class="form-group">
                 <label class="control-label col-sm-2" for="git-repo-author" translate="gitCredentialsControl.AuthorNameLabel"></label>
                 <div class="col-sm-10" uib-tooltip="{{:: 'gitCredentialsControl.help.authorName' | translate}}">
-                    <input type="text" class="form-control" id="git-repo-author" ng-model="vm.selected.parameters['author-name-property']" placeholder="{{:: 'gitCredentialsControl.authorNamePlaceholder' | translate}}">
+                    <input type="text" class="form-control" id="git-repo-author" ng-model="vm.selected.parameters['author-name-property']"
+                        placeholder="{{:: 'gitCredentialsControl.authorNamePlaceholder' | translate}}"
+                        ng-blur="vm.saveRepositories()">
                 </div>
             </div>
             <div class="form-group">
                 <label class="control-label col-sm-2" for="git-repo-author-email" translate="gitCredentialsControl.AuthorEmailLabel"></label>
                 <div class="col-sm-10" uib-tooltip="{{:: 'gitCredentialsControl.help.authorEmail' | translate}}">
-                    <input type="text" class="form-control" id="git-repo-author-email" ng-model="vm.selected.parameters['author-email-property']" placeholder="{{:: 'gitCredentialsControl.authorEmailPlaceholder' | translate}}">
+                    <input type="text" class="form-control" id="git-repo-author-email" ng-model="vm.selected.parameters['author-email-property']"
+                        placeholder="{{:: 'gitCredentialsControl.authorEmailPlaceholder' | translate}}"
+                        ng-blur="vm.saveRepositories()">
                 </div>
             </div>
             <div class="form-group" ng-show="vm.showFilePath">
                 <label class="control-label col-sm-2" for="git-repo-file-path" translate="gitCredentialsControl.RelativeFilePathLabel"></label>
                 <div class="col-sm-10" uib-tooltip="{{:: 'gitCredentialsControl.help.relativePath' | translate}}">
-                    <input type="text" class="form-control" id="git-repo-file-path" ng-model="vm.selected.parameters['file-path-property']" placeholder="{{:: 'gitCredentialsControl.relativeFilePathPlaceholder' | translate}}" required>
+                    <input type="text" class="form-control" id="git-repo-file-path" ng-model="vm.selected.parameters['file-path-property']"
+                        placeholder="{{:: 'gitCredentialsControl.relativeFilePathPlaceholder' | translate}}"
+                        required ng-blur="vm.saveRepositories()">
                 </div>
             </div>
 
@@ -96,7 +105,10 @@
                                     <div class="form-group">
                                         <label class="control-label col-sm-3" for="git-ssh-repo-passphrase" translate="gitCredentialsControl.PassphraseLabel"></label>
                                         <div class="col-sm-9" uib-tooltip="{{:: 'gitCredentialsControl.help.passphrase' | translate}}">
-                                            <input type="password" class="form-control" id="git-ssh-repo-passphrase" ng-model="vm.clearPassphrase" placeholder="{{:: 'gitCredentialsControl.passphrasePlaceholder' | translate}}">
+                                            <input type="password" class="form-control" id="git-ssh-repo-passphrase"
+                                                ng-model="vm.clearPassphrase"
+                                                placeholder="{{:: 'gitCredentialsControl.passphrasePlaceholder' | translate}}"
+                                                ng-blur="vm.saveRepositories()">
                                         </div>
                                     </div>
                                 </div>
@@ -115,7 +127,9 @@
                                         <label class="control-label col-sm-3" for="git-ssh-repo-password" translate="shared.PasswordLabel"></label>
                                         <div class="col-sm-9" uib-tooltip="{{:: 'gitCredentialsControl.help.sshPassword' | translate}}">
                                             <input type="password" class="form-control" id="git-ssh-repo-password"
-                                                        ng-model="vm.clearPassword" placeholder="{{:: 'gitCredentialsControl.passwordPlaceholder' | translate}}">
+                                                        ng-model="vm.clearPassword"
+                                                        placeholder="{{:: 'gitCredentialsControl.passwordPlaceholder' | translate}}"
+                                                        ng-blur="vm.saveRepositories()">
                                         </div>
                                     </div>
                                 </div>
@@ -129,13 +143,18 @@
                         <div class="form-group">
                             <label class="control-label col-sm-2" for="git-repo-username" translate="shared.UserNameLabel"></label>
                             <div class="col-sm-10" uib-tooltip="{{:: 'gitCredentialsControl.help.userName' | translate}}">
-                                <input type="text" class="form-control" id="git-repo-username" ng-model="vm.selected.parameters['repo-username-property']" placeholder="{{:: 'shared.userNamePlaceholder' | translate}}">
+                                <input type="text" class="form-control" id="git-repo-username"
+                                    ng-model="vm.selected.parameters['repo-username-property']"
+                                    placeholder="{{:: 'shared.userNamePlaceholder' | translate}}"
+                                    ng-blur="vm.saveRepositories()">
                             </div>
                         </div>
                         <div class="form-group">
                             <label class="control-label col-sm-2" for="git-http-repo-password" translate="shared.PasswordLabel"></label>
                             <div class="col-sm-10" uib-tooltip="{{:: 'gitCredentialsControl.help.httpPassword' | translate}}">
-                                <input type="password" class="form-control" id="git-http-repo-password" ng-model="vm.clearPassword" placeholder="{{:: 'gitCredentialsControl.passwordPlaceholder' | translate}}">
+                                <input type="password" class="form-control" id="git-http-repo-password" ng-model="vm.clearPassword"
+                                    placeholder="{{:: 'gitCredentialsControl.passwordPlaceholder' | translate}}"
+                                    ng-blur="vm.saveRepositories()">
                             </div>
                         </div>
                     </uib-accordion-group>

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/gitCredentialsControl.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/gitCredentialsControl.js
@@ -157,6 +157,7 @@
         // Event handler for clicking the add button
         vm.onAddClicked = function () {
             newRepository();
+            vm.saveRepositories();
         };
 
         // Event handler for clicking the remove button
@@ -164,13 +165,19 @@
             if (!vm.selected)
                 return;
 
-            vm.repositories.pop(vm.selected);
+            var index = vm.repositories.indexOf(vm.selected);
+            if (index === -1)
+                return;
+
+            vm.repositories.splice(index, 1);
 
             // Set the selected to the first in the collection
             if (vm.repoCount())
                 vm.setSelected(vm.repositories[0]);
             else
                 vm.setSelected(null);
+
+            vm.saveRepositories();
         };
 
         /**
@@ -261,6 +268,7 @@
          */
         vm.onAllowHostsChange = function(event) {
             readerExtractContent(event, 'repo-known-hosts-property');
+            vm.saveRepositories();
         };
 
         /**
@@ -270,6 +278,7 @@
          */
         vm.onPrivateKeyChange = function(event) {
             readerExtractContent(event, 'repo-private-key-property');
+            vm.saveRepositories();
         };
 
         /**
@@ -282,10 +291,12 @@
 
             if (angular.isUndefined(value) || value.length === 0) {
                 delete vm.selected.parameters['repo-password-property'];
+                vm.saveRepositories();
                 return;
             }
 
             vm.selected.parameters['repo-password-property'] = $base64.encode(value);
+            vm.saveRepositories();
         });
 
         /**
@@ -298,10 +309,12 @@
 
             if (angular.isUndefined(value) || value.length === 0) {
                 delete vm.selected.parameters['repo-passphrase-property'];
+                vm.saveRepositories();
                 return;
             }
 
             vm.selected.parameters['repo-passphrase-property'] = $base64.encode(value);
+            vm.saveRepositories();
         });
 
         initRepositories();

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/pageHelpControl.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/pageHelpControl.js
@@ -38,7 +38,6 @@
         	vm.showPageHelp = !vm.showPageHelp;
             if ( vm.showPageHelp )
                 vm.helpPageUrl = $sce.trustAsResourceUrl( helpService.getHelpPageUrl( vm.helpId ) );
-//                vm.helpPageUrl = $sce.trustAsResourceUrl('http://www.phantomjinx.co.uk');
         	else
                 vm.helpPageUrl = '';
         };


### PR DESCRIPTION
* Constructs a dataservice page to display the preferences complete with
  their own button in the top-right next to the help button.

* .../config.js
 * Removes the html for the preferences menu item in the hawtio user menu

* dataservice-main
 * Since each pref page supplies its own help, both the preference and help
   buttons are hidden

* dataservicePageController
 * Tracks the previous page clicked on prior to selecting a page since this
   needs to be restored on clicking return from the preferences page

* dsPrefController
 * Logic taken from the hawtio preference page

* git-preferences.html
* teiid-preferences.html
 * Corrected recursion error with the help control since the preference page
   is now a page from the dsPageService

* gitCredentialsControl.html
* teiid-preferences.html
 * Removes save/update buttons and replaces it with ng-blur (on-focus-leave)
   event handling for each widget, ie. save-as-type

* pageHelpControl.js
 * Removes reference to testing website