### PR TITLE
Fixes TEIIDTOOLS-111 and TEIIDTOOLS-124

### DIFF
--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -28,7 +28,6 @@
         "Forward" : ">>",
         "Import" : "Import",
         "ImportWhat" : "Import {{what}}",
-        "loadingProgressMsg" : "Loading...",
         "Name" : "Name",
         "NameLabel" : "Name:",
         "New" : "New",
@@ -136,9 +135,17 @@
     },
 
     "dataserviceEditWizard" : {
+        "clickFinishInstructionMsg" : "Click Finish to create the data service",
+        "clickNextSingleTableInstructionMsg" : "Click Next to select columns for the data service",
+        "clickNextTwoTablesInstructionMsg" : "Click Next to define the join for the data service",
+        "clickSourceTableInstructionMsg" : "Click on a source table to add it to your selections",
+        "dataSources" : "Data Sources",
+        "enterNameInstructionMsg" : "Enter a name for your data service",
         "getVdbModelsFailedMsg" : "Failed to get Vdb models",
-        "updateVdbFromDdlFailedMsg" : "Failed to construct temp Vdb from DDL",
-        "getVdbModelTablesFailedMsg" : "Failed to get Vdb model tables"
+        "getVdbModelTablesFailedMsg" : "Failed to get Vdb model tables",
+        "selectedTables" : "Selected Tables",
+        "stepTitle" : "Choose Data Sources",
+        "updateVdbFromDdlFailedMsg" : "Failed to construct temp Vdb from DDL"
     },
     
     "dsCloneController" : {
@@ -227,7 +234,6 @@
 
     "datasource-summary" : {
         "welcomeMsg" : "Welcome to the <strong>Data Services Builder</strong>!",
-        "Loading" : "@:shared.loadingProgressMsg",
         "noSourcesInstructionsMsg" : "Currently, there are no data sources configured.  To get started, click ",
         "sourceSchema" : "Data Source Schema"
     },
@@ -349,7 +355,6 @@
         "controlFailedMsg" : "Encountered query error: {{errorMsg}}",
         "instructionMsg" : "Enter query text then click Search",
         "RecordLimit" : "Record Limit",
-        "searchingProgressMsg" : "Searching...",
         "StartingRecordIndex" : "Starting Record Index",
         "help" : {
             "recordLimit" : "Limits the number of records returned from the query (-1 for no limit)",
@@ -363,7 +368,6 @@
         "Cancel" : "@:shared.Cancel",
         "Create" : "@:shared.Create",
         "instructionsMsg" : "Enter a name for the new data source",
-        "Loading" : "@:shared.loadingProgressMsg",
         "Name" : "@:shared.Name"
     },
 
@@ -373,7 +377,6 @@
         "Description" : "@:shared.Description",
         "filterConnection" : "Filter Connection",
         "instructionsMsg" : "Reconfigure an existing Data Source:",
-        "Loading" : "@:shared.loadingProgressMsg",
         "Name" : "@:shared.Name",
         "Save" : "@:shared.Save",
         "Translator" : "@:shared.Translator"
@@ -432,17 +435,6 @@
         "StatusErrorLabel" : "Status Error:",
         "TestAdminConnection" : "Test Admin Connection",
         "TestJdbcConnection" : "Test JDBC Connection"
-    },
-
-    "dataserviceEditWizard" : {
-        "stepTitle" : "Choose Data Sources",
-        "dataSources" : "Data Sources",
-        "selectedTables" : "Selected Tables",
-        "enterNameInstructionMsg" : "Enter a name for your data service",
-        "clickSourceTableInstructionMsg" : "Click on a source table to add it to your selections",
-        "clickFinishInstructionMsg" : "Click Finish to create the data service",
-        "clickNextSingleTableInstructionMsg" : "Click Next to select columns for the data service",
-        "clickNextTwoTablesInstructionMsg" : "Click Next to define the join for the data service"
     },
 
     "singleTableViewStep" : {

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/connections/connection-new.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/connections/connection-new.html
@@ -6,8 +6,7 @@
     </ol>
     
     <div id="connection-new-updating" ng-show="vm.driversLoading==true" class="col-md-10 row">
-        <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
-        <span class="sr-only">Loading...</span>
+        <div class="spinner spinner-lg" />
     </div>
     
     <div id="connection-new-controls" ng-show="vm.driversLoading==false" class="col-md-10 row">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/connections/connection-summary.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/connections/connection-summary.html
@@ -19,8 +19,7 @@
     </div>
     
     <div id="connection-summary-updating" ng-show="vm.connLoading==true" class="col-md-10 row">
-        <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
-        <span class="sr-only">Loading...</span>
+        <div class="spinner spinner-lg" />
     </div>
         
     <div id="connection-summary-table-row" class="col-md-10 row" ng-show="vm.connLoading==false">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-edit.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-edit.html
@@ -2,13 +2,6 @@
 	<div id="dataservice-edit-container" class="container-fluid" ng-controller="DSEditController as vm">
 	
 	    <div id="dsEdit-edit-controls" ng-show="vm.svcSourcesLoading==false" class="row">
-	        <div class="row col-md-12">
-	            <page-help-control 
-	                icon="{{vmmain.selectedPage.icon}}" 
-	                title="{{vmmain.selectedPage.title}} '{{vmmain.selectedDataservice().keng__id}}'" 
-	                help-id="dataservice-edit"
-	                container-id="outer" />
-	        </div>
             <div id="dataservice-edit-wizard" class="row col-md-12">
                 <dataservice-edit-wizard></dataservice-edit-wizard>
             </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-new.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-new.html
@@ -16,13 +16,6 @@
 	    
 	    <div id="dataservice-new-controls" ng-show="vm.hasSources==true" class="row">
             <div class="row col-md-12">
-                <page-help-control 
-                    icon="{{vmmain.selectedPage.icon}}" 
-                    title="{{vmmain.selectedPage.title}}" 
-                    help-id="dataservice-new"
-                    container-id="outer" />
-            </div>
-            <div class="row col-md-12">
                 <h4>
                     <span translate="dataservice-new.instructionsMsg" />
                         <a href ng-click="vmmain.selectPage('svcsource-new')">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-summary.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-summary.html
@@ -45,8 +45,7 @@
 	        <div pf-toolbar id="dataserviceToolbar" config="vm.toolbarConfig" ng-show="vm.dsLoading==true || vm.sourcesLoading==true || vm.hasServices==true"></div>
 	
 	        <div id="dataservice-summary-updating" ng-show="vm.dsLoading==true || vm.sourcesLoading==true" class="col-md-10 row">
-	            <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
-	            <span class="sr-only"></span>{{:: 'shared.loadingProgressMsg' | translate}}
+                <div class="spinner spinner-lg" />
 	        </div>
 	
 	        <div class="ds-summary-results-container" ng-show="vm.dsLoading==false && vm.sourcesLoading==false && vm.hasServices==true">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-test.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-test.html
@@ -6,8 +6,7 @@
 	      -->
 	    <!-- Show spinner while deploying -->
 	    <div id="deployment-spinner" ng-show="vm.dsDeploymentInProgress==true" class="col-md-10 row">
-	        <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
-	        <span class="sr-only"></span>{{:: 'shared.loadingProgressMsg' | translate}}
+            <div class="spinner spinner-lg" />
 	    </div>
 
 	    <div ng-show="vm.dsDeploymentInProgress==false && vm.dsDeploymentSuccess==false" class="row">
@@ -253,8 +252,7 @@
 
 	            <!-- Show spinner while searching -->
 	            <div id="odata-search-progress-spinner" class="col-md-8" ng-show="vm.searchInProgress==true">
-	                <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
-	                <span class="sr-only">Searching...</span>
+                    <div class="spinner spinner-lg" />
 	            </div>
 
 	            <div id="odata-metadata-fetch-failure" class="col-sm-12"

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasource-summary.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasource-summary.html
@@ -18,10 +18,9 @@
 	    <div id="svcsource-summary-table" class="col-md-12 row">
 	        <div pf-toolbar id="svcsourceToolbar" config="vm.toolbarConfig" ng-show="vm.srcLoading==true || vm.hasSources==true"></div>
 	
-	        <div id="svcsource-summary-updating" ng-show="vm.srcLoading==true">
-	            <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
-	            <span class="sr-only" translate="datasource-summary.Loading"></span>
-	        </div>
+            <div id="svcsource-summary-updating" ng-show="vm.srcLoading==true">
+                <div class="spinner spinner-lg" />
+            </div>
 	
 	        <div class="svcsource-summary-results-container" ng-show="vm.srcLoading==false && vm.hasSources==true">
 	            <div class="svcsource-summary-results">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-clone.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-clone.html
@@ -1,8 +1,7 @@
 <div id="outer" class="outer-wrapper">
 	<div id="svcsource-clone-container" class="container-fluid" ng-controller="SvcSourceCloneController as vm">
 	    <div id="svcsource-clone" ng-show="vm.cloneVdbInProgress==true" class="col-md-10 row">
-	        <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
-	        <span class="sr-only" translate="svcsource-clone.Loading"></span>
+            <div class="spinner spinner-lg" />
 	    </div>
 	    
 	    <div id="svcsource-clone-controls" ng-show="vm.cloneVdbInProgress==false" class="col-md-12 row">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-edit.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-edit.html
@@ -1,8 +1,7 @@
 <div id="outer" class="outer-wrapper">
 	<div id="svcsource-edit-container" class="container-fluid" ng-controller="SvcSourceEditController as vm">
 	    <div id="svcsource-edit-updating" ng-show="vm.transLoading==true || vm.updateAndDeployInProgress==true" class="col-md-10 row">
-	        <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
-	        <span class="sr-only" translate="svcsource-edit.Loading"></span>
+            <div class="spinner spinner-lg" />
 	    </div>
 	    
 	    <div id="svcsource-edit-controls" ng-show="vm.transLoading==false && vm.updateAndDeployInProgress==false" class="row">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-new.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcsource-new.html
@@ -1,8 +1,7 @@
 <div id="outer" class="outer-wrapper">
 	<div id="svcsource-new-container" class="container-fluid" ng-controller="SvcSourceNewController as vm">
 	    <div id="svcsource-new-updating" ng-show="vm.createAndDeployInProgress==true" class="col-md-10 row">
-	        <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
-	        <span class="sr-only"></span>{{:: 'shared.loadingProgressMsg' | translate}}
+            <div class="spinner spinner-lg" />
 	    </div>
 	    
 	    <div id="svcsource-new-controls" ng-show="vm.createAndDeployInProgress==false" class="row">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.html
@@ -48,7 +48,7 @@
                 <div class="tree-control-container col-md-4">
                     <!-- Spinner when loading -->
                     <div ng-show="vm.treeLoading==true">
-                        <i class="fa fa-spinner fa-spin fa-2x fa-fw"></i>
+                        <div class="spinner spinner-lg" />
                     </div>
                     <!-- No Content Message -->
                     <div ng-show="vm.treeLoading==false && vm.treedata.length == 0 && !vm.hasTreeFetchError">
@@ -69,7 +69,7 @@
                              <span ng-switch="" on="node.type">
                                  <span ng-switch-when="source" class="fa fa-database" aria-hidden="true"></span>
                                  <span ng-switch-when="table" class="fa fa-table" aria-hidden="true"></span>
-                                 <span ng-switch-when="loading" class="fa fa-spinner fa-spin" aria-hidden="true"></span>
+                                 <span ng-switch-when="loading" class="spinner spinner-lg" aria-hidden="true"></span>
                              </span>
                             {{node.name}}
                         </treecontrol>

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/connectionList.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/connectionList.html
@@ -1,13 +1,12 @@
 <div>
     <div id="connectionList-updating" ng-show="vm.connectionsLoading==true" class="col-md-10 row">
-        <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
-        <span class="sr-only">Loading...</span>
+        <div class="spinner spinner-lg" />
     </div>
     
     <div class="pick-list-container">
         <!-- Spinner when loading -->
         <div ng-show="vm.connectionsLoading==true">
-            <i class="fa fa-spinner fa-spin fa-2x fa-fw"></i>
+            <div class="spinner spinner-lg" />
         </div>
         <!-- No Content Message -->
         <div ng-show="vm.connectionsLoading==false && vm.items.length == 0">

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/jdbcFilterOptions.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/jdbcFilterOptions.html
@@ -18,7 +18,7 @@
         <!--  -->
         <!-- Options resetting -->
         <div class="row" ng-show="vm.optionsResetting==true">
-            <i class="fa fa-spinner fa-spin fa-2x fa-fw"></i>
+            <div class="spinner spinner-lg" />
         </div>
         <!--  -->
         <!--  -->
@@ -50,7 +50,7 @@
             <div class="tree-control-container col-md-5" ng-show="vm.supportsCatalogOrSchema">
                 <!-- Spinner when loading -->
                 <div ng-show="vm.treeLoading==true">
-                    <i class="fa fa-spinner fa-spin fa-2x fa-fw"></i>
+                    <div class="spinner spinner-lg" />
                 </div>
                 <!-- No Content Message -->
                 <div ng-show="vm.treeLoading==false && vm.treedata.length == 0 && !vm.hasTreeFetchError">
@@ -75,8 +75,7 @@
                 <div class="pick-list-container">
                     <!-- spinner while updating -->
                     <div id="tableList-updating" ng-show="vm.tablesLoading==true" class="col-md-10 row">
-                        <i class="fa fa-spinner fa-spin fa-2x fa-fw"></i>
-                        <span class="sr-only" translate="shared.loadingProgressMsg"></span>
+                        <div class="spinner spinner-lg" />
                     </div>
                     <!-- No Tables Message -->
                    <div id="tableList-updating" ng-show="vm.tablesLoading==false && vm.tables.length == 0 && !vm.hasTableFetchError" class="col-md-10 row">

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/modelTableList.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/modelTableList.html
@@ -1,7 +1,6 @@
 <div>
     <div id="modelTableList-updating" ng-show="vm.tablesLoading==true" class="col-md-10 row">
-        <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
-        <span class="sr-only" translate="shared.loadingProgressMsg"></span>
+        <div class="spinner spinner-lg" />
     </div>
     
     <div class="pick-list-container">

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/serviceSourceList.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/serviceSourceList.html
@@ -1,7 +1,6 @@
 <div>
     <div id="serviceSourceList-updating" ng-show="vm.srcLoading==true" class="col-md-10 row">
-        <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
-        <span class="sr-only" translate="shared.loadingProgressMsg" />
+        <div class="spinner spinner-lg" />
     </div>
         
     <div class="pick-list-container">

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/sqlControl.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/sqlControl.html
@@ -37,8 +37,7 @@
 
     <!-- Show spinner while searching -->
     <div id="sql-search-progress-spinner" class="col-sm-4" ng-show="vm.inProgress==true">
-        <i class="fa fa-spinner fa-spin fa-3x fa-fw"></i>
-        <span class="sr-only"></span>{{:: 'sqlControl.searchingProgressMsg' | translate}}
+        <div class="spinner spinner-lg" />
     </div>
 
     <div class="col-sm-6" ng-show="! vm.errorMsg && vm.showResultsTable == true">


### PR DESCRIPTION
- Removed the extra help icon on the new and edit data service pages [TEIIDTOOLS-111](https://issues.jboss.org/browse/TEIIDTOOLS-111)
- Now using the PatternFly spinner [TEIIDTOOLS-124](https://issues.jboss.org/browse/TEIIDTOOLS-124)
- Merges and then deletes the duplicate keys in the i18n messages file.