### PR TITLE
remove view toggle on summary pages

### DIFF
--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasourceSummaryController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasourceSummaryController.js
@@ -249,18 +249,12 @@
           appliedFilters: [],
           onFilterChange: filterChange
         };
-     
-        var viewSelected = function(viewId) {
-          vm.viewType = viewId;
-        };
-     
+
         vm.viewsConfig = {
-          views: [pfViewUtils.getListView()], // Only using list view for the moment
-          onViewSelect: viewSelected
+          currentView: pfViewUtils.getListView().id
         };
-        vm.viewsConfig.currentView = vm.viewsConfig.views[0].id;
         vm.viewType = vm.viewsConfig.currentView;
-     
+
         var compareFn = function(item1, item2) {
           var compValue = 0;
           if (vm.sortConfig.currentField.id === 'name') {

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsSummaryController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsSummaryController.js
@@ -155,18 +155,12 @@
           appliedFilters: [],
           onFilterChange: filterChange
         };
-     
-        var viewSelected = function(viewId) {
-          vm.viewType = viewId;
-        };
-     
+
         vm.viewsConfig = {
-          views: [pfViewUtils.getListView()], // Only using list view for the moment
-          onViewSelect: viewSelected
+            currentView: pfViewUtils.getListView().id
         };
-        vm.viewsConfig.currentView = vm.viewsConfig.views[0].id;
         vm.viewType = vm.viewsConfig.currentView;
-     
+
         var compareFn = function(item1, item2) {
           var compValue = 0;
           if (vm.sortConfig.currentField.id === 'name') {


### PR DESCRIPTION
TEIIDTOOLS-70 - Changes the summary page view configurations.  This eliminates the view toggle button, which is not needed since we don't currently allow toggle to a different view (such as a card view) anyway.