### PR TITLE
TEIIDTOOLS-91 Updates page titles

### DIFF
--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -28,12 +28,14 @@
         "Forward" : ">>",
         "Import" : "Import",
         "ImportWhat" : "Import {{what}}",
+        "Login" : "Login",
         "Name" : "Name",
         "NameLabel" : "Name:",
         "New" : "New",
         "NewWhat" : "New {{what}}",
         "Next" : "Next",
         "NotAvailable" : "Not Available",
+        "Password" : "Password",
         "PasswordLabel" : "Password:",
         "Remove" : "Remove",
         "Save" : "Save",
@@ -46,9 +48,9 @@
         "TestWhat" : "Test {{what}}",
         "Translator" : "Translator",
         "UncheckAll" : "Uncheck All",
+        "Username" : "Username",
         "UserNameLabel" : "User Name:",
         "userNamePlaceholder" : "Enter the user name",
-        "WhatSummary" : "{{what}} Summary",
         "Workspace" : "Workspace"
     },
 
@@ -350,6 +352,12 @@
     "modelTableList" : {
         "connectionFailedErrorMsg" : "Failed to get connection: {{error}}",
         "getTablesErrorMsg" : "Failed to get Tables: {{errorMsg}}"
+    },
+    
+    "loginPage" : {
+        "rememberCredentials" : "Remember Credentials",
+        "welcomeTitle" : "Welcome to Data Services Builder",
+        "welcomeDescription" : "A tool for creating, managing and deploying simple data services."
     },
     
     "sqlControl" : {

--- a/vdb-bench-assembly/app/login.html
+++ b/vdb-bench-assembly/app/login.html
@@ -17,13 +17,13 @@
                 <div class="col-sm-7 col-md-6 col-lg-5 login">
                     <form class="form-horizontal" role="form" ng-submit="vm.doLogin()">
                         <div class="form-group">
-                            <label for="inputUsername" class="col-sm-2 col-md-2 control-label">Username</label>
+                            <label for="inputUsername" class="col-sm-2 col-md-2 control-label">{{'shared.Username' | translate}}</label>
                             <div class="col-sm-10 col-md-10">
                                 <input type="text" class="form-control" id="inputUsername" placeholder="" tabindex="1" required ng-model="vm.entity.username" autofill autofocus>
                             </div>
                         </div>
                         <div class="form-group">
-                            <label for="inputPassword" class="col-sm-2 col-md-2 control-label">Password</label>
+                            <label for="inputPassword" class="col-sm-2 col-md-2 control-label">{{'shared.Password' | translate}}</label>
                             <div class="col-sm-10 col-md-10">
                                 <input type="password" class="form-control" id="inputPassword" placeholder="" tabindex="2" required ng-model="vm.entity.password" autofill>
                             </div>
@@ -32,12 +32,12 @@
                             <div class="col-xs-8 col-sm-offset-2 col-sm-6 col-md-offset-2 col-md-6">
                                 <div class="checkbox">
                                     <label>
-                                        <input type="checkbox" tabindex="3" ng-model="vm.rememberMe"> Remember Credentials
+                                        <input type="checkbox" tabindex="3" ng-model="vm.rememberMe"> {{'loginPage.rememberCredentials' | translate}}
                                     </label>
                                 </div>
                             </div>
                             <div class="col-xs-4 col-sm-4 col-md-4 submit">
-                                <button type="submit" class="btn btn-primary btn-lg" tabindex="4">Login</button>
+                                <button type="submit" class="btn btn-primary btn-lg" tabindex="4">{{'shared.Login' | translate}}</button>
                             </div>
                             <div id="vdb-login-error">
                                 <p>{{vm.loginError}}</p>
@@ -48,9 +48,7 @@
                 <!--/.col-*-->
                 <div class="col-sm-5 col-md-6 col-lg-7 details">
                     <p>
-                        <strong>Welcome to Data Services Builder</strong> A tool for editing, managing and testing simple data services targeted for accessing your data via the Teiid runtime framework.
-                        The DSB utilizes an editing framework wrapped around a local embedded ModeShape repository.
-                        This repository provides the backbone for managing consistent import/export of runtime resources and content validation.
+                        <strong>{{'loginPage.welcomeTitle' | translate}}</strong> - {{'loginPage.welcomeDescription' | translate}}
                     </p>
                 </div>
                 <!--/.col-*-->

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-main.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-main.html
@@ -33,7 +33,7 @@
 
             <div id="dataservice-page-content-inner" class="ds-page-content">
                 <h2 class="ds-page-title" ng-show="vmmain.selectedPage.showTitle!==false">
-                    <span class="fa fa-fw {{vmmain.selectedPage.icon}}"></span><span>{{vmmain.selectedPageTitle()}}</span>
+                    <span>{{vmmain.selectedPageTitle()}}</span>
                 </h2>
 
                 <ng-include src="vmmain.selectedPage.template"></ng-include>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsPageService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsPageService.js
@@ -53,8 +53,7 @@
         $rootScope.$on('$translateChangeSuccess', function () {
             pages[service.DS_HOME_PAGE].title = $translate.instant('dsPageService.homeTitle');
             pages[service.DS_PREFERENCE_PAGE].title = $translate.instant('dsPageService.preferencesTitle');
-            pages[service.DATASERVICE_SUMMARY_PAGE].title = $translate.instant('shared.WhatSummary',
-                                                                               {what: $translate.instant('shared.DataService')});
+            pages[service.DATASERVICE_SUMMARY_PAGE].title = $translate.instant('shared.DataServices');
             pages[service.NEW_DATASERVICE_PAGE].title = $translate.instant('shared.NewWhat',
                                                                            {what: $translate.instant('shared.DataService')});
             pages[service.IMPORT_DATASERVICE_PAGE].title = $translate.instant('shared.ImportWhat',
@@ -66,8 +65,7 @@
             pages[service.CLONE_DATASERVICE_PAGE].title = $translate.instant('shared.CopyWhat',
                                                                              {what: $translate.instant('shared.DataService')});
             pages[service.TEST_DATASERVICE_PAGE].title = $translate.instant('dsPageService.testDataServiceTitle');
-            pages[service.CONNECTION_SUMMARY_PAGE].title = $translate.instant('shared.WhatSummary',
-                                                                              {what: $translate.instant('shared.Connection')});
+            pages[service.CONNECTION_SUMMARY_PAGE].title = $translate.instant('shared.Connections');
             pages[service.NEW_CONNECTION_PAGE].title = $translate.instant('shared.NewWhat',
                                                                           {what: $translate.instant('shared.Connection')});
             pages[service.IMPORT_CONNECTION_PAGE].title = $translate.instant('shared.ImportWhat',
@@ -76,8 +74,7 @@
                                                                            {what: $translate.instant('shared.Connection')});
             pages[service.CLONE_CONNECTION_PAGE].title = $translate.instant('shared.CopyWhat',
                                                                             {what: $translate.instant('shared.Connection')});
-            pages[service.SERVICESOURCE_SUMMARY_PAGE].title = $translate.instant('shared.WhatSummary',
-                                                                                 {what: $translate.instant('shared.Source')});
+            pages[service.SERVICESOURCE_SUMMARY_PAGE].title = $translate.instant('shared.Sources');
             pages[service.SERVICESOURCE_NEW_PAGE].title = $translate.instant('dsPageService.configureSourceTitle');
             pages[service.SERVICESOURCE_EDIT_PAGE].title = $translate.instant('shared.EditWhat',
                                                                               {what: $translate.instant('shared.Source')});
@@ -113,7 +110,7 @@
         };
         pages[service.DATASERVICE_SUMMARY_PAGE] = {
             id: service.DATASERVICE_SUMMARY_PAGE,
-            title: $translate.instant('shared.WhatSummary', {what: $translate.instant('shared.DataService')}),
+            title: $translate.instant('shared.DataServices'),
             icon: 'fa-table',
             helpId: service.DATASERVICE_SUMMARY_PAGE,
             parent: null,
@@ -184,7 +181,7 @@
         };
         pages[service.CONNECTION_SUMMARY_PAGE] = {
             id: service.CONNECTION_SUMMARY_PAGE,
-            title: $translate.instant('shared.WhatSummary', {what: $translate.instant('shared.Connection')}),
+            title: $translate.instant('shared.Connections'),
             helpId: service.CONNECTION_SUMMARY_PAGE,
             template: config.pluginDir + syntax.FORWARD_SLASH +
                             pluginDirName + syntax.FORWARD_SLASH +
@@ -228,7 +225,7 @@
         };
         pages[service.SERVICESOURCE_SUMMARY_PAGE] = {
             id: service.SERVICESOURCE_SUMMARY_PAGE,
-            title: $translate.instant('shared.WhatSummary', {what: $translate.instant('shared.Source')}),
+            title: $translate.instant('shared.Sources'),
             icon: 'fa-database',
             helpId: service.SERVICESOURCE_SUMMARY_PAGE,
             parent: null,


### PR DESCRIPTION
- TEIIDTOOLS-91 - Drops icons which precede page titles
- TEIIDTOOLS-91 - Drops 'Summary' from the DataServices / DataSources / Connections summary pages
- TEIIDTOOLS-88 - Shortens the DSB description on the login page.  Also i18n the remaining text on the loginPage.html