### PR TITLE
TEIIDTOOLS-133 Dashboard widget labeling

### DIFF
--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservices/dataservices.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservices/dataservices.html
@@ -4,7 +4,7 @@
     <p ng-show="! vm.loading && vm.error">Status Error:<br/>'{{vm.error}}'</p>
 
     <div ng-show="! vm.loading && ! vm.error">
-        Number of dataservices: <span style="color: blue;">{{vm.total}}</span>
+        Number of Data Services: <span style="color: blue;">{{vm.total}}</span>
 
         <div class="ds-dashboard-widgets-dataservices-list-tr-names-container" ng-show="vm.total > 0">
             <div class="ds-dashboard-widgets-dataservices-list-tr-names">
@@ -20,11 +20,11 @@
         <div id="ds-dashboard-widgets-dataservices-footer" class="card-pf-footer">
             <p>
                 <a ng-click="vm.selectPage('dataservice-summary')">
-                    <span class="fa fa-fw {{vm.page('dataservice-summary').icon}}"></span><span>List All</span>
+                    <span class="fa fa-fw {{vm.page('dataservice-summary').icon}}"></span><span>Go to Summary</span>
                 </a>
                 <span></span>
                 <a ng-click="vm.selectPage('dataservice-new')" class="pull-right">
-                    <span class="fa fa-fw {{vm.page('dataservice-new').icon}}"></span><span>Create</span>
+                    <span class="fa fa-fw {{vm.page('dataservice-new').icon}}"></span><span>New Data Service</span>
                 </a>
             </p>
         </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservices/dataservices.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservices/dataservices.js
@@ -17,8 +17,8 @@
     function config(dashboardProvider, config, syntax) {
         dashboardProvider
             .widget('ds-dataservices', {
-                title: 'Workspace Dataservices',
-                description: 'Displays the current data services in the workspace',
+                title: 'Data Services',
+                description: 'Displays the current Data Services',
                 templateUrl: config.pluginDir + syntax.FORWARD_SLASH +
                                     pluginDirName + syntax.FORWARD_SLASH +
                                     'dataservices.html',

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/service-sources/svcsources.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/service-sources/svcsources.html
@@ -4,7 +4,7 @@
     <p ng-show="! vm.loading && vm.error">Status Error:<br/>'{{vm.error}}'</p>
 
     <div ng-show="! vm.loading && ! vm.error">
-        Number of sources: <span style="color: blue;">{{vm.total}}</span>
+        Number of Data Sources: <span style="color: blue;">{{vm.total}}</span>
 
         <div class="ds-dashboard-widgets-svcsources-list-tr-names-container" ng-show="vm.total > 0">
             <div class="ds-dashboard-widgets-svcsources-list-tr-names">
@@ -20,11 +20,11 @@
         <div id="ds-dashboard-widgets-svcsources-footer" class="card-pf-footer">
             <p>
                 <a ng-click="vm.selectPage('datasource-summary')">
-                    <span class="fa fa-fw {{vm.page('datasource-summary').icon}}"></span><span>List All</span>
+                    <span class="fa fa-fw {{vm.page('datasource-summary').icon}}"></span><span>Go to Summary</span>
                 </a>
                 <span></span>
                 <a ng-click="vm.selectPage('svcsource-new')" class="pull-right">
-                    <span class="fa fa-fw {{vm.page('svcsource-new').icon}}"></span><span>Create</span>
+                    <span class="fa fa-fw {{vm.page('svcsource-new').icon}}"></span><span>Configure Data Source</span>
                 </a>
             </p>
         </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/service-sources/svcsources.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/service-sources/svcsources.js
@@ -17,8 +17,8 @@
     function config(dashboardProvider, config, syntax) {
         dashboardProvider
             .widget('ds-svcsources', {
-                title: 'Workspace Sources',
-                description: 'Displays the current sources in the workspace',
+                title: 'Data Sources',
+                description: 'Displays the current Data Sources',
                 templateUrl: config.pluginDir + syntax.FORWARD_SLASH +
                                     pluginDirName + syntax.FORWARD_SLASH +
                                     'svcsources.html',


### PR DESCRIPTION
Incorporates wording changes on dashboard widgets that were brought up during demos.  For example changes "Workspace dataservices" to just "Data Services" (use of Workspace terminology was confusing)
