### PR TITLE
TEIIDTOOLS-140 Incorporates Text Mode Edit of service view

### DIFF
--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -63,7 +63,12 @@
     },
 
     "dataservice-edit" : {
-        "instructionsMsg" : "Change the definition of your Data Service by choosing a different data source and table"
+        "instructionsMsg" : "Change the definition of your Data Service by choosing a different data source and table",
+        "enableTextEditLbl" : "Enable Text Edit",
+        "expertTab" : "Expert Mode",
+        "sourceTablesLimitedMsg" : "Limit your view definition to use the following tables:",
+        "viewDdlTitle" : "View Definition",
+        "wizardTab" : "Wizard"
     },
 
     "dataservice-export" : {
@@ -90,9 +95,14 @@
 
     "dataservice-new" : {
         "configureSourceMsg" : "Before you can create a new Data Service, you will need to configure a data source. To configure a data source, click ",
+        "enableTextEditLbl" : "Enable Text Edit",
+        "expertTab" : "Expert Mode",
         "inputFieldsHelpMsg" : "Choose a name (and optional description) for your Data Service",
         "instructionsMsg" : "A Data Service can be composed of one or more of your available data sources. If you don't see your desired data source, click ",
-        "multiTableCheckbox" : "Join multiple tables"
+        "multiTableCheckbox" : "Join multiple tables",
+        "sourceTablesLimitedMsg" : "Limit your view definition to use the following tables:",
+        "viewDdlTitle" : "View Definition",
+        "wizardTab" : "Wizard"
     },
 
     "dataservice-summary" : {
@@ -156,7 +166,8 @@
         "getVdbModelTablesFailedMsg" : "Failed to get Vdb model tables",
         "selectedTables" : "Selected Tables",
         "stepTitle" : "Choose Data Sources",
-        "updateVdbFromDdlFailedMsg" : "Failed to construct temp Vdb from DDL"
+        "updateVdbFromDdlFailedMsg" : "Failed to construct temp Vdb from DDL",
+        "viewDdlTitle" : "View DDL"
     },
     
     "dsCloneController" : {

--- a/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
@@ -934,21 +934,26 @@
         /**
          * Service: Sets the DataService's service VDB using a single table source.
          * update an existing dataservice in the repository.
-         * If null columnNames is provided - means "include all columns"
+         * - If non-null viewDDL is supplied, it is used to define the view (overrides other provided args)
+         * - null or empty columnNames means "include all columns"
          */
-        service.setDataServiceVdbForSingleTable = function (dataserviceName, tablePath, modelSourcePath, columnNames) {
-            if (!dataserviceName || !tablePath || !modelSourcePath) {
+        service.setDataServiceVdbForSingleTable = function (dataserviceName, modelSourcePath, viewDdl, tablePath, columnNames) {
+            if (!dataserviceName || !modelSourcePath || !tablePath) {
                 throw RestServiceException("Data service update inputs are not defined");
             }
             
             return getRestService().then(function (restService) {
                 var payload = {
                     "dataserviceName": dataserviceName,
-                    "tablePath": getUserWorkspacePath()+"/"+tablePath,
-                    "modelSourcePath": getUserWorkspacePath()+"/"+modelSourcePath
+                    "modelSourcePath": getUserWorkspacePath()+"/"+modelSourcePath,
+                    "tablePath": getUserWorkspacePath()+"/"+tablePath
                 };
+                // Adds requested viewDdl if provided
+                if ( viewDdl && viewDdl.length>0 )  {
+                    payload.viewDdl = viewDdl;
+                }
                 // Adds requested column names if provided
-                if ( angular.isDefined(columnNames) && columnNames.length > 0 )  {
+                if ( columnNames && columnNames.length > 0 )  {
                     payload.columnNames = columnNames;
                 }
 
@@ -959,28 +964,104 @@
         /**
          * Service: Sets the DataService's service VDB using join tables
          * update an existing dataservice in the repository.
-         * If null columnNames is provided - means "include all columns"
+         * If non-null viewDdl is provided - it is used to set the view (overrides other supplied parameters)
+         * If null or empty columnNames are provided - means "include all columns"
          */
-        service.setDataServiceVdbForJoinTables = function (dataserviceName, tablePath, modelSourcePath, columnNames,
-                                                                            rhTablePath, rhModelSourcePath, rhColumnNames, 
+        service.setDataServiceVdbForJoinTables = function (dataserviceName, modelSourcePath, rhModelSourcePath, viewDdl,
+                                                                            tablePath, columnNames,
+                                                                            rhTablePath, rhColumnNames, 
                                                                             joinType, lhJoinColumnName, rhJoinColumnName) {
-            if (!dataserviceName || !tablePath || !modelSourcePath || 
-                                    !rhTablePath || !rhModelSourcePath || 
-                                    !joinType || !lhJoinColumnName || !rhJoinColumnName ) {
+            if (!dataserviceName || !modelSourcePath || !rhModelSourcePath || !tablePath || !rhTablePath) {
                 throw RestServiceException("Data service update inputs are not defined");
             }
             
             return getRestService().then(function (restService) {
                 var payload = {
                     "dataserviceName": dataserviceName,
-                    "tablePath": getUserWorkspacePath()+"/"+tablePath,
                     "modelSourcePath": getUserWorkspacePath()+"/"+modelSourcePath,
-                    "rhTablePath": getUserWorkspacePath()+"/"+rhTablePath,
                     "rhModelSourcePath": getUserWorkspacePath()+"/"+rhModelSourcePath,
-                    "joinType": joinType,
-                    "lhJoinColumn": lhJoinColumnName,
-                    "rhJoinColumn": rhJoinColumnName
+                    "tablePath": getUserWorkspacePath()+"/"+tablePath,
+                    "rhTablePath": getUserWorkspacePath()+"/"+rhTablePath
                 };
+                // Adds requested viewDdl if provided
+                if ( viewDdl && viewDdl.length > 0 )  {
+                    payload.viewDdl = viewDdl;
+                }
+                // Adds requested column names if provided
+                if ( columnNames && columnNames.length > 0 )  {
+                    payload.columnNames = columnNames;
+                }
+                // Adds requested rh column names if provided
+                if ( rhColumnNames && rhColumnNames.length > 0 )  {
+                    payload.rhColumnNames = rhColumnNames;
+                }
+                // Adds requested joinType if provided
+                if ( joinType && joinType.length > 0 )  {
+                    payload.joinType = joinType;
+                }
+                // Adds requested lhJoinColumn if provided
+                if ( lhJoinColumnName && lhJoinColumnName.length > 0 )  {
+                    payload.lhJoinColumn = lhJoinColumnName;
+                }
+                // Adds requested rhJoinColumn if provided
+                if ( rhJoinColumnName && rhJoinColumnName.length > 0 )  {
+                    payload.rhJoinColumn = rhJoinColumnName;
+                }
+
+                return restService.all(REST_URI.WORKSPACE + REST_URI.DATA_SERVICES + SYNTAX.FORWARD_SLASH + REST_URI.SERVICE_VDB_FOR_JOIN_TABLES).post(payload);
+            });
+        };
+
+        /**
+         * Service: Get the DataService View DDL based on the provided info.
+         */
+        service.getDataServiceViewDdlForSingleTable = function (dataserviceName, tablePath, columnNames) {
+            if (!dataserviceName || !tablePath ) {
+                throw RestServiceException("get View DDL inputs are not sufficiently defined");
+            }
+            
+            return getRestService().then(function (restService) {
+                var payload = {
+                    "dataserviceName": dataserviceName,
+                    "tablePath": getUserWorkspacePath()+"/"+tablePath
+                };
+                // Adds requested column names if provided
+                if ( columnNames && columnNames.length > 0 )  {
+                    payload.columnNames = columnNames;
+                }
+
+                return restService.all(REST_URI.WORKSPACE + REST_URI.DATA_SERVICES + SYNTAX.FORWARD_SLASH + REST_URI.SERVICE_VIEW_DDL_FOR_SINGLE_TABLE).post(payload);
+            });
+        };
+
+        /**
+         * Service: Get the DataService View DDL based on the provided info.
+         */
+        service.getDataServiceViewDdlForJoinTables = function (dataserviceName, tablePath, columnNames,
+                                                                                rhTablePath, rhColumnNames, 
+                                                                                joinType, lhJoinColumnName, rhJoinColumnName) {
+            if (!dataserviceName || !tablePath || !rhTablePath ) {
+                throw RestServiceException("get View DDL inputs are not sufficiently defined");
+            }
+            
+            return getRestService().then(function (restService) {
+                var payload = {
+                    "dataserviceName": dataserviceName,
+                    "tablePath": getUserWorkspacePath()+"/"+tablePath,
+                    "rhTablePath": getUserWorkspacePath()+"/"+rhTablePath
+                };
+                // Adds joinType if provided
+                if ( angular.isDefined(joinType) && joinType!==null )  {
+                    payload.joinType = joinType;
+                }
+                // Adds lhJoinColumn if provided
+                if ( angular.isDefined(lhJoinColumnName) && lhJoinColumnName!==null )  {
+                    payload.lhJoinColumn = lhJoinColumnName;
+                }
+                // Adds rhJoinColumn if provided
+                if ( angular.isDefined(rhJoinColumnName) && rhJoinColumnName!==null )  {
+                    payload.rhJoinColumn = rhJoinColumnName;
+                }
                 // Adds requested column names if provided
                 if ( angular.isDefined(columnNames) && columnNames.length > 0 )  {
                     payload.columnNames = columnNames;
@@ -990,7 +1071,7 @@
                     payload.rhColumnNames = rhColumnNames;
                 }
 
-                return restService.all(REST_URI.WORKSPACE + REST_URI.DATA_SERVICES + SYNTAX.FORWARD_SLASH + REST_URI.SERVICE_VDB_FOR_JOIN_TABLES).post(payload);
+                return restService.all(REST_URI.WORKSPACE + REST_URI.DATA_SERVICES + SYNTAX.FORWARD_SLASH + REST_URI.SERVICE_VIEW_DDL_FOR_JOIN_TABLES).post(payload);
             });
         };
 

--- a/vdb-bench-assembly/plugins/vdb-bench-core/constants.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/constants.js
@@ -71,6 +71,8 @@
             JDBC_CATALOG_SCHEMA: '/JdbcCatalogSchema',
             SERVICE_VDB_FOR_SINGLE_TABLE: 'ServiceVdbForSingleTable',
             SERVICE_VDB_FOR_JOIN_TABLES: 'ServiceVdbForJoinTables',
+            SERVICE_VIEW_DDL_FOR_SINGLE_TABLE: 'ServiceViewDdlForSingleTable',
+            SERVICE_VIEW_DDL_FOR_JOIN_TABLES: 'ServiceViewDdlForJoinTables',
             SERVICE_VIEW_INFO: 'serviceViewInfo',
             SOURCE_VDB_MATCHES: 'sourceVdbMatches',
             MODEL_FROM_TEIID_DDL: 'ModelFromTeiidDdl',

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-edit.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-edit.html
@@ -1,10 +1,30 @@
 <div id="outer" class="outer-wrapper">
 	<div id="dataservice-edit-container" class="container-fluid" ng-controller="DSEditController as vm">
 	
-	    <div id="dsEdit-edit-controls" ng-show="vm.svcSourcesLoading==false" class="row">
-            <div id="dataservice-edit-wizard" class="row col-md-12">
-                <dataservice-edit-wizard></dataservice-edit-wizard>
-            </div>
+	    <div id="dsEdit-edit-controls" ng-show="vm.svcSourcesLoading==false" class="col-md-12 row">
+            <uib-tabset>
+                <uib-tab heading="{{:: 'dataservice-edit.wizardTab' | translate}}" active="vm.wizardTabActive">
+                    <dataservice-edit-wizard></dataservice-edit-wizard>
+                </uib-tab>
+                <uib-tab heading="{{:: 'dataservice-edit.expertTab' | translate}}" active="vm.expertTabActive" disable="vm.disableExpertTab" ng-click="vm.onExpertTabSelected()">
+                    <div class="col-md-12">
+                        <h4 class="pull-left">{{'dataservice-edit.viewDdlTitle' | translate}}</h4>
+                    </div>
+                    <div class="col-md-12">
+                        <div ui-codemirror ng-model="vm.viewDdl" ui-codemirror-opts="vm.ddlEditorOptions" ui-refresh="vm.refreshViewDdl"></div>
+                    </div>
+                    <div class="col-md-12">
+                        <p><strong>{{'dataservice-edit.sourceTablesLimitedMsg' | translate}}</strong></p>
+                        <h4 ng-show="vm.sourceNames[0]!=null">&nbsp;&nbsp;{{vm.sourceNames[0]}}.{{vm.tableNames[0]}}</h4>
+                        <h4 ng-show="vm.sourceNames[1]!=null">&nbsp;&nbsp;{{vm.sourceNames[1]}}.{{vm.tableNames[1]}}</h4>
+                        <p>&nbsp;</p>
+                    </div>
+                    <div class="col-md-12">
+                        <input type="submit" class="btn btn-primary" value="{{:: 'shared.Finish' | translate}}" ng-click="vm.finishClicked()" />
+                        <input type="button" class="btn btn-default" value="{{:: 'shared.Cancel' | translate}}" ng-click="vmmain.selectPage('dataservice-summary')" />
+                    </div>
+                </uib-tab>
+            <uib-tabset>
 	    </div>
 	</div>
 </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-new.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-new.html
@@ -2,31 +2,45 @@
 	<div id="dataservice-new-container" class="container-fluid" ng-controller="DSNewController as vm">
 	
 	    <!-- Content shown if No Sources yet -->
-	    <div id="dataservice-new-nosources" ng-show="vm.hasSources==false" class="col-md-10 row">
-	        <div class="row">
-	            <div>
-	                <span translate="dataservice-new.configureSourceMsg" />
-	                    <a href ng-click="vmmain.selectPage('svcsource-new')">
-	                    <span class="fa fa-fw {{vmmain.page('svcsource-new').icon}}">
-	                </span>
-	                <span>{{vmmain.page('svcsource-new').title}}</span></a>
-	            </div>
-	        </div>
-	    </div>
-	    
-	    <div id="dataservice-new-controls" ng-show="vm.hasSources==true" class="row">
-            <div class="row col-md-12">
-                <h4>
-                    <span translate="dataservice-new.instructionsMsg" />
-                        <a href ng-click="vmmain.selectPage('svcsource-new')">
-                        <span class="fa fa-fw {{vmmain.page('svcsource-new').icon}}">
-                    </span>
-                    <span>{{vmmain.page('svcsource-new').title}}</span></a>
-                </h4>
-            </div>
-            <div id="dataservice-edit-wizard" class="row col-md-12">
-                <dataservice-edit-wizard></dataservice-edit-wizard>
-            </div>
-	    </div>
-	</div>
+	    <div id="dataservice-new-nosources" ng-show="vm.hasSources==false" class="col-md-12 row">
+            <span translate="dataservice-new.configureSourceMsg" />
+                <a href ng-click="vmmain.selectPage('svcsource-new')">
+                <span class="fa fa-fw {{vmmain.page('svcsource-new').icon}}">
+            </span>
+            <span>{{vmmain.page('svcsource-new').title}}</span></a>
+        </div>
+
+        <div id="dataservice-new-controls" ng-show="vm.hasSources==true" class="col-md-12 row">
+            <h4>
+                <span translate="dataservice-new.instructionsMsg" />
+                    <a href ng-click="vmmain.selectPage('svcsource-new')">
+                    <span class="fa fa-fw {{vmmain.page('svcsource-new').icon}}">
+                </span>
+                <span>{{vmmain.page('svcsource-new').title}}</span></a>
+            </h4>
+            <uib-tabset>
+                <uib-tab heading="{{:: 'dataservice-new.wizardTab' | translate}}">
+                    <dataservice-edit-wizard></dataservice-edit-wizard>
+                </uib-tab>
+                <uib-tab heading="{{:: 'dataservice-new.expertTab' | translate}}" disable="vm.disableExpertTab" ng-click="vm.onExpertTabSelected()">
+                    <div class="col-md-12">
+                        <h4 class="pull-left">{{'dataservice-new.viewDdlTitle' | translate}}</h4>
+                    </div>
+                    <div class="col-md-12">
+                        <div ui-codemirror ng-model="vm.viewDdl" ui-codemirror-opts="vm.ddlEditorOptions" ui-refresh="vm.refreshViewDdl"></div>
+                    </div>
+                    <div class="col-md-12">
+                        <p><strong>{{'dataservice-new.sourceTablesLimitedMsg' | translate}}</strong></p>
+                        <h4 ng-show="vm.sourceNames[0]!=null">&nbsp;&nbsp;{{vm.sourceNames[0]}}.{{vm.tableNames[0]}}</h4>
+                        <h4 ng-show="vm.sourceNames[1]!=null">&nbsp;&nbsp;{{vm.sourceNames[1]}}.{{vm.tableNames[1]}}</h4>
+                        <p>&nbsp;</p>
+                    </div>
+                    <div class="col-md-12">
+                        <input type="submit" class="btn btn-primary" value="{{:: 'shared.Finish' | translate}}" ng-click="vm.finishClicked()" />
+                        <input type="button" class="btn btn-default" value="{{:: 'shared.Cancel' | translate}}" ng-click="vmmain.selectPage('dataservice-summary')" />
+                    </div>
+                </uib-tab>
+            <uib-tabset>
+       </div>
+
 </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsEditController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsEditController.js
@@ -8,11 +8,21 @@
         .module(pluginName)
         .controller('DSEditController', DSEditController);
 
-    DSEditController.$inject = ['SvcSourceSelectionService', 'DSSelectionService', 'DSPageService'];
+    DSEditController.$inject = ['$scope', '$document', '$translate', 'SYNTAX', 'RepoRestService', 
+                                'EditWizardService', 'SvcSourceSelectionService', 'DSSelectionService', 'DSPageService'];
 
-    function DSEditController(SvcSourceSelectionService, DSSelectionService, DSPageService) {
+    function DSEditController($scope, $document, $translate, SYNTAX, 
+                              RepoRestService, EditWizardService, SvcSourceSelectionService, DSSelectionService, DSPageService) {
         var vm = this;
-        
+        var DEFAULT_VIEW = "CREATE VIEW ServiceView ( ) AS SELECT * FROM aTable;";
+        vm.viewDdl = "";
+        vm.refreshViewDdl = false;
+        vm.wizardTabActive = true;
+        vm.expertTabActive = false;
+        vm.disableExpertTab = EditWizardService.sourceTables().length === 0;
+        vm.sourceNames = [];
+        vm.tableNames = [];
+
         /*
          * Set a custom title to the page including the data service's id
          */
@@ -20,6 +30,352 @@
         DSPageService.setCustomTitle(page.id, page.title + " '" + DSSelectionService.selectedDataService().keng__id + "'");
 
         vm.svcSourcesLoading = SvcSourceSelectionService.isLoading();
+
+        /*
+         * Determine initial tab displayed
+         */
+        $document.ready(function () {
+            setActiveTab();
+            setViewDdlFromEditor(true);
+        });
+
+        function setActiveTab() {
+            if(EditWizardService.viewEditable()) {
+                vm.wizardTabActive = true;
+                vm.expertTabActive = false;
+            } else {
+                vm.wizardTabActive = false;
+                vm.expertTabActive = true;
+            }
+        }
+
+        /**
+         * Expert tab selected.  Get selections from EditWizardService to populate text view.
+         */
+        vm.onExpertTabSelected = function() {
+            setViewDdlFromEditor(false);
+        };
+
+        /**
+         * Sets the View DDL based on the current editor selections
+         * pageInit 'true' if page first initialization (use EditWizardService viewDdl)
+         * pageInit 'false' if user manually selects expert tab (uses EditWizardService params to generate new DDL)
+         */
+        function setViewDdlFromEditor(pageInit) {
+            var dataserviceName = EditWizardService.serviceName();
+            vm.sourceNames = EditWizardService.sources();
+            vm.tableNames = EditWizardService.sourceTables();
+
+            // -------------------------------------------------
+            // One table selected
+            // -------------------------------------------------
+            if(vm.tableNames.length===0) {
+                vm.viewDdl = EditWizardService.viewDdl();
+                vm.refreshViewDdl = !vm.refreshViewDdl;
+            // -------------------------------------------------
+            // One table selected
+            // -------------------------------------------------
+            } else if(vm.tableNames.length==1) {
+                // --------------------------------------------
+                // Success callback returns the source 1 model
+                // --------------------------------------------
+                var singleSuccessCallback = function(model) {
+                    // Page init - use EditWizardService DDL
+                    if(pageInit) {
+                        vm.viewDdl = EditWizardService.viewDdl();
+                        vm.refreshViewDdl = !vm.refreshViewDdl;
+                    // User tab change - regenerate DDL from wizard selections
+                    } else {
+                        var selSvcSourceModelName = model.keng__id;
+
+                        // Path to table for definition of the dataservice vdb
+                        var relativeTablePath = SYNTAX.TEMP+vm.sourceNames[0]+"/"+selSvcSourceModelName+"/"+vm.tableNames[0];
+
+                        // Columns to include in the service
+                        var columnNames = [];
+                        // Get column subset if not including all columns.
+                        if(!vm.includeAllColumns) {
+                            columnNames = EditWizardService.source1SelectedColumns();
+                        }
+
+                        try {
+                            RepoRestService.getDataServiceViewDdlForSingleTable( dataserviceName, relativeTablePath, columnNames ).then(
+                                function ( result ) {
+                                    // View info
+                                    vm.viewDdl = result.viewDdl;
+                                    vm.refreshViewDdl = !vm.refreshViewDdl;
+                                },
+                                function (response) {
+                                    vm.viewDdl = DEFAULT_VIEW;
+                                    vm.refreshViewDdl = !vm.refreshViewDdl;
+                                     throw RepoRestService.newRestException($translate.instant('dsNewController.saveFailedMsg', 
+                                                                                             {response: RepoRestService.responseMessage(response)}));
+                                });
+                        } catch (error) {
+                            vm.viewDdl = DEFAULT_VIEW;
+                            vm.refreshViewDdl = !vm.refreshViewDdl;
+                        }
+                    }
+                };
+
+                // Failure callback
+                var singleFailureCallback = function(errorMsg) {
+                    alert($translate.instant('shared.changedConnectionFailedMsg', {errorMsg: errorMsg}));
+                };
+
+                // get model for source 1
+                getModelForSource(EditWizardService.sources()[0], singleSuccessCallback, singleFailureCallback);
+            // -------------------------------------------------
+            // Two tables selected
+            // -------------------------------------------------
+            } else if (vm.tableNames.length==2) {
+                // --------------------------------------------
+                // Success callback returns the source models
+                // --------------------------------------------
+                var joinSuccessCallback = function(models) {
+                    // Page init - use EditWizardService DDL
+                    if(pageInit) {
+                        vm.viewDdl = EditWizardService.viewDdl();
+                        vm.refreshViewDdl = !vm.refreshViewDdl;
+                    // User tab change - regenerate DDL from wizard selections
+                    } else {
+                        var lhSourceModelName = models[0].keng__id;
+                        var rhSourceModelName = models[1].keng__id;
+
+                        // Path for LH table
+                        var lhRelativeTablePath = SYNTAX.TEMP+vm.sourceNames[0]+"/"+lhSourceModelName+"/"+vm.tableNames[0];
+                        // Path for RH table
+                        var rhRelativeTablePath = SYNTAX.TEMP+vm.sourceNames[1]+"/"+rhSourceModelName+"/"+vm.tableNames[1];
+                        
+                        // Columns to include in the service
+                        var lhColumnNames = EditWizardService.source1SelectedColumns();
+                        var rhColumnNames = EditWizardService.source2SelectedColumns();
+                        
+                        // Join criteria columns
+                        var lhJoinColumnName = null;
+                        if(EditWizardService.source1CriteriaColumn() !== null) {
+                            lhJoinColumnName = EditWizardService.source1CriteriaColumn().keng__id;
+                        }
+                        var rhJoinColumnName = null;
+                        if(EditWizardService.source2CriteriaColumn() !== null) {
+                            rhJoinColumnName = EditWizardService.source2CriteriaColumn().keng__id;
+                        }
+                        
+                        // Join type
+                        var joinType = EditWizardService.joinType();
+                        
+                        try {
+                            RepoRestService.getDataServiceViewDdlForJoinTables( dataserviceName, lhRelativeTablePath, lhColumnNames,
+                                                                                                 rhRelativeTablePath, rhColumnNames, 
+                                                                                                 joinType, lhJoinColumnName, rhJoinColumnName).then(
+                                function (result) {
+                                    // View info
+                                    vm.viewDdl = result.viewDdl;
+                                    vm.refreshViewDdl = !vm.refreshViewDdl;
+                                },
+                                function (response) {
+                                    vm.viewDdl = DEFAULT_VIEW;
+                                    vm.refreshViewDdl = !vm.refreshViewDdl;
+                                    throw RepoRestService.newRestException($translate.instant('dsNewController.saveFailedMsg', 
+                                                                                              {response: RepoRestService.responseMessage(response)}));
+                                });
+                        } catch (error) {
+                            vm.viewDdl = DEFAULT_VIEW;
+                            vm.refreshViewDdl = !vm.refreshViewDdl;
+                        }
+                    }
+                };
+
+                // Failure callback
+                var joinFailureCallback = function(errorMsg) {
+                    vm.viewDdl = DEFAULT_VIEW;
+                    vm.refreshViewDdl = !vm.refreshViewDdl;
+                    alert($translate.instant('shared.changedConnectionFailedMsg', {errorMsg: errorMsg}));
+                };
+
+                // get models for sources
+                getModelsForSources(EditWizardService.sources(), joinSuccessCallback, joinFailureCallback);
+            }
+        }
+
+        /**
+         * Handler for finish update button
+         */
+        vm.finishClicked = function() {
+            var svcName = EditWizardService.serviceName();
+            var svcDescription = EditWizardService.serviceDescription();
+            
+            try {
+                RepoRestService.updateDataService( svcName, svcDescription ).then(
+                    function () {
+                        setDataserviceServiceVdb(svcName);
+                    },
+                    function (response) {
+                        var errorMsg = $translate.instant('dataserviceEditWizard.updateDataserviceFailedMsg');
+                        throw RepoRestService.newRestException(errorMsg + "\n" + RepoRestService.responseMessage(response));
+                    });
+            } catch (error) {
+                var errorMsg = $translate.instant('dataserviceEditWizard.updateDataserviceFailedMsg');
+                throw RepoRestService.newRestException(errorMsg + "\n" + error);
+            }
+        };
+
+        /**
+         * Sets the dataservice VDB based on one or two tables selected.
+         */
+        function setDataserviceServiceVdb( dataserviceName ) {
+            vm.sourceNames = EditWizardService.sources();
+            vm.tableNames = EditWizardService.sourceTables();
+
+            // -------------------------------------------------
+            // One table selected
+            // -------------------------------------------------
+            if(vm.tableNames.length==1) {
+                // --------------------------------------------
+                // Success callback returns the source 1 model
+                // --------------------------------------------
+                var singleSuccessCallback = function(model) {
+                    var selSvcSourceModelName = model.keng__id;
+
+                    // Path to modelSource and temp table for definition of the dataservice vdb
+                    var relativeModelSourcePath = vm.sourceNames[0]+"/"+selSvcSourceModelName+"/vdb:sources/"+selSvcSourceModelName;
+                    var relativeTablePath = SYNTAX.TEMP+vm.sourceNames[0]+"/"+selSvcSourceModelName+"/"+vm.tableNames[0];
+
+                    try {
+                        RepoRestService.setDataServiceVdbForSingleTable( dataserviceName, relativeModelSourcePath, vm.viewDdl, relativeTablePath, null ).then(
+                            function () {
+                                // Reinitialise the list of data services
+                                DSSelectionService.refresh('dataservice-summary');
+                            },
+                            function (response) {
+                                throw RepoRestService.newRestException($translate.instant('dsNewController.saveFailedMsg', 
+                                                                                          {response: RepoRestService.responseMessage(response)}));
+                            });
+                    } catch (error) {
+                    }
+                };
+
+                // Failure callback
+                var singleFailureCallback = function(errorMsg) {
+                    alert($translate.instant('shared.changedConnectionFailedMsg', {errorMsg: errorMsg}));
+                };
+
+                // get model for source 1
+                getModelForSource(EditWizardService.sources()[0], singleSuccessCallback, singleFailureCallback);
+            // -------------------------------------------------
+            // Two tables selected
+            // -------------------------------------------------
+            } else if (vm.tableNames.length==2) {
+                // --------------------------------------------
+                // Success callback returns the source models
+                // --------------------------------------------
+                var joinSuccessCallback = function(models) {
+                    var lhSourceModelName = models[0].keng__id;
+                    var rhSourceModelName = models[1].keng__id;
+
+                    // Path for LH model source and temp table
+                    var lhRelativeModelSourcePath = vm.sourceNames[0]+"/"+lhSourceModelName+"/vdb:sources/"+lhSourceModelName;
+                    var lhRelativeTablePath = SYNTAX.TEMP+vm.sourceNames[0]+"/"+lhSourceModelName+"/"+vm.tableNames[0];
+                    // Path for RH model source and temp table
+                    var rhRelativeModelSourcePath = vm.sourceNames[1]+"/"+rhSourceModelName+"/vdb:sources/"+rhSourceModelName;
+                    var rhRelativeTablePath = SYNTAX.TEMP+vm.sourceNames[1]+"/"+rhSourceModelName+"/"+vm.tableNames[1];
+
+                    // Join type
+                    var joinType = EditWizardService.joinType();
+                    
+                    try {
+                        RepoRestService.setDataServiceVdbForJoinTables( dataserviceName, lhRelativeModelSourcePath, rhRelativeModelSourcePath, vm.viewDdl,
+                                                                                         lhRelativeTablePath, null, rhRelativeTablePath, null, null, null, null).then(
+                            function () {
+                                // Reinitialise the list of data services
+                                DSSelectionService.refresh('dataservice-summary');
+                            },
+                            function (response) {
+                                throw RepoRestService.newRestException($translate.instant('dsNewController.saveFailedMsg', 
+                                                                                          {response: RepoRestService.responseMessage(response)}));
+                            });
+                    } catch (error) {
+                    }
+                };
+
+                // Failure callback
+                var joinFailureCallback = function(errorMsg) {
+                    alert($translate.instant('shared.changedConnectionFailedMsg', {errorMsg: errorMsg}));
+                };
+
+                // get models for sources
+                getModelsForSources(EditWizardService.sources(), joinSuccessCallback, joinFailureCallback);
+            }
+        }
+
+        /*
+         * success callback has the model for the requested source
+         */
+        function getModelForSource(sourceName, onSuccessCallback, onFailureCallback) {
+            try {
+                RepoRestService.getVdbModels(sourceName).then(
+                    function (models) {
+                        if (_.isEmpty(models) || models.length === 0) {
+                            onFailureCallback("Failed getting VDB Models.\nThe source model is not available");
+                            return;
+                        }
+
+                        onSuccessCallback(models[0]);
+                    },
+                    function (response) {
+                        vm.viewDdl = DEFAULT_VIEW;
+                        vm.refreshViewDdl = !vm.refreshViewDdl;
+                        onFailureCallback("Failed getting VDB Models.\n" + RepoRestService.responseMessage(response));
+                    });
+            } catch (error) {
+                vm.viewDdl = DEFAULT_VIEW;
+                vm.refreshViewDdl = !vm.refreshViewDdl;
+                onFailureCallback("An exception occurred:\n" + error.message);
+            }
+        }
+
+        /*
+         * success callback has the models for the requested sources
+         */
+        function getModelsForSources(sourceNames, onSuccessCallback, onFailureCallback) {
+            var resultModels = [];
+
+            // Success callback returns the source 1 model
+            var successCallback = function(model) {
+                resultModels.push(model);
+                
+                // Call again to get the second model
+                var innerSuccessCallback = function(model) {
+                    resultModels.push(model);
+                    onSuccessCallback(resultModels);
+                };
+                var innerFailureCallback = function(errorMsg) {
+                    onFailureCallback("An exception occurred: \n" + errorMsg.message);
+                };
+                
+                getModelForSource(sourceNames[1], innerSuccessCallback, innerFailureCallback);
+            };
+
+            // Failure callback
+            var failureCallback = function(errorMsg) {
+                alert($translate.instant('shared.changedConnectionFailedMsg', {errorMsg: errorMsg}));
+            };
+            
+            getModelForSource(sourceNames[0], successCallback, failureCallback);
+        }
+
+        /**
+         * Options for the codemirror editor used for editing ddl
+         */
+        vm.ddlEditorOptions = {
+            lineWrapping: true,
+            lineNumbers: true,
+            mode: 'text/x-sql'
+        };
+
+        vm.ddlEditorLoaded = function(_editor) {
+            // Nothing to do at the moment
+        };
 
     }
     

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsNewController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsNewController.js
@@ -8,12 +8,353 @@
         .module(pluginName)
         .controller('DSNewController', DSNewController);
 
-    DSNewController.$inject = ['SvcSourceSelectionService'];
+    DSNewController.$inject = ['$scope', '$translate', 'SYNTAX', 'RepoRestService', 
+                               'EditWizardService', 'DSSelectionService', 'SvcSourceSelectionService'];
 
-    function DSNewController(SvcSourceSelectionService) {
+    function DSNewController($scope, $translate, SYNTAX, RepoRestService, EditWizardService, DSSelectionService, SvcSourceSelectionService) {
         var vm = this;
         
         vm.hasSources = SvcSourceSelectionService.getServiceSources().length>0;
+        var DEFAULT_VIEW = "CREATE VIEW ServiceView ( ) AS SELECT * FROM aTable;";
+        vm.viewDdl = "";
+        vm.refreshViewDdl = false;
+        vm.disableExpertTab = true;
+        vm.sourceNames = [];
+        vm.tableNames = [];
+
+        /*
+         * Handle change of EditWizardService tables
+         */
+        $scope.$on('editWizardTablesChanged', function (event) {
+            vm.sourceNames = EditWizardService.sources();
+            vm.tableNames = EditWizardService.sourceTables();
+            setExpertTabEnablement();
+        });
+
+        $scope.$on('editWizardServiceNameChanged', function (event) {
+            setExpertTabEnablement();
+        });
+
+        /**
+         * Set Expert Tab enablement
+         */
+        function setExpertTabEnablement() {
+            if(vm.tableNames.length === 0 || EditWizardService.serviceName().length === 0) {
+                vm.disableExpertTab = true;
+            } else {
+                vm.disableExpertTab = false;
+            }
+        }
+
+        /**
+         * Expert tab selected.  Get selections from EditWizardService to populate text view.
+         */
+        vm.onExpertTabSelected = function() {
+            setViewDdlFromEditor();
+        };
+
+        /**
+         * Sets the View DDL based on the current editor selections
+         */
+        function setViewDdlFromEditor() {
+            var dataserviceName = EditWizardService.serviceName();
+            vm.sourceNames = EditWizardService.sources();
+            vm.tableNames = EditWizardService.sourceTables();
+
+            // -------------------------------------------------
+            // One table selected
+            // -------------------------------------------------
+            if(vm.tableNames.length===0) {
+                vm.viewDdl = DEFAULT_VIEW;
+                vm.refreshViewDdl = !vm.refreshViewDdl;
+            // -------------------------------------------------
+            // One table selected
+            // -------------------------------------------------
+            } else if(vm.tableNames.length==1) {
+                // --------------------------------------------
+                // Success callback returns the source 1 model
+                // --------------------------------------------
+                var singleSuccessCallback = function(model) {
+                    var selSvcSourceModelName = model.keng__id;
+
+                    // Path to table for definition of the dataservice vdb
+                    var relativeTablePath = SYNTAX.TEMP+vm.sourceNames[0]+"/"+selSvcSourceModelName+"/"+vm.tableNames[0];
+
+                    // Columns to include in the service
+                    var columnNames = [];
+                    // Get column subset if not including all columns.
+                    if(!vm.includeAllColumns) {
+                        columnNames = EditWizardService.source1SelectedColumns();
+                    }
+
+                    try {
+                        RepoRestService.getDataServiceViewDdlForSingleTable( dataserviceName, relativeTablePath, columnNames ).then(
+                            function ( result ) {
+                                // View info
+                                vm.viewDdl = result.viewDdl;
+                                vm.refreshViewDdl = !vm.refreshViewDdl;
+                            },
+                            function (response) {
+                                vm.viewDdl = DEFAULT_VIEW;
+                                vm.refreshViewDdl = !vm.refreshViewDdl;
+                                 throw RepoRestService.newRestException($translate.instant('dsNewController.saveFailedMsg', 
+                                                                                         {response: RepoRestService.responseMessage(response)}));
+                            });
+                    } catch (error) {
+                        vm.viewDdl = DEFAULT_VIEW;
+                        vm.refreshViewDdl = !vm.refreshViewDdl;
+                    }
+                };
+
+                // Failure callback
+                var singleFailureCallback = function(errorMsg) {
+                    alert($translate.instant('shared.changedConnectionFailedMsg', {errorMsg: errorMsg}));
+                };
+
+                // get model for source 1
+                getModelForSource(EditWizardService.sources()[0], singleSuccessCallback, singleFailureCallback);
+            // -------------------------------------------------
+            // Two tables selected
+            // -------------------------------------------------
+            } else if (vm.tableNames.length==2) {
+                // --------------------------------------------
+                // Success callback returns the source models
+                // --------------------------------------------
+                var joinSuccessCallback = function(models) {
+                    var lhSourceModelName = models[0].keng__id;
+                    var rhSourceModelName = models[1].keng__id;
+
+                    // Path for LH table
+                    var lhRelativeTablePath = SYNTAX.TEMP+vm.sourceNames[0]+"/"+lhSourceModelName+"/"+vm.tableNames[0];
+                    // Path for RH table
+                    var rhRelativeTablePath = SYNTAX.TEMP+vm.sourceNames[1]+"/"+rhSourceModelName+"/"+vm.tableNames[1];
+                    
+                    // Columns to include in the service
+                    var lhColumnNames = EditWizardService.source1SelectedColumns();
+                    var rhColumnNames = EditWizardService.source2SelectedColumns();
+                    
+                    // Join criteria columns
+                    var lhJoinColumnName = null;
+                    if(EditWizardService.source1CriteriaColumn() !== null) {
+                        lhJoinColumnName = EditWizardService.source1CriteriaColumn().keng__id;
+                    }
+                    var rhJoinColumnName = null;
+                    if(EditWizardService.source2CriteriaColumn() !== null) {
+                        rhJoinColumnName = EditWizardService.source2CriteriaColumn().keng__id;
+                    }
+                    
+                    // Join type
+                    var joinType = EditWizardService.joinType();
+                    
+                    try {
+                        RepoRestService.getDataServiceViewDdlForJoinTables( dataserviceName, lhRelativeTablePath, lhColumnNames,
+                                                                                             rhRelativeTablePath, rhColumnNames, 
+                                                                                             joinType, lhJoinColumnName, rhJoinColumnName).then(
+                            function (result) {
+                                // View info
+                                vm.viewDdl = result.viewDdl;
+                                vm.refreshViewDdl = !vm.refreshViewDdl;
+                            },
+                            function (response) {
+                                vm.viewDdl = DEFAULT_VIEW;
+                                vm.refreshViewDdl = !vm.refreshViewDdl;
+                                throw RepoRestService.newRestException($translate.instant('dsNewController.saveFailedMsg', 
+                                                                                          {response: RepoRestService.responseMessage(response)}));
+                            });
+                    } catch (error) {
+                        vm.viewDdl = DEFAULT_VIEW;
+                        vm.refreshViewDdl = !vm.refreshViewDdl;
+                    }
+                };
+
+                // Failure callback
+                var joinFailureCallback = function(errorMsg) {
+                    vm.viewDdl = DEFAULT_VIEW;
+                    vm.refreshViewDdl = !vm.refreshViewDdl;
+                    alert($translate.instant('shared.changedConnectionFailedMsg', {errorMsg: errorMsg}));
+                };
+
+                // get models for sources
+                getModelsForSources(EditWizardService.sources(), joinSuccessCallback, joinFailureCallback);
+            }
+        }
+
+        /**
+         * Handler for finish create button
+         */
+        vm.finishClicked = function() {
+            var svcName = EditWizardService.serviceName();
+            var svcDescription = EditWizardService.serviceDescription();
+            
+            try {
+                RepoRestService.createDataService( svcName, svcDescription ).then(
+                    function () {
+                        setDataserviceServiceVdb(svcName);
+                    },
+                    function (response) {
+                        var errorMsg = $translate.instant('dataserviceEditWizard.createDataserviceFailedMsg');
+                        throw RepoRestService.newRestException(errorMsg + "\n" + RepoRestService.responseMessage(response));
+                    });
+            } catch (error) {
+                var errorMsg = $translate.instant('dataserviceEditWizard.createDataserviceFailedMsg');
+                throw RepoRestService.newRestException(errorMsg + "\n" + error);
+            }
+        };
+        
+        
+        /**
+         * Sets the dataservice VDB based on one or two tables selected.
+         */
+        function setDataserviceServiceVdb( dataserviceName ) {
+            // -------------------------------------------------
+            // One table selected
+            // -------------------------------------------------
+            if(vm.tableNames.length==1) {
+                var sourceName = vm.sourceNames[0];
+                var tableName = vm.tableNames[0];
+
+                // --------------------------------------------
+                // Success callback returns the source 1 model
+                // --------------------------------------------
+                var singleSuccessCallback = function(model) {
+                    var selSvcSourceModelName = model.keng__id;
+
+                    // Path to modelSource and temp table for definition of the dataservice vdb
+                    var relativeModelSourcePath = sourceName+"/"+selSvcSourceModelName+"/vdb:sources/"+selSvcSourceModelName;
+                    var relativeTablePath = SYNTAX.TEMP+sourceName+"/"+selSvcSourceModelName+"/"+tableName;
+
+                    try {
+                        RepoRestService.setDataServiceVdbForSingleTable( dataserviceName, relativeModelSourcePath, vm.viewDdl, relativeTablePath, null ).then(
+                            function () {
+                                // Reinitialise the list of data services
+                                DSSelectionService.refresh('dataservice-summary');
+                            },
+                            function (response) {
+                                throw RepoRestService.newRestException($translate.instant('dsNewController.saveFailedMsg', 
+                                                                                          {response: RepoRestService.responseMessage(response)}));
+                            });
+                    } catch (error) {
+                    }
+                };
+
+                // Failure callback
+                var singleFailureCallback = function(errorMsg) {
+                    alert($translate.instant('shared.changedConnectionFailedMsg', {errorMsg: errorMsg}));
+                };
+
+                // get model for source 1
+                getModelForSource(EditWizardService.sources()[0], singleSuccessCallback, singleFailureCallback);
+            // -------------------------------------------------
+            // Two tables selected
+            // -------------------------------------------------
+            } else if (vm.tableNames.length==2) {
+                // --------------------------------------------
+                // Success callback returns the source models
+                // --------------------------------------------
+                var joinSuccessCallback = function(models) {
+                    var lhSourceModelName = models[0].keng__id;
+                    var rhSourceModelName = models[1].keng__id;
+
+                    // Path for LH model source and temp table
+                    var lhRelativeModelSourcePath = vm.sourceNames[0]+"/"+lhSourceModelName+"/vdb:sources/"+lhSourceModelName;
+                    var lhRelativeTablePath = SYNTAX.TEMP+vm.sourceNames[0]+"/"+lhSourceModelName+"/"+vm.tableNames[0];
+                    // Path for RH model source and temp table
+                    var rhRelativeModelSourcePath = vm.sourceNames[1]+"/"+rhSourceModelName+"/vdb:sources/"+rhSourceModelName;
+                    var rhRelativeTablePath = SYNTAX.TEMP+vm.sourceNames[1]+"/"+rhSourceModelName+"/"+vm.tableNames[1];
+
+                    try {
+                        RepoRestService.setDataServiceVdbForJoinTables( dataserviceName, lhRelativeModelSourcePath, rhRelativeModelSourcePath, vm.viewDdl,
+                                                                        lhRelativeTablePath, null, rhRelativeTablePath, null, null, null, null).then(
+                            function () {
+                                // Reinitialise the list of data services
+                                DSSelectionService.refresh('dataservice-summary');
+                            },
+                            function (response) {
+                                throw RepoRestService.newRestException($translate.instant('dsNewController.saveFailedMsg', 
+                                                                                          {response: RepoRestService.responseMessage(response)}));
+                            });
+                    } catch (error) {
+                    }
+                };
+
+                // Failure callback
+                var joinFailureCallback = function(errorMsg) {
+                    alert($translate.instant('shared.changedConnectionFailedMsg', {errorMsg: errorMsg}));
+                };
+
+                // get models for sources
+                getModelsForSources(EditWizardService.sources(), joinSuccessCallback, joinFailureCallback);
+            }
+        }
+
+        /*
+         * success callback has the model for the requested source
+         */
+        function getModelForSource(sourceName, onSuccessCallback, onFailureCallback) {
+            try {
+                RepoRestService.getVdbModels(sourceName).then(
+                    function (models) {
+                        if (_.isEmpty(models) || models.length === 0) {
+                            onFailureCallback("Failed getting VDB Models.\nThe source model is not available");
+                            return;
+                        }
+
+                        onSuccessCallback(models[0]);
+                    },
+                    function (response) {
+                        vm.viewDdl = DEFAULT_VIEW;
+                        vm.refreshViewDdl = !vm.refreshViewDdl;
+                        onFailureCallback("Failed getting VDB Models.\n" + RepoRestService.responseMessage(response));
+                    });
+            } catch (error) {
+                vm.viewDdl = DEFAULT_VIEW;
+                vm.refreshViewDdl = !vm.refreshViewDdl;
+                onFailureCallback("An exception occurred:\n" + error.message);
+            }
+        }
+
+        /*
+         * success callback has the models for the requested sources
+         */
+        function getModelsForSources(sourceNames, onSuccessCallback, onFailureCallback) {
+            var resultModels = [];
+
+            // Success callback returns the source 1 model
+            var successCallback = function(model) {
+                resultModels.push(model);
+                
+                // Call again to get the second model
+                var innerSuccessCallback = function(model) {
+                    resultModels.push(model);
+                    onSuccessCallback(resultModels);
+                };
+                var innerFailureCallback = function(errorMsg) {
+                    onFailureCallback("An exception occurred: \n" + errorMsg.message);
+                };
+                
+                getModelForSource(sourceNames[1], innerSuccessCallback, innerFailureCallback);
+            };
+
+            // Failure callback
+            var failureCallback = function(errorMsg) {
+                alert($translate.instant('shared.changedConnectionFailedMsg', {errorMsg: errorMsg}));
+            };
+            
+            getModelForSource(sourceNames[0], successCallback, failureCallback);
+        }
+
+        /**
+         * Options for the codemirror editor used for editing ddl
+         */
+        vm.ddlEditorOptions = {
+            lineWrapping: true,
+            lineNumbers: true,
+            mode: 'text/x-sql'
+        };
+
+        vm.ddlEditorLoaded = function(_editor) {
+            // Nothing to do at the moment
+        };
 
     }
 

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/EditWizardService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/EditWizardService.js
@@ -10,9 +10,9 @@
         .module('vdb-bench.dataservice')
         .factory('EditWizardService', EditWizardService);
 
-    EditWizardService.$inject = ['$rootScope', 'RepoRestService', 'JOIN'];
+    EditWizardService.$inject = ['$rootScope', '$translate', 'RepoRestService', 'JOIN'];
 
-    function EditWizardService($rootScope, RepoRestService, JOIN) {
+    function EditWizardService($rootScope, $translate, RepoRestService, JOIN) {
 
         var wiz = {};
         wiz.serviceName = "";
@@ -30,6 +30,8 @@
         wiz.src2CriteriaColumnName = "";
         wiz.src1CriteriaColumn = null;
         wiz.src2CriteriaColumn = null;
+        wiz.viewEditable = false;
+        wiz.viewDdl = "";
 
         /*
          * Service instance to be returned
@@ -56,7 +58,7 @@
             } else {
                 wiz.serviceName = dataservice.keng__id;
                 wiz.serviceDescription = dataservice.tko__description;
-                initSourceAndTableSelections(dataservice.keng__id, pageId);
+                initServiceSelections(dataservice.keng__id, pageId);
             }
         };
 
@@ -78,6 +80,12 @@
             wiz.src2CriteriaColumnName = "";
             wiz.src1CriteriaColumn = null;
             wiz.src2CriteriaColumn = null;
+            wiz.viewEditable = false;
+            wiz.viewDdl = "";
+            // Broadcast table change
+            $rootScope.$broadcast("editWizardTablesChanged");
+            // Broadcast name changed
+            $rootScope.$broadcast("editWizardServiceNameChanged");
         }
 
         /*
@@ -113,6 +121,8 @@
          */
         service.setServiceName = function(name) {
             wiz.serviceName = name;
+            // Broadcast name changed
+            $rootScope.$broadcast("editWizardServiceNameChanged");
         };
 
         /*
@@ -147,6 +157,34 @@
         };
 
         /*
+         * Set the dataservice view DDL
+         */
+        service.setViewDdl = function(ddl) {
+            wiz.viewDdl = ddl;
+        };
+
+        /*
+         * Get the dataservice description
+         */
+        service.viewDdl = function() {
+            return wiz.viewDdl;
+        };
+
+        /*
+         * Set the dataservice view editable status
+         */
+        service.setViewEditable = function(editable) {
+            wiz.viewEditable = editable;
+        };
+
+        /*
+         * Get the dataservice view editable status
+         */
+        service.viewEditable = function() {
+            return wiz.viewEditable;
+        };
+
+        /*
          * Reset the source tables
          */
         service.resetSourceTables = function() {
@@ -154,6 +192,8 @@
             wiz.sourceTables = [];
             wiz.src1AvailableColumns = [];
             wiz.src2AvailableColumns = [];
+            // Broadcast table change
+            $rootScope.$broadcast("editWizardTablesChanged");
         };
 
         /*
@@ -163,9 +203,13 @@
             if( wiz.sourceTables.length===0 ) {
                 wiz.sources.push(source);
                 wiz.sourceTables.push(sourceTable);
+                // Broadcast table change
+                $rootScope.$broadcast("editWizardTablesChanged");
             } else if ( wiz.sourceTables.length===1 && ( source !== wiz.sources[0] || sourceTable !== wiz.sourceTables[0] ) ) {
                 wiz.sources.push(source);
                 wiz.sourceTables.push(sourceTable);
+                // Broadcast table change
+                $rootScope.$broadcast("editWizardTablesChanged");
             }
         };
 
@@ -177,6 +221,8 @@
             wiz.sourceTables.splice(0,1);
             // Move source2 columns to source1
             wiz.src1AvailableColumns = wiz.src2AvailableColumns;
+            // Broadcast table change
+            $rootScope.$broadcast("editWizardTablesChanged");
         };
 
         /*
@@ -187,6 +233,8 @@
             wiz.sourceTables.splice(1,1);
             // Clears source2 columns
             wiz.src2AvailableColumns = [];
+            // Broadcast table change
+            $rootScope.$broadcast("editWizardTablesChanged");
         };
 
         /*
@@ -420,9 +468,9 @@
         }
 
         /**
-         * Initialize the source and table selections for the dataservice
+         * Initialize the selections for the dataservice
          */
-        function initSourceAndTableSelections ( dataServiceName, pageId ) {
+        function initServiceSelections ( dataServiceName, pageId ) {
             // Reset selections
             service.resetSourceTables();
 
@@ -450,6 +498,9 @@
                                 wiz.src1CriteriaColumnName = result[i].lhCriteriaCol;
                                 wiz.src2CriteriaColumnName = result[i].rhCriteriaCol;
                                 wiz.selectedJoin = result[i].joinType;
+                            } else if(infoType==="DDL") {
+                                wiz.viewDdl = result[i].viewDdl;
+                                wiz.viewEditable = result[i].viewEditable;
                             }
                         }
 

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.html
@@ -8,7 +8,7 @@
                 next-title="vm.nextButtonTitle"
                 hide-indicators="false"
                 embed-in-page="true" 
-                content-height="'455px'">
+                content-height="'470px'">
 
             <div pf-wizard-step
                     step-title="{{vm.stepTitle}}"

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.js
@@ -9,7 +9,7 @@
         .directive('dataserviceEditWizard', DataserviceEditWizard);
 
     DataserviceEditWizard.$inject = ['CONFIG', 'SYNTAX'];
-    DataserviceEditWizardController.$inject = ['$scope', '$rootScope', '$document', '$translate', 
+    DataserviceEditWizardController.$inject = ['$scope', '$rootScope', '$document', '$translate',
                                                'RepoRestService', 'EditWizardService', 'DSSelectionService', 'SvcSourceSelectionService', 'REST_URI', 'SYNTAX'];
 
     function DataserviceEditWizard(config, syntax) {
@@ -26,7 +26,7 @@
         return directive;
     }
 
-    function DataserviceEditWizardController($scope, $rootScope, $document, $translate, 
+    function DataserviceEditWizardController($scope, $rootScope, $document, $translate,
                                              RepoRestService, EditWizardService, DSSelectionService, SvcSourceSelectionService, REST_URI, SYNTAX) {
         var vm = this;
         vm.stepTitle = $translate.instant('dataserviceEditWizard.stepTitle');
@@ -73,7 +73,6 @@
             // Determine editing or creating new.
             if(EditWizardService.serviceName().length>0) {
                 EditWizardService.setEditing(true);
-                //vm.selectedTable = EditWizardService.sourceTables()[0];
             } else {
                 EditWizardService.setEditing(false);
             }
@@ -610,7 +609,7 @@
                     }
                     
                     try {
-                        RepoRestService.setDataServiceVdbForSingleTable( dataserviceName, relativeTablePath, relativeModelSourcePath, columnNames ).then(
+                        RepoRestService.setDataServiceVdbForSingleTable( dataserviceName, relativeModelSourcePath, null, relativeTablePath, columnNames ).then(
                             function () {
                                 // Reinitialise the list of data services
                                 DSSelectionService.refresh('dataservice-summary');
@@ -665,8 +664,9 @@
                     var joinType = EditWizardService.joinType();
                     
                     try {
-                        RepoRestService.setDataServiceVdbForJoinTables( dataserviceName, lhRelativeTablePath, lhRelativeModelSourcePath, lhColumnNames,
-                                                                                         rhRelativeTablePath, rhRelativeModelSourcePath, rhColumnNames, 
+                        RepoRestService.setDataServiceVdbForJoinTables( dataserviceName, lhRelativeModelSourcePath, rhRelativeModelSourcePath, null,
+                                                                                         lhRelativeTablePath, lhColumnNames,
+                                                                                         rhRelativeTablePath, rhColumnNames, 
                                                                                          joinType, lhJoinColumnName, rhJoinColumnName).then(
                             function () {
                                 // Reinitialise the list of data services


### PR DESCRIPTION
- RepositoryRestService was modified to follow the changes in the rest calls.  allows passing of 'viewDdl' directly when creating or editing the service.  Also added new functions for the 'getViewDdl' rest calls.
- 'Expert Mode' tab was added on the dataservice create and edit pages.  This allows the user to text edit the view ddl.  Changes made in other areas to support.
- EditWizardService - added viewDdl info to the wizard service.  also added broadcast of tableChanges and serviceName changes so that the new service page could get updates.

