### PR TITLE
Sprint10 layout fixes

### DIFF
--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.html
@@ -31,7 +31,7 @@
                         <div class="form-group">
                             <label class="col-md-2 control-label" for="textInput" translate="shared.Description"></label>
                             <div class="col-md-9">
-                                <textarea rows="3"
+                                <textarea rows="1"
                                           maxlength="256"
                                           ng-model="vm.serviceDescription" 
                                           ng-init="vm.serviceDescription" 

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/twoTableViewStep.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/twoTableViewStep.html
@@ -31,14 +31,23 @@
     </div>
     <div class="col-md-1">
          <h3><strong translate="twoTableViewStep.joinType" /></h3>
-         <img title="{{vm.joinToolTipInner}}" ng-class="vm.joinType == 'INNER' ? 'join-button-down' : 'join-button-up'" 
-              ng-click="vm.selectJoinType('INNER')" src="plugins/vdb-bench-dataservice/content/img/JoinInner.png" />
-         <img title="{{vm.joinToolTipLeftOuter}}" ng-class="vm.joinType == 'LEFT_OUTER' ? 'join-button-down' : 'join-button-up'" 
-              ng-click="vm.selectJoinType('LEFT_OUTER')" src="plugins/vdb-bench-dataservice/content/img/JoinLeftOuter.png" />
-         <img title="{{vm.joinToolTipRightOuter}}" ng-class="vm.joinType == 'RIGHT_OUTER' ? 'join-button-down' : 'join-button-up'" 
-              ng-click="vm.selectJoinType('RIGHT_OUTER')" src="plugins/vdb-bench-dataservice/content/img/JoinRightOuter.png" />
-         <img title="{{vm.joinToolTipFullOuter}}" ng-class="vm.joinType == 'FULL_OUTER' ? 'join-button-down' : 'join-button-up'" 
-              ng-click="vm.selectJoinType('FULL_OUTER')" src="plugins/vdb-bench-dataservice/content/img/JoinFullOuter.png" />
+         <div style="height:3em"></div>
+         <div class="col-md-12">
+             <img title="{{vm.joinToolTipInner}}" ng-class="vm.joinType == 'INNER' ? 'join-button-down' : 'join-button-up'" 
+                  ng-click="vm.selectJoinType('INNER')" src="plugins/vdb-bench-dataservice/content/img/JoinInner.png" />
+         </div>
+         <div class="col-md-12">
+             <img title="{{vm.joinToolTipLeftOuter}}" ng-class="vm.joinType == 'LEFT_OUTER' ? 'join-button-down' : 'join-button-up'" 
+                  ng-click="vm.selectJoinType('LEFT_OUTER')" src="plugins/vdb-bench-dataservice/content/img/JoinLeftOuter.png" />
+         </div>
+         <div class="col-md-12">
+             <img title="{{vm.joinToolTipRightOuter}}" ng-class="vm.joinType == 'RIGHT_OUTER' ? 'join-button-down' : 'join-button-up'" 
+                  ng-click="vm.selectJoinType('RIGHT_OUTER')" src="plugins/vdb-bench-dataservice/content/img/JoinRightOuter.png" />
+         </div>
+         <div class="col-md-12">
+             <img title="{{vm.joinToolTipFullOuter}}" ng-class="vm.joinType == 'FULL_OUTER' ? 'join-button-down' : 'join-button-up'" 
+                  ng-click="vm.selectJoinType('FULL_OUTER')" src="plugins/vdb-bench-dataservice/content/img/JoinFullOuter.png" />
+         </div>
     </div>
     <div class="col-md-5">
         <h3><strong>{{vm.selectedSources[1]}}.{{vm.selectedTables[1]}}</strong></h3>

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/connectionList.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/connectionList.html
@@ -1,8 +1,4 @@
 <div>
-    <div id="connectionList-updating" ng-show="vm.connectionsLoading==true" class="col-md-10 row">
-        <div class="spinner spinner-lg" />
-    </div>
-    
     <div class="pick-list-container">
         <!-- Spinner when loading -->
         <div ng-show="vm.connectionsLoading==true">


### PR DESCRIPTION
- reduce height of description textarea in dataservice wizard
- force single row layout of join buttons
- removes duplicate spinners on connectionList