### PR TITLE
TEIIDTOOLS-139

### DIFF
--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -282,7 +282,8 @@
         "actionTitleRefresh" : "Refresh the Table",
         "gettingDdlMsg" : "Fetching DDL...",
         "getDdlFailedMsg" : "Failed to get the DDL.",
-        "removeSourceFailedMsg" : "Failed to remove the ServiceSource.",
+        "removeLocalSourceFailedMsg" : "Failed to remove the local ServiceSource.",
+        "removeServerDeploymentFailedMsg" : "Failed to remove the deployed ServiceSource.",
         "getModelSourceFailedMsg" : "Failed to get model source:",
         "getModhelSourceConnectionFailedMsg" : "Failed to get connection:"
     },

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/EditWizardService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/EditWizardService.js
@@ -538,7 +538,7 @@
                         throw RepoRestService.newRestException(errorMsg + "\n" + RepoRestService.responseMessage(response));
                     });
             } catch (error) {
-                var removeSourceFailedMsg = $translate.instant('dataserviceEditWizard.getColumnsFailedMsg');
+                var errorMsg = $translate.instant('dataserviceEditWizard.getColumnsFailedMsg');
                 throw RepoRestService.newRestException(errorMsg + "\n" + error);
             }
         }

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.js
@@ -394,12 +394,12 @@
                         updateVdbModelFromDdl(vdbName, models[0].keng__id);
                     },
                     function (response) {
-                        var removeSourceFailedMsg = $translate.instant('dataserviceEditWizard.getVdbModelsFailedMsg');
-                        throw RepoRestService.newRestException(removeSourceFailedMsg + "\n" + RepoRestService.responseMessage(response));
+                        var getModelsFailedMsg = $translate.instant('dataserviceEditWizard.getVdbModelsFailedMsg');
+                        throw RepoRestService.newRestException(getModelsFailedMsg + "\n" + RepoRestService.responseMessage(response));
                     });
             } catch (error) {
-                var removeSourceFailedMsg = $translate.instant('dataserviceEditWizard.getVdbModelsFailedMsg');
-                throw RepoRestService.newRestException(removeSourceFailedMsg + "\n" + error);
+                var getModelsFailedMsg = $translate.instant('dataserviceEditWizard.getVdbModelsFailedMsg');
+                throw RepoRestService.newRestException(getModelsFailedMsg + "\n" + error);
             }
         }
 
@@ -414,12 +414,12 @@
                             getTempVdbModels( SYNTAX.TEMP+vdbName );
                         },
                         function (response) {
-                            var removeSourceFailedMsg = $translate.instant('dataserviceEditWizard.updateVdbFromDdlFailedMsg');
-                            throw RepoRestService.newRestException(removeSourceFailedMsg + "\n" + RepoRestService.responseMessage(response));
+                            var updateVdbFailedMsg = $translate.instant('dataserviceEditWizard.updateVdbFromDdlFailedMsg');
+                            throw RepoRestService.newRestException(updateVdbFailedMsg + "\n" + RepoRestService.responseMessage(response));
                         });
             } catch (error) {
-                var removeSourceFailedMsg = $translate.instant('dataserviceEditWizard.updateVdbFromDdlFailedMsg');
-                throw RepoRestService.newRestException(removeSourceFailedMsg + "\n" + error);
+                var updateVdbFailedMsg = $translate.instant('dataserviceEditWizard.updateVdbFromDdlFailedMsg');
+                throw RepoRestService.newRestException(updateVdbFailedMsg + "\n" + error);
             }
         }
 
@@ -437,12 +437,12 @@
                         getVdbModelTables(srcVdbName, models[0].keng__id);
                     },
                     function (response) {
-                        var removeSourceFailedMsg = $translate.instant('dataserviceEditWizard.getVdbModelsFailedMsg');
-                        throw RepoRestService.newRestException(removeSourceFailedMsg + "\n" + RepoRestService.responseMessage(response));
+                        var getVdbModelsFailedMsg = $translate.instant('dataserviceEditWizard.getVdbModelsFailedMsg');
+                        throw RepoRestService.newRestException(getVdbModelsFailedMsg + "\n" + RepoRestService.responseMessage(response));
                     });
             } catch (error) {
-                var removeSourceFailedMsg = $translate.instant('dataserviceEditWizard.getVdbModelsFailedMsg');
-                throw RepoRestService.newRestException(removeSourceFailedMsg + "\n" + error);
+                var getVdbModelsFailedMsg = $translate.instant('dataserviceEditWizard.getVdbModelsFailedMsg');
+                throw RepoRestService.newRestException(getVdbModelsFailedMsg + "\n" + error);
             }
         	
         }
@@ -473,12 +473,12 @@
                         }
                    },
                     function (response) {
-                       var removeSourceFailedMsg = $translate.instant('dataserviceEditWizard.getVdbModelTablesFailedMsg');
-                       throw RepoRestService.newRestException(removeSourceFailedMsg + "\n" + RepoRestService.responseMessage(response));
+                       var getTablesFailedMsg = $translate.instant('dataserviceEditWizard.getVdbModelTablesFailedMsg');
+                       throw RepoRestService.newRestException(getTablesFailedMsg + "\n" + RepoRestService.responseMessage(response));
                     });
             } catch (error) {
-                var removeSourceFailedMsg = $translate.instant('dataserviceEditWizard.getVdbModelTablesFailedMsg');
-                throw RepoRestService.newRestException(removeSourceFailedMsg + "\n" + error);
+                var getTablesFailedMsg = $translate.instant('dataserviceEditWizard.getVdbModelTablesFailedMsg');
+                throw RepoRestService.newRestException(getTablesFailedMsg + "\n" + error);
             }
         }
 
@@ -528,7 +528,7 @@
                         throw RepoRestService.newRestException(errorMsg + "\n" + RepoRestService.responseMessage(response));
                     });
             } catch (error) {
-                var removeSourceFailedMsg = $translate.instant('dataserviceEditWizard.getColumnsFailedMsg');
+                var errorMsg = $translate.instant('dataserviceEditWizard.getColumnsFailedMsg');
                 throw RepoRestService.newRestException(errorMsg + "\n" + error);
             }
         }


### PR DESCRIPTION
Addresses issue TEIIDTOOLS-139 "Delete datasource doesn't always delete workspace entry".  Could not reproduce the issue, but I have seen this happen before.  The 'delete source' action is a 2 step process - (1) removes the workspace entry and (2) undeploys the server vdb.

- reversed the order of operation.  Now, the server vdb is undeployed first.
- Regardless of the outcome of the server undeployment, the workspace vdb is now removed.
- changed the exception message to try to clarify which half of the process failed.  Should make it easier to pinpoint what is failing.
- other minor changes to exception message naming