### PR TITLE
TEIIDTOOLS-137 Adds join criteria builder

### DIFF
--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -470,27 +470,41 @@
     },
 
     "singleTableViewStep" : {
-        "stepTitle" : "View Definition",
+        "stepTitle" : "Choose Columns",
         "clickFinishInstructionMsg" : "Click Finish to create the data service",
         "selectOneOrMoreColumnsInstructionMsg" : "Select one or more columns for your Data Service view"
     },
 
     "twoTableViewStep" : {
-        "stepTitle" : "Join Definition",
+        "stepTitle" : "Choose Columns",
         "joinType" : "Join Type",
-        "joinCriteria" : "Join Criteria",
-        "equalsCriteria" : "equals",
-        "chooseCriteriaCol" : "-- choose criteria column --",
         "joinToolTipInner" : "Inner Join",
         "joinToolTipLeftOuter" : "Left Outer Join",
         "joinToolTipRightOuter" : "Right Outer Join",
         "joinToolTipFullOuter" : "Full OUter Join",
-        "clickFinishInstructionMsg" : "Click Finish to create the data service",
+        "clickNextJoinCriteriaInstructionMsg" : "Select columns for your service, then click Next to continue",
         "selectColumnsForLeftTableInstructionMsg" : "Select one or more columns from the left source",
         "selectColumnsForRightTableInstructionMsg" : "Select one or more columns from the right source",
-        "selectJoinTypeInstructionMsg" : "Select a join type",
-        "selectLeftTableCriteriaColumnInstructionMsg" : "Select a column for the left table criteria",
-        "selectRightTableCriteriaColumnInstructionMsg" : "Select a column for the right table criteria"
+        "selectJoinTypeInstructionMsg" : "Select a join type"
+    },
+
+    "joinCriteriaStep" : {
+        "stepTitle" : "Define Criteria",
+        "clickFinishInstructionMsg" : "Add more conditions or click Finish to create the data service",
+        "addCriteriaConditionInstructionMsg" : "Click to add a criteria condition",
+        "finishCriteriaConditionInstructionMsg" : "Complete the criteria conditions"
+    },
+
+    "criteriaBuilder" : {
+        "addCondition" : "Add Condition",
+        "currentCriteria" : "Current Criteria",
+        "chooseCriteriaCol" : "-- choose column --",
+        "chooseOperator" : "-- choose --",
+        "chooseKeyword" : "-- choose --",
+        "lhColumnTitle" : "Left Column",
+        "rhColumnTitle" : "Right Column",
+        "operatorTitle" : "Operator",
+        "keywordTitle" : "Keyword"
     }
 
 }

--- a/vdb-bench-assembly/index.html
+++ b/vdb-bench-assembly/index.html
@@ -151,6 +151,7 @@
     <script src="plugins/vdb-bench-widgets/fileInputHandler.js"></script>
     <script src="plugins/vdb-bench-widgets/gitCredentialsControl.js"></script>
     <script src="plugins/vdb-bench-widgets/pageHelpControl.js"></script>
+    <script src="plugins/vdb-bench-widgets/criteriaBuilder.js"></script>
     <!-- endinject -->
 
     <!-- vdb-bench-wksp-mgmt -->
@@ -230,6 +231,7 @@
     <script src="plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.js"></script>
     <script src="plugins/vdb-bench-dataservice/widgets/dataservice-wizard/singleTableViewStep.js"></script>
     <script src="plugins/vdb-bench-dataservice/widgets/dataservice-wizard/twoTableViewStep.js"></script>
+    <script src="plugins/vdb-bench-dataservice/widgets/dataservice-wizard/joinCriteriaStep.js"></script>
     <script src="plugins/vdb-bench-dataservice/widgets/dataservice-wizard/EditWizardService.js"></script>
     <!-- endinject -->
     <!-- endbuild -->

--- a/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
@@ -970,7 +970,7 @@
         service.setDataServiceVdbForJoinTables = function (dataserviceName, modelSourcePath, rhModelSourcePath, viewDdl,
                                                                             tablePath, columnNames,
                                                                             rhTablePath, rhColumnNames, 
-                                                                            joinType, lhJoinColumnName, rhJoinColumnName) {
+                                                                            joinType, criteriaPredicates) {
             if (!dataserviceName || !modelSourcePath || !rhModelSourcePath || !tablePath || !rhTablePath) {
                 throw RestServiceException("Data service update inputs are not defined");
             }
@@ -999,13 +999,9 @@
                 if ( joinType && joinType.length > 0 )  {
                     payload.joinType = joinType;
                 }
-                // Adds requested lhJoinColumn if provided
-                if ( lhJoinColumnName && lhJoinColumnName.length > 0 )  {
-                    payload.lhJoinColumn = lhJoinColumnName;
-                }
-                // Adds requested rhJoinColumn if provided
-                if ( rhJoinColumnName && rhJoinColumnName.length > 0 )  {
-                    payload.rhJoinColumn = rhJoinColumnName;
+                // Adds criteria predicates if provided
+                if ( criteriaPredicates && criteriaPredicates.length > 0 )  {
+                    payload.criteriaPredicates = criteriaPredicates;
                 }
 
                 return restService.all(REST_URI.WORKSPACE + REST_URI.DATA_SERVICES + SYNTAX.FORWARD_SLASH + REST_URI.SERVICE_VDB_FOR_JOIN_TABLES).post(payload);
@@ -1039,7 +1035,7 @@
          */
         service.getDataServiceViewDdlForJoinTables = function (dataserviceName, tablePath, columnNames,
                                                                                 rhTablePath, rhColumnNames, 
-                                                                                joinType, lhJoinColumnName, rhJoinColumnName) {
+                                                                                joinType, criteriaPredicates ) {
             if (!dataserviceName || !tablePath || !rhTablePath ) {
                 throw RestServiceException("get View DDL inputs are not sufficiently defined");
             }
@@ -1051,24 +1047,20 @@
                     "rhTablePath": getUserWorkspacePath()+"/"+rhTablePath
                 };
                 // Adds joinType if provided
-                if ( angular.isDefined(joinType) && joinType!==null )  {
+                if ( joinType )  {
                     payload.joinType = joinType;
                 }
-                // Adds lhJoinColumn if provided
-                if ( angular.isDefined(lhJoinColumnName) && lhJoinColumnName!==null )  {
-                    payload.lhJoinColumn = lhJoinColumnName;
-                }
-                // Adds rhJoinColumn if provided
-                if ( angular.isDefined(rhJoinColumnName) && rhJoinColumnName!==null )  {
-                    payload.rhJoinColumn = rhJoinColumnName;
-                }
                 // Adds requested column names if provided
-                if ( angular.isDefined(columnNames) && columnNames.length > 0 )  {
+                if ( columnNames && columnNames.length > 0 )  {
                     payload.columnNames = columnNames;
                 }
                 // Adds requested rh column names if provided
-                if ( angular.isDefined(rhColumnNames) && rhColumnNames.length > 0 )  {
+                if ( rhColumnNames && rhColumnNames.length > 0 )  {
                     payload.rhColumnNames = rhColumnNames;
+                }
+                // Adds criteria predicates if provided
+                if ( criteriaPredicates && criteriaPredicates.length > 0 )  {
+                    payload.criteriaPredicates = criteriaPredicates;
                 }
 
                 return restService.all(REST_URI.WORKSPACE + REST_URI.DATA_SERVICES + SYNTAX.FORWARD_SLASH + REST_URI.SERVICE_VIEW_DDL_FOR_JOIN_TABLES).post(payload);

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsEditController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsEditController.js
@@ -151,15 +151,8 @@
                         var lhColumnNames = EditWizardService.source1SelectedColumns();
                         var rhColumnNames = EditWizardService.source2SelectedColumns();
                         
-                        // Join criteria columns
-                        var lhJoinColumnName = null;
-                        if(EditWizardService.source1CriteriaColumn() !== null) {
-                            lhJoinColumnName = EditWizardService.source1CriteriaColumn().keng__id;
-                        }
-                        var rhJoinColumnName = null;
-                        if(EditWizardService.source2CriteriaColumn() !== null) {
-                            rhJoinColumnName = EditWizardService.source2CriteriaColumn().keng__id;
-                        }
+                        // Join criteria predicates
+                        var criteriaPredicates = EditWizardService.criteriaPredicates();
                         
                         // Join type
                         var joinType = EditWizardService.joinType();
@@ -167,7 +160,7 @@
                         try {
                             RepoRestService.getDataServiceViewDdlForJoinTables( dataserviceName, lhRelativeTablePath, lhColumnNames,
                                                                                                  rhRelativeTablePath, rhColumnNames, 
-                                                                                                 joinType, lhJoinColumnName, rhJoinColumnName).then(
+                                                                                                 joinType, criteriaPredicates).then(
                                 function (result) {
                                     // View info
                                     vm.viewDdl = result.viewDdl;

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsNewController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsNewController.js
@@ -133,15 +133,9 @@
                     var lhColumnNames = EditWizardService.source1SelectedColumns();
                     var rhColumnNames = EditWizardService.source2SelectedColumns();
                     
-                    // Join criteria columns
-                    var lhJoinColumnName = null;
-                    if(EditWizardService.source1CriteriaColumn() !== null) {
-                        lhJoinColumnName = EditWizardService.source1CriteriaColumn().keng__id;
-                    }
-                    var rhJoinColumnName = null;
-                    if(EditWizardService.source2CriteriaColumn() !== null) {
-                        rhJoinColumnName = EditWizardService.source2CriteriaColumn().keng__id;
-                    }
+                    // Join criteria predicates
+                    var criteriaPredicates = EditWizardService.criteriaPredicates();
+
                     
                     // Join type
                     var joinType = EditWizardService.joinType();
@@ -149,7 +143,7 @@
                     try {
                         RepoRestService.getDataServiceViewDdlForJoinTables( dataserviceName, lhRelativeTablePath, lhColumnNames,
                                                                                              rhRelativeTablePath, rhColumnNames, 
-                                                                                             joinType, lhJoinColumnName, rhJoinColumnName).then(
+                                                                                             joinType, criteriaPredicates).then(
                             function (result) {
                                 // View info
                                 vm.viewDdl = result.viewDdl;

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.html
@@ -108,8 +108,11 @@
             <!-- directive includes the single table step -->
             <single-table-view-step wizard-active="vm.selectedTables.length<2 && vm.includeAllColumns===false"></single-table-view-step>
 
-            <!-- directive includes the two table join steop -->
+            <!-- directive includes the two table join step -->
             <two-table-view-step wizard-active="vm.selectedTables.length==2"></two-table-view-step>
+
+            <!-- directive includes the join criteria step -->
+            <join-criteria-step wizard-active="vm.selectedTables.length==2"></join-criteria-step>
 
         </div>
     </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.js
@@ -273,6 +273,8 @@
             } else if(vm.currentWizardStep === "wizard-view-definition") {
                 vm.nextButtonTitle = $translate.instant('shared.Finish');
             } else if(vm.currentWizardStep === "wizard-join-definition") {
+                vm.nextButtonTitle = $translate.instant('shared.Next');
+            } else if(vm.currentWizardStep === "wizard-join-criteria") {
                 vm.nextButtonTitle = $translate.instant('shared.Finish');
             }
         }
@@ -656,9 +658,8 @@
                     var lhColumnNames = EditWizardService.source1SelectedColumns();
                     var rhColumnNames = EditWizardService.source2SelectedColumns();
                     
-                    // Join criteria columns
-                    var lhJoinColumnName = EditWizardService.source1CriteriaColumn().keng__id;
-                    var rhJoinColumnName = EditWizardService.source2CriteriaColumn().keng__id;
+                    // Join criteria predicates
+                    var criteriaPredicates = EditWizardService.criteriaPredicates();
                     
                     // Join type
                     var joinType = EditWizardService.joinType();
@@ -667,7 +668,7 @@
                         RepoRestService.setDataServiceVdbForJoinTables( dataserviceName, lhRelativeModelSourcePath, rhRelativeModelSourcePath, null,
                                                                                          lhRelativeTablePath, lhColumnNames,
                                                                                          rhRelativeTablePath, rhColumnNames, 
-                                                                                         joinType, lhJoinColumnName, rhJoinColumnName).then(
+                                                                                         joinType, criteriaPredicates).then(
                             function () {
                                 // Reinitialise the list of data services
                                 DSSelectionService.refresh('dataservice-summary');

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/joinCriteriaStep.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/joinCriteriaStep.html
@@ -1,0 +1,16 @@
+<div pf-wizard-step
+        step-title="{{vm.stepTitle}}"
+        wz-disabled="{{!vm.wizardActive}}"
+        step-id="wizard-join-criteria"
+        allow-click-nav="false"
+        wz-disabled="false"
+        on-show="vm.joinCriteriaStepShown()"
+        next-enabled = "vm.nextEnablement"
+        prev-enabled = "true"
+        ok-to-nav-away="true">
+    <h3><i>{{vm.instructionMessage}}</i></h3>
+    <div class="col-md-8">
+        <criteria-builder></criteria-builder>
+    </div>
+    
+</div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/joinCriteriaStep.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/joinCriteriaStep.js
@@ -1,0 +1,71 @@
+(function () {
+    'use strict';
+
+    var pluginName = 'vdb-bench.dataservice';
+    var pluginDirName = 'vdb-bench-dataservice/widgets/dataservice-wizard';
+
+    angular
+        .module(pluginName)
+        .directive('joinCriteriaStep', JoinCriteriaStep);
+
+    JoinCriteriaStep.$inject = ['CONFIG', 'SYNTAX'];
+    JoinCriteriaStepController.$inject = ['$rootScope', '$scope', '$translate', 'EditWizardService', 'SYNTAX'];
+
+    function JoinCriteriaStep(config, syntax) {
+        var directive = {
+            restrict: 'E',
+            scope: {},
+            bindToController: {
+                wizardActive : '='
+            },
+            controller: JoinCriteriaStepController,
+            controllerAs: 'vm',
+            templateUrl: config.pluginDir + syntax.FORWARD_SLASH +
+                         pluginDirName + syntax.FORWARD_SLASH +
+                         'joinCriteriaStep.html'
+        };
+
+        return directive;
+    }
+
+    function JoinCriteriaStepController($rootScope, $scope, $translate, EditWizardService, SYNTAX) {
+        var vm = this;
+
+        vm.stepTitle = $translate.instant('joinCriteriaStep.stepTitle');
+        vm.instructionMessage = "";
+        vm.nextEnablement = updateNextEnablement();
+
+        /*
+         * Join Criteria step shown
+         */
+        vm.joinCriteriaStepShown = function() {
+            // Broadcast page shown
+            $rootScope.$broadcast("editWizardJoinCriteriaShown");
+            updateNextEnablement();
+        };
+
+        $scope.$on("editWizardJoinCriteriaChanged", function (event) {
+            updateNextEnablement();
+        });
+
+        /*
+         * Update next enablement
+         */
+        function updateNextEnablement() {
+            var criteriaPredicates = EditWizardService.criteriaPredicates();
+            var criteriaComplete = EditWizardService.criteriaComplete();
+            if(criteriaPredicates.length===0) {
+                vm.nextEnablement = false;
+                vm.instructionMessage = $translate.instant('joinCriteriaStep.addCriteriaConditionInstructionMsg');
+            } else if(!criteriaComplete) {
+                vm.nextEnablement = false;
+                vm.instructionMessage = $translate.instant('joinCriteriaStep.finishCriteriaConditionInstructionMsg');
+            } else {
+                vm.nextEnablement = true;
+                vm.instructionMessage = $translate.instant('joinCriteriaStep.clickFinishInstructionMsg');
+            }
+        }
+
+    }
+
+})();

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/twoTableViewStep.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/twoTableViewStep.html
@@ -69,23 +69,4 @@
             </div>
         </div>
     </div>
-    <div class="col-md-12">
-        <h3><strong translate="twoTableViewStep.joinCriteria" /></h3>
-    </div>
-    <div class="col-md-5">
-        <select id="lhCriteriaCol" ng-model="vm.lhCriteriaCol" ng-options="lhCol as lhCol.keng__id for lhCol in vm.lhSourceItems" 
-                                   ng-change="vm.lhCriteriaColumnChanged()">
-            <option value="" translate="twoTableViewStep.chooseCriteriaCol"></option>
-        </select>
-    </div>
-    <div class="col-md-1">
-        <strong translate="twoTableViewStep.equalsCriteria" />
-    </div>
-    <div class="col-md-5">
-        <select id="rhCriteriaCol" ng-model="vm.rhCriteriaCol" ng-options="rhCol as rhCol.keng__id for rhCol in vm.rhSourceItems" 
-                                   ng-change="vm.rhCriteriaColumnChanged()">
-            <option value="" translate="twoTableViewStep.chooseCriteriaCol"></option>
-        </select>
-    </div>
-    
 </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/twoTableViewStep.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/twoTableViewStep.js
@@ -36,8 +36,6 @@
         vm.selectedTables = [];
         vm.lhSourceItems = [];
         vm.rhSourceItems = [];
-        vm.lhCriteriaCol = null;
-        vm.rhCriteriaCol = null;
         vm.instructionMessage = $translate.instant('twoTableViewStep.selectColumnsForLeftTableInstructionMsg');
         vm.nextEnablement = updateNextEnablement();
         vm.joinType = EditWizardService.joinType();
@@ -59,8 +57,6 @@
             vm.lhSourceItems = EditWizardService.source1AvailableColumns();
             vm.rhSourceItems = EditWizardService.source2AvailableColumns();
             vm.joinType = EditWizardService.joinType();
-            vm.lhCriteriaCol = EditWizardService.source1CriteriaColumn();
-            vm.rhCriteriaCol = EditWizardService.source2CriteriaColumn();
             updateNextEnablement();
         };
 
@@ -70,20 +66,6 @@
         vm.selectJoinType = function(joinType) {
             EditWizardService.setJoinType(joinType);
             vm.joinType = joinType;
-        };
-
-        /*
-         * Called when left criteria column is changed
-         */
-        vm.lhCriteriaColumnChanged = function() {
-            EditWizardService.setSource1CriteriaColumn(vm.lhCriteriaCol);
-        };
-
-        /*
-         * Called when right criteria column is changed
-         */
-        vm.rhCriteriaColumnChanged = function() {
-            EditWizardService.setSource2CriteriaColumn(vm.rhCriteriaCol);
         };
 
        vm.selectAllLeftColumns = function() {
@@ -213,15 +195,9 @@
             } else if( !joinValid() ){
                 vm.nextEnablement = false;
                 vm.instructionMessage = $translate.instant('twoTableViewStep.selectJoinTypeInstructionMsg');
-            } else if( !vm.lhCriteriaCol ){
-                vm.nextEnablement = false;
-                vm.instructionMessage = $translate.instant('twoTableViewStep.selectLeftTableCriteriaColumnInstructionMsg');
-            } else if( !vm.rhCriteriaCol ){
-                vm.nextEnablement = false;
-                vm.instructionMessage = $translate.instant('twoTableViewStep.selectRightTableCriteriaColumnInstructionMsg');
             } else {
                 vm.nextEnablement = true;
-                vm.instructionMessage = $translate.instant('twoTableViewStep.clickFinishInstructionMsg');
+                vm.instructionMessage = $translate.instant('twoTableViewStep.clickNextJoinCriteriaInstructionMsg');
             }
         }
 

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/criteriaBuilder.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/criteriaBuilder.html
@@ -1,0 +1,80 @@
+<div>
+    <form name="builder-criteria" role="form">
+        <div class="col-md-12">
+            <h5><strong translate="criteriaBuilder.currentCriteria" />:&nbsp;&nbsp;{{vm.criteriaString}}</h5>
+            <h6>&nbsp;</h6>
+        </div>
+        <div class="col-md-12">
+            <button class="btn btn-primary" ng-click="vm.addCriteriaPredicate()">
+                <span class="glyphicon glyphicon-plus"></span>{{:: 'criteriaBuilder.addCondition' | translate}}
+            </button>
+        </div>
+
+        <div class="col-md-3">
+            <h5><strong translate="criteriaBuilder.lhColumnTitle" /></h5>
+        </div>
+        <div class="col-md-2">
+            <h5><strong translate="criteriaBuilder.operatorTitle" /></h5>
+        </div>
+        <div class="col-md-3">
+            <h5><strong translate="criteriaBuilder.rhColumnTitle" /></h5>
+        </div>
+        <div class="col-md-4">
+            <h5>&nbsp;</h4>
+        </div>
+
+        <div class="form-group" ng-repeat="criteriaPredicate in vm.criteriaPredicates">
+          <div class="row">
+            <!--  Left Column -->
+            <div class="col-md-3">
+                <select ng-model="criteriaPredicate.lhColName" ng-change="vm.lhColumnChanged( )">
+                    <option value="" translate="criteriaBuilder.chooseCriteriaCol"></option>
+                    <option ng-selected="{{lhCol.keng__id == criteriaPredicate.lhColName}}"
+                            ng-repeat="lhCol in vm.lhSourceCols"
+                            value="{{lhCol.keng__id}}">
+                            {{lhCol.keng__id}}
+                    </option>
+                </select>
+            </div>
+            <!--  Operator -->
+            <div class="col-md-2">
+                <select ng-model="criteriaPredicate.operatorName" ng-change="vm.operatorChanged( )">
+                    <option value="" translate="criteriaBuilder.chooseOperator"></option>
+                    <option ng-selected="{{operator.name == criteriaPredicate.operatorName}}"
+                            ng-repeat="operator in vm.operatorOptions"
+                            value="{{operator.name}}">
+                            {{operator.name}}
+                    </option>
+                </select>
+            </div>
+            <!-- Right Column -->
+            <div class="col-md-3">
+                <select ng-model="criteriaPredicate.rhColName" ng-change="vm.rhColumnChanged( )">
+                    <option value="" translate="criteriaBuilder.chooseCriteriaCol"></option>
+                    <option ng-selected="{{rhCol.keng__id == criteriaPredicate.rhColName}}"
+                            ng-repeat="rhCol in vm.rhSourceCols"
+                            value="{{rhCol.keng__id}}">
+                            {{rhCol.keng__id}}
+                    </option>
+                </select>
+            </div>
+            <div class="col-md-2">
+                <button class="btn btn-sm btn-danger" ng-click="vm.removeCriteriaPredicate(criteriaPredicate)" ng-disabled="vm.shouldDisableRemoveButton(criteriaPredicate)">
+                    <span class="glyphicon glyphicon-minus"></span>
+                </button>
+            </div>
+            <!-- combineKey -->
+            <div class="col-md-2">
+                <select ng-model="criteriaPredicate.combineKeyword" ng-change="vm.combineKeywordChanged( )" ng-show="vm.shouldShowCombineKeyword(criteriaPredicate)">
+                    <option value="" translate="criteriaBuilder.chooseKeyword"></option>
+                    <option ng-selected="{{keyword.name == criteriaPredicate.combineKeyword}}"
+                            ng-repeat="keyword in vm.combineKeywords"
+                            value="{{keyword.name}}">
+                            {{keyword.name}}
+                    </option>
+                </select>
+            </div>
+          </div>
+        </div>
+    </form>
+</div>

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/criteriaBuilder.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/criteriaBuilder.js
@@ -1,0 +1,197 @@
+(function () {
+    'use strict';
+
+    var pluginName = 'vdb-bench.widgets';
+    var pluginDirName = 'vdb-bench-widgets';
+
+    angular
+        .module(pluginName)
+        .directive('criteriaBuilder', CriteriaBuilder);
+
+    CriteriaBuilder.$inject = ['CONFIG', 'SYNTAX'];
+    CriteriaBuilderController.$inject = ['$scope', '$translate', 'REST_URI', 'SYNTAX', 'EditWizardService' ];
+
+    function CriteriaBuilder(config, syntax) {
+        var directive = {
+            restrict: 'E',
+            scope: {},
+            controller: CriteriaBuilderController,
+            controllerAs: 'vm',
+            templateUrl: config.pluginDir + syntax.FORWARD_SLASH +
+                pluginDirName + syntax.FORWARD_SLASH +
+                'criteriaBuilder.html'
+        };
+
+        return directive;
+    }
+
+    function CriteriaBuilderController($scope, $translate, REST_URI, SYNTAX, EditWizardService) {
+        var vm = this;
+
+        var UNDEF = "<undef>";
+        vm.lhSourceCols = [];
+        vm.rhSourceCols = [];
+        vm.operatorOptions = [ 
+            { name: "=" }, 
+            { name: "<>"}, 
+            { name: "<" }, 
+            { name: "<="}, 
+            { name: ">" }, 
+            { name: ">="} ];
+        vm.combineKeywords = [ 
+            { name: "AND" }, 
+            { name: "OR"} ];
+        vm.criteriaPredicates = [];
+        vm.criteriaString = "";
+
+        /*
+         * When join wizard page is shown
+         */
+        $scope.$on('editWizardJoinCriteriaShown', function (event) {
+            vm.lhSourceCols = EditWizardService.source1AvailableColumns();
+            vm.rhSourceCols = EditWizardService.source2AvailableColumns();
+            vm.criteriaPredicates = EditWizardService.criteriaPredicates();
+            updateCriteriaString();
+        });
+
+        /**
+         * Add the specified predicate at the specified index
+         */
+        vm.addCriteriaPredicate = function() {
+            // Add a new predicate to the current list
+            var newId = vm.criteriaPredicates.length;
+            var predicate = {
+                id : newId,
+                lhColName : '',
+                operatorName : vm.operatorOptions[0].name,
+                rhColName : '',
+                combineKeyword : vm.combineKeywords[0].name
+            };
+            vm.criteriaPredicates.push(predicate);
+
+            //  Reset the wizard service predicates
+            EditWizardService.setCriteriaPredicates(vm.criteriaPredicates);
+
+            // Update the criteria
+            updateCriteriaString();
+        };
+
+        /**
+         * Event handler for removing a criteria predicate
+         */
+        vm.removeCriteriaPredicate = function (where) {
+            if (_.isEmpty(where)) {
+                return;
+            }
+
+            if (vm.criteriaPredicates.length === 0) {
+                return;
+            }
+
+            var indxRemove = -1;
+            // Determine the index of the predicate to be removed
+            for(var i=0; i<vm.criteriaPredicates.length; i++) {
+                if(where.id === vm.criteriaPredicates[i].id) {
+                    indxRemove = i;
+                    break;
+                }
+            }
+            // Remove the predicate (if found).  Resequence the predicates
+            if (indxRemove > -1) {
+                vm.criteriaPredicates.splice(indxRemove,1);
+                resequencePredicates();
+            }
+
+            EditWizardService.setCriteriaPredicates(vm.criteriaPredicates);
+
+            updateCriteriaString();
+        };
+
+        // Resequences the predicates after one is removed
+        function resequencePredicates() {
+            for(var i=0; i<vm.criteriaPredicates.length; i++) {
+                vm.criteriaPredicates[i].id = i;	
+            }
+        }
+
+        /**
+         * Access to the collection of where predicates
+         */
+        vm.getCriteriaPredicates = function() {
+            return vm.criteriaPredicates;
+        };
+
+        /**
+         * Handle operator changed
+         */
+        vm.operatorChanged = function( ) {
+            updateCriteriaString();
+        };
+
+        /**
+         * Handle LH column changed
+         */
+        vm.lhColumnChanged = function( ) {
+            updateCriteriaString();
+        };
+
+        /**
+         * Handle RH column changed
+         */
+        vm.rhColumnChanged = function( ) {
+            updateCriteriaString();
+        };
+
+        /**
+         * Handle combine keyword (AND|OR) changed
+         */
+        vm.combineKeywordChanged = function( ) {
+            updateCriteriaString();
+        };
+
+        /**
+         * Determine if the where predicate keyword should be shown
+         */
+        vm.shouldShowCombineKeyword = function(predicate) {
+            if(predicate.id === vm.criteriaPredicates.length-1) {
+                return false;
+            }
+            return true;
+        };
+
+        /**
+         * Determine if the remove button should be disabled
+         */
+        vm.shouldDisableRemoveButton = function(predicate) {
+            if(predicate && vm.criteriaPredicates.length === 1) {
+                return true;
+            }
+            return false;
+        };
+
+        /**
+         * Update the criteria string based on current selections
+         */
+        function updateCriteriaString() {
+            var criteria = "(";
+            var nPredicates = vm.criteriaPredicates.length;
+            for(var i=0; i<nPredicates; i++) {
+                var leftCol = vm.criteriaPredicates[i].lhColName;
+                var rightCol = vm.criteriaPredicates[i].rhColName;
+                var oper = vm.criteriaPredicates[i].operatorName;
+                var keyword = vm.criteriaPredicates[i].combineKeyword;
+                if(!leftCol || leftCol.length<1) leftCol = UNDEF;
+                if(!rightCol || rightCol.length<1) rightCol = UNDEF;
+                if(!oper || oper.length<1) oper = UNDEF;
+                if(!keyword || keyword.length<1) keyword = UNDEF;
+                criteria = criteria + leftCol + " " + oper + " " + rightCol;
+                if(i < nPredicates-1) {
+                    criteria = criteria + " " + keyword + " ";
+                }
+            }
+            criteria = criteria + ")";
+            vm.criteriaString = criteria;
+        }
+    }
+
+})();


### PR DESCRIPTION
- added criteriaBuilder directive for building criteria from simple predicates
- added an additional step to the Service Editor wizard - the criteria definition is now on its own page.
- adjustments to other steps and wizard resulting from new wizard step
- changed RepositoryRestService to adjust for modified rest calls.  Now passes predicate array instead of specifying columns.