### PR TITLE
TEIIDTOOLS-143 mods for view definition validation

### DIFF
--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -195,6 +195,8 @@
         "enterNameInstructionMsg" : "Enter a name for your data service",
         "getVdbModelsFailedMsg" : "Failed to get Vdb models",
         "getVdbModelTablesFailedMsg" : "Failed to get Vdb model tables",
+        "createDataserviceFailedMsg" : "Failed to create the data service",
+        "updateDataserviceFailedMsg" : "Failed to update the data service",
         "selectedTables" : "Selected Tables",
         "stepTitle" : "Choose Data Sources",
         "updateVdbFromDdlFailedMsg" : "Failed to construct temp Vdb from DDL",
@@ -210,6 +212,8 @@
     },
 
     "dsEditController" : {
+        "enterViewDefnMsg" : "Enter a View Definition",
+        "updateDataserviceFailedMsg" : "Failed to update the data service",
         "saveFailedMsg" : "Failed to update the data service: {{response}}"
     },
     
@@ -227,7 +231,8 @@
     },
 
     "dsNewController" : {
-        "createFailedMsg" : "Failed to create the data service: {{response}}",
+        "createDataserviceFailedMsg" : "Failed to create the data service",
+        "enterViewDefnMsg" : "Enter a View Definition",
         "saveFailedMsg" : "Failed to update the data service: {{response}}"
     },
 

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-edit.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-edit.html
@@ -11,8 +11,12 @@
                         <h4 class="pull-left">{{'dataservice-edit.viewDdlTitle' | translate}}</h4>
                     </div>
                     <div class="col-md-12">
-                        <div ui-codemirror ng-model="vm.viewDdl" ui-codemirror-opts="vm.ddlEditorOptions" ui-refresh="vm.refreshViewDdl"></div>
+                        <div ui-codemirror="{ onLoad : vm.editorLoaded }" ng-model="vm.viewDdl" ui-codemirror-opts="vm.ddlEditorOptions" ui-refresh="vm.refreshViewDdl"></div>
+                        <div class="has-error" ng-if="vm.showDdlError">
+                            <span class="help-block">{{vm.ddlErrorMsg}}</span>
+                        </div>
                     </div>
+                    <p>&nbsp;</p>
                     <div class="col-md-12">
                         <p><strong>{{'dataservice-edit.sourceTablesLimitedMsg' | translate}}</strong></p>
                         <h4 ng-show="vm.sourceNames[0]!=null">&nbsp;&nbsp;{{vm.sourceNames[0]}}.{{vm.tableNames[0]}}</h4>
@@ -20,7 +24,7 @@
                         <p>&nbsp;</p>
                     </div>
                     <div class="col-md-12">
-                        <input type="submit" class="btn btn-primary" value="{{:: 'shared.Finish' | translate}}" ng-click="vm.finishClicked()" />
+                        <input type="submit" class="btn btn-primary" value="{{:: 'shared.Finish' | translate}}" ng-click="vm.finishClicked()" ng-disabled="vm.disableFinish" />
                         <input type="button" class="btn btn-default" value="{{:: 'shared.Cancel' | translate}}" ng-click="vmmain.selectPage('dataservice-summary')" />
                     </div>
                 </uib-tab>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-new.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-new.html
@@ -27,8 +27,12 @@
                         <h4 class="pull-left">{{'dataservice-new.viewDdlTitle' | translate}}</h4>
                     </div>
                     <div class="col-md-12">
-                        <div ui-codemirror ng-model="vm.viewDdl" ui-codemirror-opts="vm.ddlEditorOptions" ui-refresh="vm.refreshViewDdl"></div>
+                        <div ui-codemirror="{ onLoad : vm.editorLoaded }" ng-model="vm.viewDdl" ui-codemirror-opts="vm.ddlEditorOptions" ui-refresh="vm.refreshViewDdl"></div>
+                        <div class="has-error" ng-if="vm.showDdlError">
+                            <span class="help-block">{{vm.ddlErrorMsg}}</span>
+                        </div>
                     </div>
+                    <p>&nbsp;</p>
                     <div class="col-md-12">
                         <p><strong>{{'dataservice-new.sourceTablesLimitedMsg' | translate}}</strong></p>
                         <h4 ng-show="vm.sourceNames[0]!=null">&nbsp;&nbsp;{{vm.sourceNames[0]}}.{{vm.tableNames[0]}}</h4>
@@ -36,7 +40,7 @@
                         <p>&nbsp;</p>
                     </div>
                     <div class="col-md-12">
-                        <input type="submit" class="btn btn-primary" value="{{:: 'shared.Finish' | translate}}" ng-click="vm.finishClicked()" />
+                        <input type="submit" class="btn btn-primary" value="{{:: 'shared.Finish' | translate}}" ng-click="vm.finishClicked()" ng-disabled="vm.disableFinish"/>
                         <input type="button" class="btn btn-default" value="{{:: 'shared.Cancel' | translate}}" ng-click="vmmain.selectPage('dataservice-summary')" />
                     </div>
                 </uib-tab>

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/jdbcFilterOptions.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/jdbcFilterOptions.js
@@ -156,7 +156,15 @@
                                 if(result[r].type === JDBC_FILTER.CATALOG) {
                                     hasCatalogs = true;
                                 }
-                                treeInfo.push(resultItem);
+                                // teiid handling - dont show SYS, SYSADMIN, pg_catalog schemas
+                                if(connection.dv__driverName === "teiid") {
+                                    if(resultItem.type==="Schema" && 
+                                        (resultItem.name!=="SYS" && resultItem.name!=="SYSADMIN" && resultItem.name!=="pg_catalog")) {
+                                        treeInfo.push(resultItem);
+                                    }
+                                } else {
+                                    treeInfo.push(resultItem);
+                                }
                             }
                             // filters available - use to set initial selections
                             if(vm.catalogFilter!==JDBC_FILTER.BLANK || vm.schemaFilter!==JDBC_FILTER.BLANK) {


### PR DESCRIPTION
- adds help message under the "Expert" ddl area
- now monitors codemirror ddl area for ddl changes.  If the area is empty (no view definition entered) a message is displayed and the finish button is disabled.  User must enter something.
- changed exception handling in dsEditController and dsNewController.  If there is a problem setting the view definition, the error message is displayed and the user stays on the page.  This forces the user to enter a parsable DDL before leaving the wizard.
- change jdbcFilterOptions to filter out certain schema for teiid sources  