### PR TITLE
TEIIDTOOLS-60 Eliminate usage of temp vdbs

### DIFF
--- a/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
@@ -512,7 +512,7 @@
         /**
          * Service: create a new VDB in the repository
          */
-        service.updateVdbModel = function (vdbName, modelName, isSource, importerProperties) {
+        service.updateVdbModel = function (vdbName, modelName, isSource, importerProperties, modelDdl) {
             if (!vdbName || !modelName) {
                 throw new RestServiceException("VDB name or model name is not defined");
             }
@@ -522,7 +522,8 @@
                     "keng__id": modelName,
                     "keng__dataPath": getUserWorkspacePath()+"/"+vdbName+"/"+modelName,
                     "keng__kType": "Model",
-                    "mmcore__modelType": "PHYSICAL"
+                    "mmcore__modelType": "PHYSICAL",
+                    "keng__ddl": modelDdl
                 };
                 
                 

--- a/vdb-bench-assembly/plugins/vdb-bench-core/constants.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/constants.js
@@ -43,8 +43,7 @@
             SEMI_COLON: ';',
             SPEECH_MARKS: '"',
             HTML: 'html',
-            UNKNOWN: 'unknown',
-            TEMP: 'temp'
+            UNKNOWN: 'unknown'
         })
 
         .constant('JOIN', {

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceEditController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/svcSourceEditController.js
@@ -277,7 +277,7 @@
                 } else {
                     // Filter properties changed, update the model
                     if(vm.filterPropsChanged) {
-                        RepoRestService.updateVdbModel( vm.svcSourceName, connectionName, true, filterProperties).then(
+                        RepoRestService.updateVdbModel( vm.svcSourceName, connectionName, true, filterProperties, "").then(
                                 function (theModel) {
                                     if(vm.translatorChanged) {
                                         updateVdbModelSource( vm.svcSourceName, connectionName, connectionName, translatorName, jndiName );

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsEditController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsEditController.js
@@ -89,7 +89,7 @@
                         var selSvcSourceModelName = model.keng__id;
 
                         // Path to table for definition of the dataservice vdb
-                        var relativeTablePath = SYNTAX.TEMP+vm.sourceNames[0]+"/"+selSvcSourceModelName+"/"+vm.tableNames[0];
+                        var relativeTablePath = vm.sourceNames[0]+"/"+selSvcSourceModelName+"/"+vm.tableNames[0];
 
                         // Columns to include in the service
                         var columnNames = [];
@@ -143,9 +143,9 @@
                         var rhSourceModelName = models[1].keng__id;
 
                         // Path for LH table
-                        var lhRelativeTablePath = SYNTAX.TEMP+vm.sourceNames[0]+"/"+lhSourceModelName+"/"+vm.tableNames[0];
+                        var lhRelativeTablePath = vm.sourceNames[0]+"/"+lhSourceModelName+"/"+vm.tableNames[0];
                         // Path for RH table
-                        var rhRelativeTablePath = SYNTAX.TEMP+vm.sourceNames[1]+"/"+rhSourceModelName+"/"+vm.tableNames[1];
+                        var rhRelativeTablePath = vm.sourceNames[1]+"/"+rhSourceModelName+"/"+vm.tableNames[1];
                         
                         // Columns to include in the service
                         var lhColumnNames = EditWizardService.source1SelectedColumns();
@@ -232,7 +232,7 @@
 
                     // Path to modelSource and temp table for definition of the dataservice vdb
                     var relativeModelSourcePath = vm.sourceNames[0]+"/"+selSvcSourceModelName+"/vdb:sources/"+selSvcSourceModelName;
-                    var relativeTablePath = SYNTAX.TEMP+vm.sourceNames[0]+"/"+selSvcSourceModelName+"/"+vm.tableNames[0];
+                    var relativeTablePath = vm.sourceNames[0]+"/"+selSvcSourceModelName+"/"+vm.tableNames[0];
 
                     try {
                         RepoRestService.setDataServiceVdbForSingleTable( dataserviceName, relativeModelSourcePath, vm.viewDdl, relativeTablePath, null ).then(
@@ -266,12 +266,12 @@
                     var lhSourceModelName = models[0].keng__id;
                     var rhSourceModelName = models[1].keng__id;
 
-                    // Path for LH model source and temp table
+                    // Path for LH model source and table
                     var lhRelativeModelSourcePath = vm.sourceNames[0]+"/"+lhSourceModelName+"/vdb:sources/"+lhSourceModelName;
-                    var lhRelativeTablePath = SYNTAX.TEMP+vm.sourceNames[0]+"/"+lhSourceModelName+"/"+vm.tableNames[0];
-                    // Path for RH model source and temp table
+                    var lhRelativeTablePath = vm.sourceNames[0]+"/"+lhSourceModelName+"/"+vm.tableNames[0];
+                    // Path for RH model source and table
                     var rhRelativeModelSourcePath = vm.sourceNames[1]+"/"+rhSourceModelName+"/vdb:sources/"+rhSourceModelName;
-                    var rhRelativeTablePath = SYNTAX.TEMP+vm.sourceNames[1]+"/"+rhSourceModelName+"/"+vm.tableNames[1];
+                    var rhRelativeTablePath = vm.sourceNames[1]+"/"+rhSourceModelName+"/"+vm.tableNames[1];
 
                     // Join type
                     var joinType = EditWizardService.joinType();

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsNewController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsNewController.js
@@ -78,7 +78,7 @@
                     var selSvcSourceModelName = model.keng__id;
 
                     // Path to table for definition of the dataservice vdb
-                    var relativeTablePath = SYNTAX.TEMP+vm.sourceNames[0]+"/"+selSvcSourceModelName+"/"+vm.tableNames[0];
+                    var relativeTablePath = vm.sourceNames[0]+"/"+selSvcSourceModelName+"/"+vm.tableNames[0];
 
                     // Columns to include in the service
                     var columnNames = [];
@@ -125,9 +125,9 @@
                     var rhSourceModelName = models[1].keng__id;
 
                     // Path for LH table
-                    var lhRelativeTablePath = SYNTAX.TEMP+vm.sourceNames[0]+"/"+lhSourceModelName+"/"+vm.tableNames[0];
+                    var lhRelativeTablePath = vm.sourceNames[0]+"/"+lhSourceModelName+"/"+vm.tableNames[0];
                     // Path for RH table
-                    var rhRelativeTablePath = SYNTAX.TEMP+vm.sourceNames[1]+"/"+rhSourceModelName+"/"+vm.tableNames[1];
+                    var rhRelativeTablePath = vm.sourceNames[1]+"/"+rhSourceModelName+"/"+vm.tableNames[1];
                     
                     // Columns to include in the service
                     var lhColumnNames = EditWizardService.source1SelectedColumns();
@@ -213,9 +213,9 @@
                 var singleSuccessCallback = function(model) {
                     var selSvcSourceModelName = model.keng__id;
 
-                    // Path to modelSource and temp table for definition of the dataservice vdb
+                    // Path to modelSource and table for definition of the dataservice vdb
                     var relativeModelSourcePath = sourceName+"/"+selSvcSourceModelName+"/vdb:sources/"+selSvcSourceModelName;
-                    var relativeTablePath = SYNTAX.TEMP+sourceName+"/"+selSvcSourceModelName+"/"+tableName;
+                    var relativeTablePath = sourceName+"/"+selSvcSourceModelName+"/"+tableName;
 
                     try {
                         RepoRestService.setDataServiceVdbForSingleTable( dataserviceName, relativeModelSourcePath, vm.viewDdl, relativeTablePath, null ).then(
@@ -249,12 +249,12 @@
                     var lhSourceModelName = models[0].keng__id;
                     var rhSourceModelName = models[1].keng__id;
 
-                    // Path for LH model source and temp table
+                    // Path for LH model source and table
                     var lhRelativeModelSourcePath = vm.sourceNames[0]+"/"+lhSourceModelName+"/vdb:sources/"+lhSourceModelName;
-                    var lhRelativeTablePath = SYNTAX.TEMP+vm.sourceNames[0]+"/"+lhSourceModelName+"/"+vm.tableNames[0];
-                    // Path for RH model source and temp table
+                    var lhRelativeTablePath = vm.sourceNames[0]+"/"+lhSourceModelName+"/"+vm.tableNames[0];
+                    // Path for RH model source and table
                     var rhRelativeModelSourcePath = vm.sourceNames[1]+"/"+rhSourceModelName+"/vdb:sources/"+rhSourceModelName;
-                    var rhRelativeTablePath = SYNTAX.TEMP+vm.sourceNames[1]+"/"+rhSourceModelName+"/"+vm.tableNames[1];
+                    var rhRelativeTablePath = vm.sourceNames[1]+"/"+rhSourceModelName+"/"+vm.tableNames[1];
 
                     try {
                         RepoRestService.setDataServiceVdbForJoinTables( dataserviceName, lhRelativeModelSourcePath, rhRelativeModelSourcePath, vm.viewDdl,

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/EditWizardService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/EditWizardService.js
@@ -49,9 +49,6 @@
          *   If dataservice is supplied, init values for the dataservice.
          */
         service.init = function (dataservice, pageId) {
-            // clear temporary models
-            clearTemporaryModels();
-
             // null dataservice, reset values
             if(dataservice===null) {
                 resetSelections();
@@ -490,20 +487,13 @@
         };
 
         /**
-         * Clears any temp models that may exist in the workspace
-         */
-        function clearTemporaryModels() {
-            // TODO:  clean up temp models
-        }
-
-        /**
          * Initialize the selections for the dataservice
          */
         function initServiceSelections ( dataServiceName, pageId ) {
             // Reset selections
             service.resetSourceTables();
 
-            // Gets the teiid model schema.  If successful, create a temp model using the schema
+            // Gets the teiid model schema.  If successful, update model using the schema
             try {
                 RepoRestService.getViewInfoForDataService( dataServiceName ).then(
                     function ( result ) {
@@ -576,9 +566,9 @@
          * Get the Vdb model table columns
          */
         function setSourceTableColumns(nSrc,vdbName,modelName,tableName) {
-            // Update the items using the Repo scratch object
+            // Update the items
             try {
-                RepoRestService.getVdbModelTableColumns( SYNTAX.TEMP+vdbName, modelName, tableName ).then(
+                RepoRestService.getVdbModelTableColumns( vdbName, modelName, tableName ).then(
                     function ( result ) {
                         if(nSrc===1) {
                             EditWizardService.setSource1AvailableColumns(result);

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.js
@@ -409,11 +409,11 @@
          * Creates a temp model in the workspace from teiid DDL.  Temp model is used to build the Views
          */
         function updateVdbModelFromDdl ( vdbName, modelName ) {
-            // Gets the teiid model schema.  If successful, create a temp model using the schema
+            // Updates the selected VdbModel using the specified teiid model schema.
             try {
-                RepoRestService.updateVdbModelFromDdl( SYNTAX.TEMP+vdbName, modelName, vdbName, modelName ).then(
+                RepoRestService.updateVdbModelFromDdl( vdbName, modelName, vdbName, modelName ).then(
                         function ( result ) {
-                            getTempVdbModels( SYNTAX.TEMP+vdbName );
+                            getTempVdbModels( vdbName );
                         },
                         function (response) {
                             var updateVdbFailedMsg = $translate.instant('dataserviceEditWizard.updateVdbFromDdlFailedMsg');
@@ -510,9 +510,9 @@
          * Get the Vdb model table columns
          */
         function setSourceTableColumns(nSrc,vdbName,modelName,tableName) {
-            // Update the items using the Repo scratch object
+            // Update the items using the specified repo table
             try {
-                RepoRestService.getVdbModelTableColumns( SYNTAX.TEMP+vdbName, modelName, tableName ).then(
+                RepoRestService.getVdbModelTableColumns( vdbName, modelName, tableName ).then(
                     function ( result ) {
                         if(nSrc===1) {
                             EditWizardService.setSource1AvailableColumns(result);
@@ -599,9 +599,9 @@
                 var singleSuccessCallback = function(model) {
                     var selSvcSourceModelName = model.keng__id;
 
-                    // Path to modelSource and temp table for definition of the dataservice vdb
+                    // Path to modelSource and table for definition of the dataservice vdb
                     var relativeModelSourcePath = sourceName+"/"+selSvcSourceModelName+"/vdb:sources/"+selSvcSourceModelName;
-                    var relativeTablePath = SYNTAX.TEMP+sourceName+"/"+selSvcSourceModelName+"/"+tableName;
+                    var relativeTablePath = sourceName+"/"+selSvcSourceModelName+"/"+tableName;
                     
                     // Columns to include in the service
                     var columnNames = [];
@@ -647,12 +647,12 @@
                     var lhSourceModelName = models[0].keng__id;
                     var rhSourceModelName = models[1].keng__id;
 
-                    // Path for LH model source and temp table
+                    // Path for LH model source and table
                     var lhRelativeModelSourcePath = lhSourceName+"/"+lhSourceModelName+"/vdb:sources/"+lhSourceModelName;
-                    var lhRelativeTablePath = SYNTAX.TEMP+lhSourceName+"/"+lhSourceModelName+"/"+lhTableName;
+                    var lhRelativeTablePath = lhSourceName+"/"+lhSourceModelName+"/"+lhTableName;
                     // Path for RH model source and temp table
                     var rhRelativeModelSourcePath = rhSourceName+"/"+rhSourceModelName+"/vdb:sources/"+rhSourceModelName;
-                    var rhRelativeTablePath = SYNTAX.TEMP+rhSourceName+"/"+rhSourceModelName+"/"+rhTableName;
+                    var rhRelativeTablePath = rhSourceName+"/"+rhSourceModelName+"/"+rhTableName;
                     
                     // Columns to include in the service
                     var lhColumnNames = EditWizardService.source1SelectedColumns();

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/modelTableList.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/modelTableList.js
@@ -49,12 +49,12 @@
                 vm.tablesLoading = false;
                 return;
             }
-            var tempVdbName = SYNTAX.TEMP+selectedSource.keng__id;
+            var vdbName = selectedSource.keng__id;
             
             var successCallback = function(model) {
-                // Update the items using the Repo scratch object
+                // Update the items using the specified vdb model
                 try {
-                    RepoRestService.getVdbModelTables( tempVdbName, model.keng__id ).then(
+                    RepoRestService.getVdbModelTables( vdbName, model.keng__id ).then(
                         function ( result ) {
                             vm.allItems = result;
                             vm.items = vm.allItems;


### PR DESCRIPTION
Previously was using local temp/scratch VDBs to maintain the 'datasource' model definitions.  This PR eliminates the temp VDB usage - now maintaining directly on the 'datasource' vdb models.
- removes 'TEMP' prefix from syntax constants and eliminates usage.
- allow modelDefinition property to be passed in RepositoryRestService with other properties.