### PR TITLE
minor ui cleanup

### DIFF
--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -443,7 +443,7 @@
     
     "sqlControl" : {
         "controlFailedMsg" : "Encountered query error: {{errorMsg}}",
-        "instructionMsg" : "Enter query text then click Search",
+        "instructionMsg" : "Enter query text then click Submit",
         "RecordLimit" : "Record Limit",
         "StartingRecordIndex" : "Starting Record Index",
         "help" : {

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsPageService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsPageService.js
@@ -102,7 +102,7 @@
             id: service.DS_PREFERENCE_PAGE,
             title: $translate.instant('dsPageService.preferencesTitle'),
             showTitle: false,
-            icon: 'pficon-settings',
+            icon: 'fa fa-cog',
             helpId: service.DS_PREFERENCE_PAGE,
             parent: null,
             template: config.pluginDir + syntax.FORWARD_SLASH +

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/content/css/styles.less
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/content/css/styles.less
@@ -439,12 +439,8 @@ body.ng-pageslide-body-closed::before {
     padding: 10px;
 }
 
-.repo-props .border-title {
-    text-align: left;
-    margin-top: -20px;
-    margin-left: 20px;
-    height: 20px;
-    font-size: inherit;
+.repo-props-title {
+    margin-bottom: 0px;
+    padding-left: 20px;
     font-weight: bold;
-    background-color: inherit;
 }

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/gitCredentialsControl.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/gitCredentialsControl.html
@@ -31,8 +31,8 @@
             </div>
         </div>
 
+        <h5 class="repo-props-title" translate="gitCredentialsControl.Properties" />
         <div class="repo-props">
-            <h1 class="border-title" translate="gitCredentialsControl.Properties" />
             <div class="form-group" ng-show="vm.showName">
                 <div class="col-sm-3">
                     <label class="help-label git-prefs-help">


### PR DESCRIPTION
A few minor changes noticed in the ui.
- on test page changed the instruction text to match the button name
- changed preference page title icon to match preferences (fa-cog)
- git preferences property section - moved the 'Properties' heading outside the 'box'.  changed styling to put the heading right on top of the border.  Fixes previous issue with border line going thru the heading.