### PR TITLE
TEIIDTOOLS-154 Inits join criteria for 2 table services

### DIFF
--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -335,6 +335,7 @@
 
     "editWizardService" : {
         "initTableSelectionsFailedMsg" : "Error initializing data service source table selections.",
+        "getJoinCriteriaFailedMsg" : "Error retrieving join criteria.",
         "nameRequired" : "@:shared.nameRequired",
         "validateDataServiceNameError" : "Error validating data service name."
     },

--- a/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
@@ -1087,6 +1087,24 @@
         };
 
         /**
+         * Service: Get the DataService join criteria for the provided tables.
+         */
+        service.getJoinCriteriaForTables = function (tablePath, rhTablePath ) {
+            if ( !tablePath || !rhTablePath ) {
+                throw RestServiceException("getJoinCriteria inputs are not sufficiently defined");
+            }
+            
+            return getRestService().then(function (restService) {
+                var payload = {
+                    "tablePath": getUserWorkspacePath()+"/"+tablePath,
+                    "rhTablePath": getUserWorkspacePath()+"/"+rhTablePath
+                };
+
+                return restService.all(REST_URI.WORKSPACE + REST_URI.DATA_SERVICES + SYNTAX.FORWARD_SLASH + REST_URI.CRITERIA_FOR_JOIN_TABLES).post(payload);
+            });
+        };
+
+        /**
          * Service: delete a data service from the resposiory
          */
         service.deleteDataService = function (dataserviceName) {

--- a/vdb-bench-assembly/plugins/vdb-bench-core/constants.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/constants.js
@@ -68,6 +68,7 @@
             TABLES: '/Tables',
             COLUMNS: '/Columns',
             JDBC_CATALOG_SCHEMA: '/JdbcCatalogSchema',
+            CRITERIA_FOR_JOIN_TABLES: 'CriteriaForJoinTables',
             SERVICE_VDB_FOR_SINGLE_TABLE: 'ServiceVdbForSingleTable',
             SERVICE_VDB_FOR_JOIN_TABLES: 'ServiceVdbForJoinTables',
             SERVICE_VIEW_DDL_FOR_SINGLE_TABLE: 'ServiceViewDdlForSingleTable',

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasourceSummaryController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasourceSummaryController.js
@@ -419,8 +419,18 @@
             // Need to select the item first
             SvcSourceSelectionService.selectServiceSource(item);
 
-            editSvcSourceClicked();
+            // Initiate a Connection refresh prior to edit.  Wait for the refresh to complete before proceeding.  
+            ConnectionSelectionService.refresh();
         };
+
+        /*
+         * Edit triggers a Connection refresh.  When complete (loading=false), proceed with the edit.
+         */
+        $scope.$on('loadingConnectionsChanged', function (event, loading) {
+            if(loading === false) {
+                editSvcSourceClicked();
+            }
+        });
 
         /**
          * Handle clone ServiceSource click

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsEditController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsEditController.js
@@ -143,11 +143,13 @@
 
                 // Failure callback
                 var singleFailureCallback = function(errorMsg) {
+                    vm.viewDdl = DEFAULT_VIEW;
+                    vm.refreshViewDdl = !vm.refreshViewDdl;
                     alert($translate.instant('shared.changedConnectionFailedMsg', {errorMsg: errorMsg}));
                 };
 
                 // get model for source 1
-                getModelForSource(EditWizardService.sources()[0], singleSuccessCallback, singleFailureCallback);
+                EditWizardService.getModelForSourceVdb(EditWizardService.sources()[0], singleSuccessCallback, singleFailureCallback);
             // -------------------------------------------------
             // Two tables selected
             // -------------------------------------------------
@@ -210,7 +212,7 @@
                 };
 
                 // get models for sources
-                getModelsForSources(EditWizardService.sources(), joinSuccessCallback, joinFailureCallback);
+                EditWizardService.getModelsForSourceVdbs(EditWizardService.sources(), joinSuccessCallback, joinFailureCallback);
             }
         }
 
@@ -262,11 +264,13 @@
 
                 // Failure callback
                 var singleFailureCallback = function(errorMsg) {
+                    vm.viewDdl = DEFAULT_VIEW;
+                    vm.refreshViewDdl = !vm.refreshViewDdl;
                     alert($translate.instant('shared.changedConnectionFailedMsg', {errorMsg: errorMsg}));
                 };
 
                 // get model for source 1
-                getModelForSource(EditWizardService.sources()[0], singleSuccessCallback, singleFailureCallback);
+                EditWizardService.getModelForSourceVdb(EditWizardService.sources()[0], singleSuccessCallback, singleFailureCallback);
             // -------------------------------------------------
             // Two tables selected
             // -------------------------------------------------
@@ -298,64 +302,8 @@
                 };
 
                 // get models for sources
-                getModelsForSources(EditWizardService.sources(), joinSuccessCallback, joinFailureCallback);
+                EditWizardService.getModelsForSourceVdbs(EditWizardService.sources(), joinSuccessCallback, joinFailureCallback);
             }
-        }
-
-        /*
-         * success callback has the model for the requested source
-         */
-        function getModelForSource(sourceName, onSuccessCallback, onFailureCallback) {
-            try {
-                RepoRestService.getVdbModels(sourceName).then(
-                    function (models) {
-                        if (_.isEmpty(models) || models.length === 0) {
-                            onFailureCallback("Failed getting VDB Models.\nThe source model is not available");
-                            return;
-                        }
-
-                        onSuccessCallback(models[0]);
-                    },
-                    function (response) {
-                        vm.viewDdl = DEFAULT_VIEW;
-                        vm.refreshViewDdl = !vm.refreshViewDdl;
-                        onFailureCallback("Failed getting VDB Models.\n" + RepoRestService.responseMessage(response));
-                    });
-            } catch (error) {
-                vm.viewDdl = DEFAULT_VIEW;
-                vm.refreshViewDdl = !vm.refreshViewDdl;
-                onFailureCallback("An exception occurred:\n" + error.message);
-            }
-        }
-
-        /*
-         * success callback has the models for the requested sources
-         */
-        function getModelsForSources(sourceNames, onSuccessCallback, onFailureCallback) {
-            var resultModels = [];
-
-            // Success callback returns the source 1 model
-            var successCallback = function(model) {
-                resultModels.push(model);
-                
-                // Call again to get the second model
-                var innerSuccessCallback = function(model) {
-                    resultModels.push(model);
-                    onSuccessCallback(resultModels);
-                };
-                var innerFailureCallback = function(errorMsg) {
-                    onFailureCallback("An exception occurred: \n" + errorMsg.message);
-                };
-                
-                getModelForSource(sourceNames[1], innerSuccessCallback, innerFailureCallback);
-            };
-
-            // Failure callback
-            var failureCallback = function(errorMsg) {
-                alert($translate.instant('shared.changedConnectionFailedMsg', {errorMsg: errorMsg}));
-            };
-            
-            getModelForSource(sourceNames[0], successCallback, failureCallback);
         }
 
         function ddlChanged(obj) {

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsNewController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsNewController.js
@@ -121,11 +121,13 @@
 
                 // Failure callback
                 var singleFailureCallback = function(errorMsg) {
+                    vm.viewDdl = DEFAULT_VIEW;
+                    vm.refreshViewDdl = !vm.refreshViewDdl;
                     alert($translate.instant('shared.changedConnectionFailedMsg', {errorMsg: errorMsg}));
                 };
 
                 // get model for source 1
-                getModelForSource(EditWizardService.sources()[0], singleSuccessCallback, singleFailureCallback);
+                EditWizardService.getModelForSourceVdb(EditWizardService.sources()[0], singleSuccessCallback, singleFailureCallback);
             // -------------------------------------------------
             // Two tables selected
             // -------------------------------------------------
@@ -182,7 +184,7 @@
                 };
 
                 // get models for sources
-                getModelsForSources(EditWizardService.sources(), joinSuccessCallback, joinFailureCallback);
+                EditWizardService.getModelsForSourceVdbs(EditWizardService.sources(), joinSuccessCallback, joinFailureCallback);
             }
         }
 
@@ -233,11 +235,13 @@
 
                 // Failure callback
                 var singleFailureCallback = function(errorMsg) {
+                    vm.viewDdl = DEFAULT_VIEW;
+                    vm.refreshViewDdl = !vm.refreshViewDdl;
                     alert($translate.instant('shared.changedConnectionFailedMsg', {errorMsg: errorMsg}));
                 };
 
                 // get model for source 1
-                getModelForSource(EditWizardService.sources()[0], singleSuccessCallback, singleFailureCallback);
+                EditWizardService.getModelForSourceVdb(EditWizardService.sources()[0], singleSuccessCallback, singleFailureCallback);
             // -------------------------------------------------
             // Two tables selected
             // -------------------------------------------------
@@ -266,64 +270,8 @@
                 };
 
                 // get models for sources
-                getModelsForSources(EditWizardService.sources(), joinSuccessCallback, joinFailureCallback);
+                EditWizardService.getModelsForSourceVdbs(EditWizardService.sources(), joinSuccessCallback, joinFailureCallback);
             }
-        }
-
-        /*
-         * success callback has the model for the requested source
-         */
-        function getModelForSource(sourceName, onSuccessCallback, onFailureCallback) {
-            try {
-                RepoRestService.getVdbModels(sourceName).then(
-                    function (models) {
-                        if (_.isEmpty(models) || models.length === 0) {
-                            onFailureCallback("Failed getting VDB Models.\nThe source model is not available");
-                            return;
-                        }
-
-                        onSuccessCallback(models[0]);
-                    },
-                    function (response) {
-                        vm.viewDdl = DEFAULT_VIEW;
-                        vm.refreshViewDdl = !vm.refreshViewDdl;
-                        onFailureCallback("Failed getting VDB Models.\n" + RepoRestService.responseMessage(response));
-                    });
-            } catch (error) {
-                vm.viewDdl = DEFAULT_VIEW;
-                vm.refreshViewDdl = !vm.refreshViewDdl;
-                onFailureCallback("An exception occurred:\n" + error.message);
-            }
-        }
-
-        /*
-         * success callback has the models for the requested sources
-         */
-        function getModelsForSources(sourceNames, onSuccessCallback, onFailureCallback) {
-            var resultModels = [];
-
-            // Success callback returns the source 1 model
-            var successCallback = function(model) {
-                resultModels.push(model);
-                
-                // Call again to get the second model
-                var innerSuccessCallback = function(model) {
-                    resultModels.push(model);
-                    onSuccessCallback(resultModels);
-                };
-                var innerFailureCallback = function(errorMsg) {
-                    onFailureCallback("An exception occurred: \n" + errorMsg.message);
-                };
-                
-                getModelForSource(sourceNames[1], innerSuccessCallback, innerFailureCallback);
-            };
-
-            // Failure callback
-            var failureCallback = function(errorMsg) {
-                alert($translate.instant('shared.changedConnectionFailedMsg', {errorMsg: errorMsg}));
-            };
-            
-            getModelForSource(sourceNames[0], successCallback, failureCallback);
         }
 
         function ddlChanged(obj) {

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.js
@@ -186,6 +186,8 @@
                 EditWizardService.setIncludeAllSource1Columns(true);
                 vm.includeAllColumns = EditWizardService.includeAllSource1Columns();
             }
+            // Deselect tree selections
+            vm.initialTreeNodeSelection = null;
             updateInstructionMessage();
             updateNextEnablementAndText();
         };
@@ -199,6 +201,8 @@
             vm.selectedTables = EditWizardService.sourceTables();
             // update checkbox based on the new source1
             vm.includeAllColumns = EditWizardService.includeAllSource1Columns();
+            // Deselect tree selections
+            vm.initialTreeNodeSelection = null;
             updateInstructionMessage();
             updateNextEnablementAndText();
         };
@@ -626,7 +630,7 @@
                 };
 
                 // get model for source 1
-                getModelForSource(EditWizardService.sources()[0], singleSuccessCallback, singleFailureCallback);
+                EditWizardService.getModelForSourceVdb(EditWizardService.sources()[0], singleSuccessCallback, singleFailureCallback);
             // -------------------------------------------------
             // Two tables selected
             // -------------------------------------------------
@@ -683,60 +687,8 @@
                 };
 
                 // get models for sources
-                getModelsForSources(EditWizardService.sources(), joinSuccessCallback, joinFailureCallback);
+                EditWizardService.getModelsForSourceVdbs(EditWizardService.sources(), joinSuccessCallback, joinFailureCallback);
             }
-        }
-
-        /*
-         * success callback has the model for the requested source
-         */
-        function getModelForSource(sourceName, onSuccessCallback, onFailureCallback) {
-            try {
-                RepoRestService.getVdbModels(sourceName).then(
-                    function (models) {
-                        if (_.isEmpty(models) || models.length === 0) {
-                            onFailureCallback("Failed getting VDB Models.\nThe source model is not available");
-                            return;
-                        }
-
-                        onSuccessCallback(models[0]);
-                    },
-                    function (response) {
-                        onFailureCallback("Failed getting VDB Models.\n" + RepoRestService.responseMessage(response));
-                    });
-            } catch (error) {
-                onFailureCallback("An exception occurred:\n" + error.message);
-            }
-        }
-
-        /*
-         * success callback has the models for the requested sources
-         */
-        function getModelsForSources(sourceNames, onSuccessCallback, onFailureCallback) {
-            var resultModels = [];
-
-            // Success callback returns the source 1 model
-            var successCallback = function(model) {
-                resultModels.push(model);
-                
-                // Call again to get the second model
-                var innerSuccessCallback = function(model) {
-                    resultModels.push(model);
-                    onSuccessCallback(resultModels);
-                };
-                var innerFailureCallback = function(errorMsg) {
-                    onFailureCallback("An exception occurred: \n" + errorMsg.message);
-                };
-                
-                getModelForSource(sourceNames[1], innerSuccessCallback, innerFailureCallback);
-            };
-
-            // Failure callback
-            var failureCallback = function(errorMsg) {
-                alert($translate.instant('shared.changedConnectionFailedMsg', {errorMsg: errorMsg}));
-            };
-            
-            getModelForSource(sourceNames[0], successCallback, failureCallback);
         }
 
         vm.getNameErrorMessage = function() {


### PR DESCRIPTION
This will init the join criteria when the user selects 2 tables for their data service.  If the tables have a pk-fk relationship, the criteria is based on that.  If no relationship exists, then criteria is not initialized.

- Added new service call to RepositoryRestService to get the join criteria.
- Adds join init function to EditWizardService to call the komodo service.
- moved 'getModelForSource' and 'getModelsForSources' functions into EditWizardService, so they could be reused.  The moved functions are now utilized in the other wizard page controllers (previously had copies of similar code).
- added fix for TEIIDTOOLS-153.  In datasourceSummaryController.js, now doing a refresh of the connections before proceeding to the edit page.