### PR TITLE
TEIIDTOOLS-145 Adds delete confirmation dialog

### DIFF
--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -110,6 +110,7 @@
         "connectionsNumberToolTip" : "The number of native data connections, eg. JDBC databases, utilised by this dataservice",
         "createDataServiceMsg" : "A Data Service is created using one or more Data Sources. To create your first Data Service, click <strong>New Data Service</strong> below.",
         "createSourceMsg" : "A Data Service is created using one or more Data Sources. To create your first Data Source, click ",
+        "confirmDeleteTitle" : "Confirm Delete",
         "documentationDataServiceMsg" : "Documentation such as how to connect to your data service and client examples are available here.",
         "documentationDataService" : "Documentation",
         "GitExport" : "Git Export",
@@ -247,6 +248,7 @@
     },
 
     "dsSummaryController" : {
+        "confirmDeleteMsg" : "Are you sure you want to delete data service '{{serviceName}}'?",
         "deleteFailedMsg" : "Failed to remove the data service: {{response}}",
         "deployFailedMsg" : "Failed to deploy the data service: {{response}}",
         "findSourceVdbsFailedMsg" : "Failed to find source VDBs: {{response}}",
@@ -254,7 +256,7 @@
         "descriptionFilterPlaceholder" : "Filter by Description...",
         "nameFilterPlaceholder" : "Filter by Name..."
     },
-    
+
     "dsTestController" : {
         "noResultsColumnName" : "Err: No Data!",
         "noResultsMsg" : "No data was returned from the query",
@@ -301,6 +303,7 @@
     },
 
     "datasource-summary" : {
+        "confirmDeleteTitle" : "Confirm Delete",
         "welcomeMsg" : "Currently, there are no data sources configured. In order to create a data service you must create a data source.",
         "noSourcesExist" : "No Data Sources Found",
         "noSourcesInstructionsMsg" : "To get started, click <strong>Configure Data Source</strong> below to create your first data source.",
@@ -325,6 +328,7 @@
         "actionTitleImport" : "Import a Data Source",
         "actionTitleNew" : "Create a Data Source",
         "actionTitleRefresh" : "Refresh the Table",
+        "confirmDeleteMsg" : "Are you sure you want to delete data source '{{sourceName}}'?",
         "gettingDdlMsg" : "Fetching DDL...",
         "getDdlFailedMsg" : "Failed to get the DDL.",
         "removeLocalSourceFailedMsg" : "Failed to remove the local ServiceSource.",

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/content/css/styles.less
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/content/css/styles.less
@@ -733,3 +733,7 @@ button[id^='dropdownKebabRight_'] {
 .dsb-wizard-container .wizard-pf-main {
     padding: 0em 2em 0em 2em !important;
 }
+
+.dsb-modal {
+    padding-right: 0em !important;
+}

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-summary.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-summary.html
@@ -1,6 +1,25 @@
 <div id="outer" class="outer-wrapper">
 	<div id="ds-summary-container" class="container-fluid" ng-controller="DSSummaryController as vm">
 	
+        <!-- Modal Dialog for user to confirm deletion of a data service -->
+        <div class="modal fade dsb-modal" id="confirmDeleteModal" tabindex="-1" role="dialog" aria-labelledby="confirmDeleteModalLabel" aria-hidden="true">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">
+                  <span class="pficon pficon-close"></span>
+                </button>
+                <h4 class="modal-title" id="confirmDeleteModalLabel" translate="dataservice-summary.confirmDeleteTitle"></h4>
+              </div>
+              <div class="modal-body">{{vm.confirmDeleteMsg}}</div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal" translate="shared.Cancel"></button>
+                <button type="button" class="btn btn-primary" ng-click="vm.deleteSelectedDataService()" translate="shared.Delete"></button>
+              </div>
+            </div>
+          </div>
+        </div>
+
 	    <!-- Content shown if No Sources or DataServices yet -->
         <div class="blank-slate-pf" 
              id="dataservice-summary-nosources-noservices" 

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasource-summary.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasource-summary.html
@@ -1,6 +1,25 @@
 <div id="outer" class="outer-wrapper"> 
     <div id="svcsource-summary-container" class="container-fluid" ng-controller="DatasourceSummaryController as vm">
-        
+
+        <!-- Modal Dialog for user to confirm deletion of a data source -->
+        <div class="modal fade dsb-modal" id="confirmDeleteModal" tabindex="-1" role="dialog" aria-labelledby="confirmDeleteModalLabel" aria-hidden="true">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">
+                  <span class="pficon pficon-close"></span>
+                </button>
+                <h4 class="modal-title" id="confirmDeleteModalLabel" translate="datasource-summary.confirmDeleteTitle"></h4>
+              </div>
+              <div class="modal-body">{{vm.confirmDeleteMsg}}</div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal" translate="shared.Cancel"></button>
+                <button type="button" class="btn btn-primary" ng-click="vm.deleteSelectedSvcSource()" translate="shared.Delete"></button>
+              </div>
+            </div>
+          </div>
+        </div>
+
         <!-- Content shown if No Sources yet -->
         <div class="blank-slate-pf" 
              id="svcsource-summary-nosources" 

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasourceSummaryController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasourceSummaryController.js
@@ -26,6 +26,7 @@
         vm.deleteVdbInProgress = false;
         vm.displayDdl = false; // Do not display by default
         vm.hasSources = false;
+        vm.confirmDeleteMsg = "";
 
         /**
          * Options for the codemirror editor used for previewing ddl
@@ -314,13 +315,15 @@
         };
      
         /**
-         * Handle delete ServiceSource click.
+         * Delete the selected ServiceSource.
          * 1) undeploy the vdb from the server
          * 2) delete the vdb from the repo
          */
-        var deleteSvcSourceClicked = function ( ) {
+        vm.deleteSelectedSvcSource = function ( ) {
             var selVdbName = SvcSourceSelectionService.selectedServiceSource().keng__id;
 
+            // dismiss the delete confirmation modal
+            $('#confirmDeleteModal').modal('hide');
             // Deletes the server and workspace vdbs.  Also does a refresh when complete
             deleteServerVdb(selVdbName);
         };
@@ -332,7 +335,9 @@
             // Need to select the item first
             SvcSourceSelectionService.selectServiceSource(item);
 
-            deleteSvcSourceClicked();
+            // show the delete confirmation modal
+            vm.confirmDeleteMsg = $translate.instant('datasourceSummaryController.confirmDeleteMsg', {sourceName: item.keng__id});
+            $('#confirmDeleteModal').modal('show');
         };
  
         /**

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsSummaryController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsSummaryController.js
@@ -23,6 +23,7 @@
         vm.deploymentMessage = null;
         vm.allItems = DSSelectionService.getDataServices();
         vm.items = vm.allItems;
+        vm.confirmDeleteMsg = "";
 
         function setHelpId() {
             var page = DSPageService.page(DSPageService.DATASERVICE_SUMMARY_PAGE);
@@ -203,10 +204,13 @@
         };
      
         /**
-         * Handle delete dataservice click
+         * Delete the selected data service
          */
-        var deleteDataServiceClicked = function ( ) {
+        vm.deleteSelectedDataService = function( ) {
             var selDSName = DSSelectionService.selectedDataService().keng__id;
+
+            // dismiss the delete confirmation modal
+            $('#confirmDeleteModal').modal('hide');
             try {
                 RepoRestService.deleteDataService( selDSName ).then(
                     function () {
@@ -217,7 +221,9 @@
                         throw RepoRestService.newRestException($translate.instant('dsSummaryController.deleteFailedMsg', 
                                                                                   {response: RepoRestService.responseMessage(response)}));
                     });
-            } catch (error) {} finally {
+            } catch (error) {
+                throw RepoRestService.newRestException($translate.instant('dsSummaryController.deleteFailedMsg', 
+                        {response: error.message}));
             }
 
             // Disable the actions until next selection
@@ -231,7 +237,9 @@
             // Need to select the item first
             DSSelectionService.selectDataService(item);
 
-            deleteDataServiceClicked();
+            // Show the delete confirmation modal
+            vm.confirmDeleteMsg = $translate.instant('dsSummaryController.confirmDeleteMsg', {serviceName: item.keng__id});
+            $('#confirmDeleteModal').modal('show');
         };
 
         /**


### PR DESCRIPTION
Adds delete confirmation modal dialog to dataservice and datasource summary pages.  The user must confirm before the item is deleted.  This should help prevent accidental deletion if a user mistakenly clicks the delete action.