### PR TITLE
TEIIDTOOLS-132 Improves dataservice export error display

### DIFF
--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -226,8 +226,10 @@
         "failedExportDetailMsg" : "Data service '{{dataServiceName}}' could not be exported to repository path '{{repoPath}}'",
         "failedExportMsg" : "<strong>Export Failed</strong>",
         "failedNoDetailsMsg" : "Data service '{{dataServiceName}}' failed for a unspecified reasons.'",
+        "hideErrorDetailTitle" : "Hide Error Detail",
         "missingPathMsg" : "@:dsImportGitWizard.missingPathMsg",
         "missingRepositoryUrlMsg" : "@:dsImportGitWizard.missingRepositoryUrlMsg",
+        "showErrorDetailTitle" : "Show Error Detail",
         "successfulExportDetailMsg" : "Data service '{{dataServiceName}}' was exported to repository path '{{repoPath}}'",
         "successfulExportMsg" : "<strong>Successful Export</strong>"
     },

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/export/dsExportGitWizard.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/export/dsExportGitWizard.js
@@ -13,6 +13,7 @@
     DSExportGitWizardController.$inject = ['$scope', 
                                            '$base64',
                                            '$translate',
+                                           '$sce',
                                            'SYNTAX', 
                                            'DSSelectionService', 
                                            'RepoRestService'];
@@ -39,6 +40,7 @@
     function DSExportGitWizardController($scope, 
                                          $base64,
                                          $translate,
+                                         $sce,
                                          syntax, 
                                          DSSelectionService, 
                                          RepoRestService) {
@@ -48,14 +50,24 @@
         vm.requireEmailName = false;
         vm.inProgress = false;
         vm.response = '';
+        vm.showDetails = false;
+        vm.detailsToggleTitle = $translate.instant("dsExportGitWizard.showErrorDetailTitle");
  
         function setError(message) {
-            if (message) {
-                message = message.replace(/<br\/>/g, syntax.NEWLINE);
-            }
-
-            vm.error = message;
+            vm.error = $sce.trustAsHtml(message);
         }
+
+        /**
+         * Toggles display of the error details
+         */
+        vm.toggleDetails = function() {
+            vm.showDetails = !vm.showDetails;
+            if(vm.showDetails) {
+                vm.detailsToggleTitle = $translate.instant("dsExportGitWizard.hideErrorDetailTitle");
+            } else {
+                vm.detailsToggleTitle = $translate.instant("dsExportGitWizard.showErrorDetailTitle");
+            }
+        };
 
         vm.exportFailure = function() {
             return !vm.inProgress && vm.response === 'Failed';

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/export/git-export-wizard.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/export/git-export-wizard.html
@@ -79,7 +79,10 @@
             </div>
             <h3 class="blank-slate-pf-main-action" translate="dsExportGitWizard.failedExportMsg" />
             <p class="blank-slate-pf-secondary-action">{{ vm.responseMsg }}</p>
-            <p class="blank-slate-pf-secondary-action">{{ vm.error }}</p>
+            <a ng-click="vm.toggleDetails()">{{vm.detailsToggleTitle}}</a>
+            <div ng-init="vm.showDetails = false" ng-show="vm.showDetails">
+                <p><div style="text-align:left" ng-bind-html="vm.error"></div></p>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
- displays stacktrace as html, so the html chars are rendered correctly
- added a toggle link to show/hide the error stacktrace
- left justify the stacktrace