### PR TITLE
Fixes TEIIDTOOLS-159

### DIFF
--- a/vdb-bench-assembly/plugins/vdb-bench-git-prefs/git-preferences.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-git-prefs/git-preferences.html
@@ -16,5 +16,10 @@
                                               these are excluded from local storage saving due to security reasons so no point in displaying them
         on-selection: callback for accessing the selected repository
     -->
-    <git-credentials-control edit="true" show-name="true", show-file-path="false" show-security-attributes="false"></git-credentials-control>
+    <git-credentials-control edit="true"
+                             show-name="true",
+                             show-file-path="false"
+                             show-repo-props="true"
+                             show-security-attributes="false">
+    </git-credentials-control>
 </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/gitCredentialsControl.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/gitCredentialsControl.js
@@ -24,7 +24,7 @@
             restrict: 'E',
             scope: {},
             bindToController: {
-                repo: '=',
+                repo: '=?',
                 edit: '=',
                 showName: '=',
                 showFilePath: '=',


### PR DESCRIPTION
- added 'show-repo-props' attribute to git control in git-preferences.html
- changed the 'repo' bind variable in gitCredentialsControl.js to be optional