### PR TITLE
TEIIDTOOLS-173 DataSource property change

### DIFF
--- a/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
@@ -462,7 +462,7 @@
                 // Property added to distinguish service sources
                 if (isSource)  {
                     payload.keng__properties = [{ "name": "dsbServiceSource",
-                                                  "value": "true"}];
+                                                  "value": CredentialService.credentials().username}];
                 }
 
                 var uri = REST_URI.WORKSPACE + REST_URI.VDBS + SYNTAX.FORWARD_SLASH + vdbName;
@@ -491,7 +491,7 @@
                 // Property added to distinguish service sources
                 if (isSource)  {
                     payload.keng__properties = [{ "name": "dsbServiceSource",
-                                                  "value": "true"}];
+                                                  "value": CredentialService.credentials().username}];
                 }
 
                 var uri = REST_URI.WORKSPACE + REST_URI.VDBS + SYNTAX.FORWARD_SLASH + vdbName;

--- a/vdb-bench-assembly/plugins/vdb-bench-core/SvcSourceSelectionService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/SvcSourceSelectionService.js
@@ -12,10 +12,10 @@
         .factory('SvcSourceSelectionService', SvcSourceSelectionService);
 
     SvcSourceSelectionService.$inject = ['$rootScope', 'SYNTAX', 'REST_URI', 'VDB_KEYS', 
-                                         'RepoRestService', 'ConnectionSelectionService', 'TranslatorSelectionService', 'DownloadService'];
+                                         'RepoRestService', 'CredentialService', 'ConnectionSelectionService', 'TranslatorSelectionService', 'DownloadService'];
 
     function SvcSourceSelectionService($rootScope, SYNTAX, REST_URI, VDB_KEYS, 
-                                        RepoRestService, ConnectionSelectionService, TranslatorSelectionService, DownloadService) {
+                                        RepoRestService, CredentialService, ConnectionSelectionService, TranslatorSelectionService, DownloadService) {
 
         var svcSrc = {};
         svcSrc.loading = false;
@@ -113,7 +113,7 @@
                 alert("An exception occurred:\n" + error.message);
             }
         }
-        
+
         /**
          * Updates the Workspace VDB status based on teiid deployments
          */
@@ -150,7 +150,7 @@
                         for(var key in allVdbs[i].keng__properties) {
                             var test = allVdbs[i].keng__properties[key].name;
                             var value = allVdbs[i].keng__properties[key].value;
-                            if(test=='dsbServiceSource' && value=='true') {
+                            if(test=='dsbServiceSource') {
                                 isSource = true;
                             }
                             if(test=='dsbSourceTranslator') {
@@ -338,7 +338,57 @@
 
             return true;
         };
-        
+
+        /*
+         * determine if the supplied datasource is a service source vdb
+         */
+        service.isServiceSource = function ( datasource ) {
+            var isSource = false;
+            for(var key in datasource.keng__properties) {
+                var propName = datasource.keng__properties[key].name;
+                var propValue = datasource.keng__properties[key].value;
+                if(propName==='dsbServiceSource') {
+                    isSource = true;
+                    break;
+                }
+            }
+            return isSource;
+        };
+
+        /*
+         * return the serviceSource owner name
+         *    (defaults to current user if the dsbServiceSource property is not found)
+         */
+        service.getServiceSourceOwner = function ( datasource ) {
+            var owner = CredentialService.credentials().username;
+            for(var key in datasource.keng__properties) {
+                var propName = datasource.keng__properties[key].name;
+                var propValue = datasource.keng__properties[key].value;
+                if(propName==='dsbServiceSource') {
+                    owner = propValue;
+                    break;
+                }
+            }
+            return owner;
+        };
+
+        /*
+         * return the serviceSource status
+         *    (defaults to 'Unknown' if the dsbTeiidStatus property is not found)
+         */
+        service.getServiceSourceStatus = function ( datasource ) {
+            var status = "Unknown";
+            for(var key in datasource.keng__properties) {
+                var propName = datasource.keng__properties[key].name;
+                var propValue = datasource.keng__properties[key].value;
+                if(propName==='dsbTeiidStatus') {
+                    status = propValue;
+                    break;
+                }
+            }
+            return status;
+        };
+
         /*
          * Refresh the collection of service sources
          */

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservicePageController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservicePageController.js
@@ -92,6 +92,8 @@
                 DatasourceWizardService.init(null,null);
             } else if(pageId == DSPageService.NEW_DATASERVICE_PAGE) {
                 EditWizardService.init(null,null);
+            } else if(pageId === DSPageService.SERVICESOURCE_SUMMARY_PAGE) {
+                SvcSourceSelectionService.refresh();
             }
 
             vm.prevPageId = vm.selectedPageId();

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasource-summary.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasource-summary.html
@@ -51,10 +51,13 @@
             <div class="svcsource-summary-results-container" ng-show="vm.srcLoading==false && vm.hasSources==true">
                 <div class="svcsource-summary-results">
                     <div class="col-md-12 list-view-container" ng-if="vm.viewType == 'listView'">
-                        <div pf-list-view config="vm.listConfig" 
+                        <div pf-list-view 
+                             config="vm.listConfig" 
                              items="vm.getServiceSources()"
                              action-buttons="vm.actionButtons"
-                             menu-actions="vm.menuActions">
+                             enable-button-for-item-fn="vm.enableButton"
+                             menu-actions="vm.menuActions"
+                             update-menu-action-for-item-fn="vm.enableMenuAction">
                             <div class="list-view-pf-left">
                                 <span class="fa fa-database list-view-pf-icon-sm"></span>
                             </div>
@@ -85,6 +88,11 @@
                                         <span class="fa fa-exchange"></span>
                                         <span ng-repeat="prop in item.keng__properties" ng-show="prop.name=='dsbSourceConnection'">
                                             {{prop.value}}
+                                        </span>
+                                    </div>
+                                    <div class="list-view-pf-additional-info-item" data-toggle="tooltip" data-placement="right" title="The owner of this source" >
+                                        <span ng-repeat="prop in item.keng__properties" ng-show="prop.name=='dsbServiceSource'">
+                                            Owner: {{prop.value}}
                                         </span>
                                     </div>
                                 </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasourceSummaryController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasourceSummaryController.js
@@ -10,11 +10,11 @@
 
     DatasourceSummaryController.$inject = ['$scope', '$rootScope', '$translate', 'RepoRestService', 'REST_URI', 'SYNTAX', 
                                            'SvcSourceSelectionService', 'TranslatorSelectionService', 'DatasourceWizardService', 
-                                           'ConnectionSelectionService', 'DownloadService', 'pfViewUtils'];
+                                           'ConnectionSelectionService', 'DownloadService', 'CredentialService', 'pfViewUtils'];
 
     function DatasourceSummaryController($scope, $rootScope, $translate, RepoRestService, REST_URI, SYNTAX, 
                                           SvcSourceSelectionService, TranslatorSelectionService, DatasourceWizardService, 
-                                          ConnectionSelectionService, DownloadService, pfViewUtils) {
+                                          ConnectionSelectionService, DownloadService, CredentialService, pfViewUtils) {
         var vm = this;
 
         vm.srcLoading = SvcSourceSelectionService.isLoading();
@@ -494,7 +494,8 @@
                 name: $translate.instant('datasourceSummaryController.actionNameEdit'),
                 title: $translate.instant('datasourceSummaryController.actionTitleEdit'),
                 actionFn: editSvcSourceMenuAction,
-                include: false
+                include: false,
+                isDisabled: true
             }
         ];
 
@@ -530,7 +531,7 @@
           sortConfig: vm.sortConfig,
           actionsConfig: vm.actionsConfig
         };
-     
+
         /**
          * List and Card Configuration
          */
@@ -542,7 +543,37 @@
           onSelect: handleSelect,
           checkDisabled: false
         };
-        
+
+        /**
+         * Sets the listView button enablements
+         */
+        vm.enableButton = function(action, item) {
+            // Disable edit if a different user owns the datasource
+            if(action.name==='Edit') {
+                var owner = SvcSourceSelectionService.getServiceSourceOwner(item);
+                if( owner === CredentialService.credentials().username ) {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+        };
+
+        /**
+         * Sets the listView menu actions enablements
+         */
+        vm.enableMenuAction = function(action, item) {
+            // Disable delete if a different user owns the datasource
+            if(action.name==='Delete') {
+                var owner = SvcSourceSelectionService.getServiceSourceOwner(item);
+                if( owner === CredentialService.credentials().username ) {
+                    action.isDisabled = false;
+                } else {
+                    action.isDisabled = true;
+                }
+            }
+        };
+
         /**
          * Access to the collection of data services
          */


### PR DESCRIPTION
This commit distinguishes the datasources by user on the datasource summary page.  The logged in user can still see all of the source vdbs (even those created by someone else), but they can only edit/delete the source vdbs that they own.
- For source VDBs, the dsbServiceSource property now holds the username as its value.
- datasource-summary page - additionallly shows the 'Owner' of the source.
- datasourceSummaryController - disables the 'Edit' button and 'Delete' menu action if the source is not owned by the logged in user.
- SvcSourceSelectionService - added some helper methods to get property values.
- svcSourceCloneController - the user is allowed to copy another users sources.  If another user owns the source being copied, the copied source's owner is updated to the current user before being redeployed.