### PR TITLE
TEIIDTOOLS-176 fix dataservice test deployment

### DIFF
--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -251,11 +251,14 @@
     "dsSummaryController" : {
         "confirmDeleteMsg" : "Are you sure you want to delete data service '{{serviceName}}'?",
         "deleteFailedMsg" : "Failed to remove the data service: {{response}}",
-        "deployFailedMsg" : "Failed to deploy the data service: {{response}}",
         "findSourceVdbsFailedMsg" : "Failed to find source VDBs: {{response}}",
         "findViewTablesFailedMsg" : "Failed to find view tables: {{response}}",
         "descriptionFilterPlaceholder" : "Filter by Description...",
         "nameFilterPlaceholder" : "Filter by Name..."
+    },
+
+    "DSSelectionService" : {
+        "deployFailedMsg" : "Failed to deploy the data service: {{response}}"
     },
 
     "dsTestController" : {

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservicePageController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservicePageController.js
@@ -94,6 +94,8 @@
                 EditWizardService.init(null,null);
             } else if(pageId === DSPageService.SERVICESOURCE_SUMMARY_PAGE) {
                 SvcSourceSelectionService.refresh();
+            } else if(pageId == DSPageService.TEST_DATASERVICE_PAGE) {
+                DSSelectionService.deploySelectedDataService();
             }
 
             vm.prevPageId = vm.selectedPageId();

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsSummaryController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsSummaryController.js
@@ -19,8 +19,6 @@
         vm.sourcesLoading = SvcSourceSelectionService.isLoading();
         vm.hasSources = false;
         vm.hasServices = false;
-        vm.deploymentSuccess = false;
-        vm.deploymentMessage = null;
         vm.allItems = DSSelectionService.getDataServices();
         vm.items = vm.allItems;
         vm.confirmDeleteMsg = "";
@@ -246,44 +244,6 @@
          * Handle deploy dataservice click
          */
         var deployDataServiceClicked = function ( ) {
-            var selDS = DSSelectionService.selectedDataService();
-            var selDSName = selDS.keng__id;
-            var dsVdbName = DSSelectionService.selectedDataServiceVdbName();
-
-            DSSelectionService.setDeploying(true, selDSName, false, null);
-            try {
-                RepoRestService.deployDataService( selDSName ).then(
-                    function ( result ) {
-                        vm.deploymentSuccess = result.Information.deploymentSuccess == "true";
-                        if(vm.deploymentSuccess === true) {
-
-                            var successCallback = function() {
-                                DSSelectionService.setDeploying(false, selDSName, true, null);
-                            };
-                            var failCallback = function(failMessage) {
-                                DSSelectionService.setDeploying(false, selDSName, false, failMessage);
-                            };
-
-                            //
-                            // Monitor the service vdb of the dataservice to determine when its active
-                            //
-                            RepoRestService.pollForActiveVdb(dsVdbName, successCallback, failCallback);
-
-                        } else {
-                            DSSelectionService.setDeploying(false, selDSName, false, result.Information.ErrorMessage1);
-                        }
-                   },
-                    function (response) {
-                        DSSelectionService.setDeploying(false, selDSName, false, RepoRestService.responseMessage(response));
-                        throw RepoRestService.newRestException($translate.instant('dsSummaryController.deployFailedMsg', 
-                                                                                  {response: RepoRestService.responseMessage(response)}));
-                    });
-            } catch (error) {} finally {
-                vm.deploymentSuccess = false;
-                vm.deploymentMessage = null;
-                DSSelectionService.setDeploying(false);
-            }
-
             // Broadcast the pageChange
             $rootScope.$broadcast("dataServicePageChanged", 'dataservice-test');
         };


### PR DESCRIPTION
- Moves the dataservice vdb deployment function from dsSummaryController into the DSSelectionService.
- Changing pages to the dataservice test page now initiates deployment of the service vdb.