### PR TITLE
TEIIDTOOLS-160 Adds repo info to git export success page

### DIFF
--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -39,6 +39,7 @@
         "Password" : "Password",
         "PasswordLabel" : "Password:",
         "Remove" : "Remove",
+        "Repository" : "Repository",
         "Save" : "Save",
         "Schemas" : "Schemas",
         "Search" : "Search",
@@ -217,14 +218,14 @@
     "dsExportGitWizard" : {
         "exportProgressDetailMsg" : "Data service '{{dataServiceName}}' is being exported ...",
         "exportProgressMsg" : "<strong>Export in Progress</strong>",
-        "failedExportDetailMsg" : "Data service '{{dataServiceName}}' could not be exported to repository path '{{repoPath}}'",
+        "failedExportDetailMsg" : "Data service '{{dataServiceName}}' could not be exported to the git repository '{{repoPath}}'",
         "failedExportMsg" : "<strong>Export Failed</strong>",
         "failedNoDetailsMsg" : "Data service '{{dataServiceName}}' failed for a unspecified reasons.'",
         "hideErrorDetailTitle" : "Hide Error Detail",
         "missingPathMsg" : "@:dsImportGitWizard.missingPathMsg",
         "missingRepositoryUrlMsg" : "@:dsImportGitWizard.missingRepositoryUrlMsg",
         "showErrorDetailTitle" : "Show Error Detail",
-        "successfulExportDetailMsg" : "Data service '{{dataServiceName}}' was exported to repository path '{{repoPath}}'",
+        "successfulExportDetailMsg" : "Data service '{{dataServiceName}}' was successfully exported to the git repository",
         "successfulExportMsg" : "<strong>Successful Export</strong>"
     },
 

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/export/dsExportGitWizard.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/export/dsExportGitWizard.js
@@ -88,12 +88,11 @@
 
             if (response === 'OK') {
                 vm.responseMsg = $translate.instant( 'dsExportGitWizard.successfulExportDetailMsg', 
-                                                     { dataServiceName: dataService.keng__id, 
-                                                       repoPath: vm.repo.parameters[ 'file-path-property' ] } );
+                                                     { dataServiceName: dataService.keng__id } );
             } else {
                 vm.responseMsg = $translate.instant( 'dsExportGitWizard.failedExportDetailMsg', 
                                                      { dataServiceName: dataService.keng__id,
-                                                       repoPath: vm.repo.parameters[ 'file-path-property' ] } );
+                                                       repoPath: vm.repo.parameters[ 'repo-path-property' ] } );
             }
         }
 
@@ -147,6 +146,27 @@
             }
 
             return true;
+        };
+
+        /**
+         * Returns full target URL including branch and folder
+         */
+        vm.repoTargetUrl = function() {
+            // git path propery (ends with .git)
+            var gitUrl = vm.repo.parameters['repo-path-property'];
+
+            // if path ends with .git, it is removed.  Then /tree/ is appended.
+            var baseUrl = gitUrl.replace(".git","").concat("/tree/");
+
+            // Add the branch name to the url
+            var branch = vm.repo.parameters['repo-branch-property'];
+            if( !branch || branch.length === 0 ) {
+                branch = 'master';
+            }
+
+            var folder = vm.repo.parameters['file-path-property'];
+
+            return baseUrl.concat(branch).concat("/"+folder);
         };
 
         /**

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/export/git-export-wizard.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/export/git-export-wizard.html
@@ -69,7 +69,11 @@
                 <span class="pficon pficon-ok"></span>
             </div>
             <h3 class="blank-slate-pf-main-action" translate="dsExportGitWizard.successfulExportMsg" />
-            <p class="blank-slate-pf-secondary-action">{{ vm.responseMsg }}</p>
+            <p class="blank-slate-pf-secondary-action">
+            {{ vm.responseMsg }}
+            <br>
+            <strong>{{:: 'shared.Repository' | translate}}:</strong>&nbsp;<a href={{vm.repoTargetUrl()}} target="_blank">{{vm.repoTargetUrl()}}</a>
+            </p>
         </div>
         <div
             class="wizard-pf-complete blank-slate-pf"


### PR DESCRIPTION
Adds repo information to the git export success page.  (Includes repo link, branch and folder)

see https://issues.jboss.org/browse/TEIIDTOOLS-160 for a screencap of the changed page.