### PR TITLE
TEIIDTOOLS-178 Clarify selected tables in service wizard

### DIFF
--- a/vdb-bench-assembly/plugins/vdb-bench-core/constants.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/constants.js
@@ -46,6 +46,11 @@
             UNKNOWN: 'unknown'
         })
 
+        .constant('STYLES', {
+            DSWIZARD_TABLE_NOT_SELECTED: 'table-selection-container',
+            DSWIZARD_TABLE_SELECTED: 'table-selection-container-selected'
+        })
+
         .constant('JOIN', {
             INNER: 'INNER',
             FULL_OUTER: 'FULL_OUTER',

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/content/css/styles.less
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/content/css/styles.less
@@ -691,6 +691,16 @@ button[id^='dropdownKebabRight_'] {
     padding-right: 0.5em;
 }
 
+.table-selection-container-selected {
+    border: 3px dashed #111111;
+    height: 75px;
+    min-height: 75px;
+    margin: 10px;
+    padding-left: 0.5em;
+    padding-right: 0.5em;
+    background-color: #def3ff;
+}
+
 .join-button-up {
     background-color: transparent;
     border: #DDDDDD 3px solid;

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.html
@@ -105,14 +105,14 @@
                     </div>
                 </div>
                 <div class="col-md-4">
-                    <div class="table-selection-container">
+                    <div class="{{vm.table1Style}}">
                         <div class="col-md-1 pull-right">
                             <button id="btn-remove-table1-selection" class="btn btn-xs pficon pficon-close" ng-click="vm.removeTable1Selection()"></button>
                         </div>
                         <h4><strong>{{vm.selectedSources[0]}}</strong></h4>
                         <h3>&nbsp;&nbsp;{{vm.selectedTables[0]}}</h4>
                     </div>
-                    <div class="table-selection-container">
+                    <div class="{{vm.table2Style}}">
                         <div class="col-md-1 pull-right">
                             <button id="btn-remove-table2-selection" class="btn btn-xs pficon pficon-close" ng-click="vm.removeTable2Selection()"></button>
                         </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.js
@@ -10,7 +10,7 @@
 
     DataserviceEditWizard.$inject = ['CONFIG', 'SYNTAX'];
     DataserviceEditWizardController.$inject = ['$scope', '$rootScope', '$document', '$translate',
-                                               'RepoRestService', 'EditWizardService', 'DSSelectionService', 'SvcSourceSelectionService', 'REST_URI', 'SYNTAX'];
+                                               'RepoRestService', 'EditWizardService', 'DSSelectionService', 'SvcSourceSelectionService', 'REST_URI', 'SYNTAX', 'STYLES'];
 
     function DataserviceEditWizard(config, syntax) {
         var directive = {
@@ -27,7 +27,7 @@
     }
 
     function DataserviceEditWizardController($scope, $rootScope, $document, $translate,
-                                             RepoRestService, EditWizardService, DSSelectionService, SvcSourceSelectionService, REST_URI, SYNTAX) {
+                                             RepoRestService, EditWizardService, DSSelectionService, SvcSourceSelectionService, REST_URI, SYNTAX, STYLES) {
         var vm = this;
         vm.stepTitle = $translate.instant('dataserviceEditWizard.stepTitle');
         vm.nextButtonTitle = $translate.instant('shared.Next');
@@ -49,6 +49,8 @@
         
         vm.buildVdbs = [];
         vm.buildVdbIndex = 0;
+        vm.table1Style = STYLES.DSWIZARD_TABLE_NOT_SELECTED;
+        vm.table2Style = STYLES.DSWIZARD_TABLE_NOT_SELECTED;
 
         /*
          * page init here
@@ -139,14 +141,18 @@
          */
         vm.treeSelectionChanged = function(theNode, isSelected, parentNode) {
             vm.selectedTable = null;
+            vm.table1Style = STYLES.DSWIZARD_TABLE_NOT_SELECTED;
+            vm.table2Style = STYLES.DSWIZARD_TABLE_NOT_SELECTED;
             if(isSelected) {
                 // Node is a table (no children)
                 if(theNode.children.length===0) {
                     vm.selectedTable = theNode.name;
                     EditWizardService.addSourceTable(parentNode.name,theNode.name);
                     if(EditWizardService.sources()[0]===parentNode.name && EditWizardService.sourceTables()[0]===theNode.name) {
+                        vm.table1Style = STYLES.DSWIZARD_TABLE_SELECTED;
                         setSourceTableColumns(1, parentNode.name, theNode.sourceModel, theNode.name);
                     } else if(EditWizardService.sources()[1]===parentNode.name && EditWizardService.sourceTables()[1]===theNode.name) {
+                        vm.table2Style = STYLES.DSWIZARD_TABLE_SELECTED;
                         setSourceTableColumns(2, parentNode.name, theNode.sourceModel, theNode.name);
                     }
                 }
@@ -188,6 +194,8 @@
             }
             // Deselect tree selections
             vm.initialTreeNodeSelection = null;
+            vm.table1Style = STYLES.DSWIZARD_TABLE_NOT_SELECTED;
+            vm.table2Style = STYLES.DSWIZARD_TABLE_NOT_SELECTED;
             updateInstructionMessage();
             updateNextEnablementAndText();
         };
@@ -203,6 +211,8 @@
             vm.includeAllColumns = EditWizardService.includeAllSource1Columns();
             // Deselect tree selections
             vm.initialTreeNodeSelection = null;
+            vm.table1Style = STYLES.DSWIZARD_TABLE_NOT_SELECTED;
+            vm.table2Style = STYLES.DSWIZARD_TABLE_NOT_SELECTED;
             updateInstructionMessage();
             updateNextEnablementAndText();
         };
@@ -345,7 +355,6 @@
             for( var iSrc = 0; iSrc < vm.selectedSources.length; ++iSrc ) {
                 for( var i = 0; i < vm.treedata.length; ++i) {
                     if(vm.treedata[i].name === vm.selectedSources[iSrc]) {
-                        //expandSourceNode(vm.treedata[i]);
                         vm.initialTreeExpandedNodes.push(vm.treedata[i]);
                     }
                 }
@@ -495,6 +504,13 @@
                         for( var j = 0; j < sourceNode.children.length; ++j) {
                             if(sourceNode.children[j].name === tableNames[iTable]) {
                                 vm.initialTreeNodeSelection = sourceNode.children[j];
+                                vm.table1Style = STYLES.DSWIZARD_TABLE_NOT_SELECTED;
+                                vm.table2Style = STYLES.DSWIZARD_TABLE_NOT_SELECTED;
+                                if(EditWizardService.sources()[0]===sourceNames[iTable] && EditWizardService.sourceTables()[0]===tableNames[iTable]) {
+                                    vm.table1Style = STYLES.DSWIZARD_TABLE_SELECTED;
+                                } else if(EditWizardService.sources()[1]===sourceNames[iTable] && EditWizardService.sourceTables()[1]===tableNames[iTable]) {
+                                    vm.table2Style = STYLES.DSWIZARD_TABLE_SELECTED;
+                                }
                                 setSourceTableColumns(iTable+1, 
                                                       sourceNode.name, 
                                                       vm.initialTreeNodeSelection.sourceModel, 


### PR DESCRIPTION
Adds a different style for the table selection in the dataservice wizard.  This hopefully clarifies how the tree selection relates to the selected table boxes.
- add style for selected table box, makes outline bold and sets a background color
- highlight the table selection corresponding to the tree selection.
