### PR TITLE
TEIIDTOOLS-180 Check for service vdb conflict on deployment

### DIFF
--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -257,6 +257,8 @@
     "dsSummaryController" : {
         "confirmDeleteMsg" : "Are you sure you want to delete data service '{{serviceName}}'?",
         "deleteFailedMsg" : "Failed to remove the data service: {{response}}",
+        "deployFailedMsg" : "Error deploying the data service: {{response}}",
+        "unableToDeployMsg" : "Unable to deploy the Data Service.",
         "findSourceVdbsFailedMsg" : "Failed to find source VDBs: {{response}}",
         "findViewTablesFailedMsg" : "Failed to find view tables: {{response}}",
         "descriptionFilterPlaceholder" : "Filter by Description...",

--- a/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
@@ -1173,6 +1173,20 @@
         };
 
         /**
+         * Service: determine deployable status of a data service
+         */
+        service.getDataServiceDeployableStatus = function (dataserviceName) {
+            return getRestService().then(function (restService) {
+                if (!dataserviceName) {
+                    throw RestServiceException("Data service name is not defined");
+                }
+
+                var uri = REST_URI.TEIID + REST_URI.DATA_SERVICE + SYNTAX.FORWARD_SLASH + dataserviceName + SYNTAX.FORWARD_SLASH + REST_URI.DEPLOYABLE_STATUS;
+                return restService.one(uri).get();
+            });
+        };
+
+        /**
          * Service: Poll the teiid server for the point that the vdb becomes active
          * Has a timeout limit of 1 minute.
          */

--- a/vdb-bench-assembly/plugins/vdb-bench-core/constants.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/constants.js
@@ -84,6 +84,7 @@
             DATA_SERVICES_CLONE: '/dataservices/clone',
             DATA_SERVICE: '/dataservice',
             DATA_SERVICES: '/dataservices',
+            DEPLOYABLE_STATUS: 'deployableStatus',
             CONNECTIONS_CLONE: '/connections/clone',
             CONNECTION: '/connection',
             CONNECTIONS: '/connections',

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservicePageController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservicePageController.js
@@ -94,6 +94,8 @@
                 EditWizardService.init(null,null);
             } else if(pageId === DSPageService.SERVICESOURCE_SUMMARY_PAGE) {
                 SvcSourceSelectionService.refresh();
+            } else if(pageId === DSPageService.DATASERVICE_SUMMARY_PAGE) {
+                DSSelectionService.refresh();
             } else if(pageId == DSPageService.TEST_DATASERVICE_PAGE) {
                 DSSelectionService.deploySelectedDataService();
             }

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsSummaryController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsSummaryController.js
@@ -255,7 +255,28 @@
             // Need to select the item first
             DSSelectionService.selectDataService(item);
 
-            deployDataServiceClicked();
+            // Determine if the service can safely be deployed
+            try {
+                var selDSName = item.keng__id;
+                RepoRestService.getDataServiceDeployableStatus( selDSName ).then(
+                    function (result) {
+                        var deployableMessage = result.Information.deployableStatus;
+                        if(deployableMessage === "OK") {
+                            deployDataServiceClicked();
+                        } else {
+                            var msg = $translate.instant('dsSummaryController.unableToDeployMsg') + "\n\n" + 
+                                      deployableMessage;
+                            alert(msg);
+                        }
+                    },
+                    function (response) {
+                        throw RepoRestService.newRestException($translate.instant('dsSummaryController.deployFailedMsg', 
+                                                                                  {response: RepoRestService.responseMessage(response)}));
+                    });
+            } catch (error) {
+                throw RepoRestService.newRestException($translate.instant('dsSummaryController.deployFailedMsg', 
+                        {response: error.message}));
+            }
         };
         
         /**


### PR DESCRIPTION
- Prior to 'Test' of a Dataservice, a check method is now called first.  This method returns a status which indicates whether the Dataservice can be safely deployed (checks whether deployment of the service vdb would overwrite another users VDB).
- If a conflict exists, an alert dialog is displayed.
- dataservicePageController modification so that the dataservice page is refreshed properly.