### PR TITLE
TTOOLS-189 issue with git export cancel

### DIFF
--- a/vdb-bench-assembly/plugins/vdb-bench-core/DSSelectionService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/DSSelectionService.js
@@ -48,6 +48,7 @@
                 RepoRestService.getDataServices( ).then(
                     function (newDataServices) {
                         RepoRestService.copy(newDataServices, ds.dataservices);
+                        ds.dataservice = null;
                         setLoading(false);
                         if(pageId) {
                             // Broadcast the pageChange
@@ -57,17 +58,16 @@
                     function (response) {
                         // Some kind of error has occurred
                         ds.dataservices = [];
+                        ds.dataservice = null;
                         setLoading(false);
                         throw RepoRestService.newRestException("Failed to load data services from the host services.\n" + response.message);
                     });
             } catch (error) {
                 ds.dataservices = [];
+                ds.dataservice = null;
                 setLoading(false);
                 alert("An exception occurred:\n" + error.message);
             }
-
-            // Removes any outdated dataservice
-            service.selectDataService(null);
         }
 
         /*

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-export.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-export.html
@@ -15,6 +15,8 @@
 	                    -->
 	                <div pf-wizard-step step-title="{{:: 'dataservice-export.exportTypeStepTitle' | translate}}"
 	                     step-id="export-type"
+                         step-priority="0"
+                         substeps="false"
 	                     wz-disabled="{{ vm.storageTypes.length < 2 }}"
 	                     ng-show="{{ vm.storageTypes.length > 1 }}">
 	                    <h1 translate="dataservice-export.instructionsMsg"></h1>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/export/git-export-wizard.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/export/git-export-wizard.html
@@ -8,6 +8,7 @@
         wz-disabled="{{!vm.wizardActive}}"
         next-enabled="vm.validateRepoProps()"
         allow-click-nav="false"
+        substeps="false"
         ok-to-nav-away="vm.validateRepoProps()">
     <h1 class="step-message" translate="git-export-wizard.repoPropsStepMsg" />
 
@@ -25,6 +26,7 @@
 <div pf-wizard-step
      step-title="{{:: 'git-export-wizard.commitStepTitle' | translate}}"
      step-id="git-export-execute"
+     step-priority="2"
      allow-click-nav="false"
      substeps="true"
      wz-disabled="{{!vm.wizardActive}}">


### PR DESCRIPTION
- change to DSSelectionService - the deselection was causing multiple events to be broadcast.  eliminates the extra event.
- other minor changes to export pages to make step attributes consistent