### PR TITLE
TEIIDTOOLS-183

### DIFF
--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/export/dsExportGitWizard.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/export/dsExportGitWizard.js
@@ -70,7 +70,7 @@
         };
 
         vm.exportFailure = function() {
-            return !vm.inProgress && vm.response === 'Failed';
+            return !vm.inProgress && vm.response !== 'OK';
         };
 
         vm.exportSuccess = function() {

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/gitCredentialsControl.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/gitCredentialsControl.js
@@ -80,9 +80,7 @@
                 StorageService.setObject(GIT_REPOS_KEY, vm.repositories);
             }
 
-            if ( _.isEmpty( vm.repo ) || _.isEmpty( vm.repo.name ) ) {
-                vm.setSelected( vm.repositories[ 0 ] );
-            }
+            vm.setSelected( vm.repositories[ 0 ] );
         }
 
         function newRepository() {


### PR DESCRIPTION
* Fixes Back button on Git Export wizard
 * Would seem that the pf-wizard has to have ALL steps/sub-steps return
   true for prevEnabled when the Back button is clicked. If 1 step returns
   false then the back button does not step back.
 * In this case, the exportFailure function returns true only if the
   Progress step has failed. This is wrong since it stops all Back buttons
   working. Changing it to NOT OK means that even when vm.response is not
   set, ie. first time through, the back button will still function correctly

* gitCredentialsControl
 * Minor fix when refreshing git credentials