### PR TITLE
TEIIDTOOLS-197 Warn user on delete of datasource used by a dataservice

### DIFF
--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -19,6 +19,7 @@
         "Delete" : "Delete",
         "DeleteWhat" : "Delete {{what}}",
         "Description" : "Description",
+        "Dismiss" : "Dismiss",
         "Download" : "Download",
         "Driver" : "Driver",
         "Edit" : "Edit",
@@ -116,6 +117,7 @@
         "connectionsNumberToolTip" : "The number of native data connections, eg. JDBC databases, utilised by this dataservice",
         "createDataServiceMsg" : "A Data Service accesses one or more Data Sources. To create your first Data Service, click <strong>New Data Service</strong> below.  To import a Data Service from a git repository, click <strong>Import Data Service</strong>.",
         "createSourceMsg" : "A Data Service is created using one or more Data Sources. To create your first Data Source, click ",
+        "cannotEditTitle" : "Cannot Edit Data Service",
         "confirmDeleteTitle" : "Confirm Delete",
         "codeSamplesDataServiceMsg" : "Code samples showing how to connect to your data service are available here.",
         "codeSamplesDataService" : "Code Samples",
@@ -131,8 +133,7 @@
         "viewSourcesToolTip" : "The source tables accessed by this data service",
         "welcomeMsg" : "Welcome to the <strong>Data Services Builder</strong>!"
     },
-    
-    
+
     "dataservice-documentation" : {
         "javaTab" : "Java",
         "javaScriptTab" : "Javascript",
@@ -266,6 +267,7 @@
     },
 
     "dsSummaryController" : {
+        "cannotEditMissingSourcesMsg" : "Data Service '{{dsName}}' cannot be edited because the following sources are not available:<br/>[{{srcList}}]<br/>",
         "confirmDeleteMsg" : "Are you sure you want to delete data service '{{serviceName}}'?",
         "deleteFailedMsg" : "Failed to remove the data service: {{response}}",
         "deployFailedMsg" : "Error deploying the data service: {{response}}",
@@ -352,6 +354,7 @@
         "actionTitleNew" : "Create a Data Source",
         "actionTitleRefresh" : "Refresh the Table",
         "confirmDeleteMsg" : "Are you sure you want to delete data source '{{sourceName}}'?",
+        "confirmDeleteDataservicesAffectedMsg" : "The following Data Service(s) utilize this source:<br/>[{{dsList}}]<br/>If you delete data source '{{sourceName}}', the data service(s) will not longer be editable.<br/><br/>Are you sure you want to delete '{{sourceName}}'?",
         "gettingDdlMsg" : "Fetching DDL...",
         "getDdlFailedMsg" : "Failed to get the DDL.",
         "removeLocalSourceFailedMsg" : "Failed to remove the local ServiceSource.",

--- a/vdb-bench-assembly/plugins/vdb-bench-core/DSSelectionService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/DSSelectionService.js
@@ -140,6 +140,28 @@
             return ds.editServiceSourceTableSelection;
         };
 
+        /**
+         * Get the names of the Dataservices that use the provided source name
+         */
+        service.getDataservicesUsingSource = function( sourceName ) {
+            var dataserviceNames = [];
+
+            for (var i = 0; i < ds.dataservices.length; ++i) {
+                if(ds.dataservices[i].serviceViewTables) {
+                    var viewTables = ds.dataservices[i].serviceViewTables;
+                    for (var j = 0; j < viewTables.length; ++j) {
+                        var viewTable = viewTables[j];
+                        if(viewTable.startsWith(sourceName+'.')) {
+                            dataserviceNames.push(ds.dataservices[i].keng__id);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            return dataserviceNames;
+        };
+
         /*
          * Select the given dataservice
          */

--- a/vdb-bench-assembly/plugins/vdb-bench-core/SvcSourceSelectionService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/SvcSourceSelectionService.js
@@ -390,6 +390,20 @@
         };
 
         /*
+         * Determine if a service source with the specified name currently exists
+         */
+        service.hasServiceSource = function( svcSourceName ) {
+            var hasSource = false;
+            for(var i=0; i<svcSrc.serviceSources.length; i++) {
+                if(svcSrc.serviceSources[i].keng__id === svcSourceName) {
+                    hasSource = true;
+                    break;
+                }
+            }
+            return hasSource;
+        };
+
+        /*
          * Refresh the collection of service sources
          */
         service.refresh = function(pageId) {

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-summary.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-summary.html
@@ -20,6 +20,26 @@
           </div>
         </div>
 
+        <!-- Modal Dialog to inform user of missing source on edit attempt -->
+        <div class="modal fade dsb-modal" id="cannotEditModal" tabindex="-1" role="dialog" aria-labelledby="cannotEditModalLabel" aria-hidden="true">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">
+                  <span class="pficon pficon-close"></span>
+                </button>
+                <h4 class="modal-title" id="cannotEditModalLabel" translate="dataservice-summary.cannotEditTitle"></h4>
+              </div>
+              <div class="modal-body">
+                  <span ng-bind-html="vm.cannotEditMsg" />
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-primary" data-dismiss="modal" translate="shared.Dismiss"></button>
+              </div>
+            </div>
+          </div>
+        </div>
+
 	    <!-- Content shown if No Sources or DataServices yet -->
         <div class="blank-slate-pf" 
              id="dataservice-summary-nosources-noservices" 

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasource-summary.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasource-summary.html
@@ -11,7 +11,9 @@
                 </button>
                 <h4 class="modal-title" id="confirmDeleteModalLabel" translate="datasource-summary.confirmDeleteTitle"></h4>
               </div>
-              <div class="modal-body">{{vm.confirmDeleteMsg}}</div>
+              <div class="modal-body">
+                  <span ng-bind-html="vm.confirmDeleteMsg" />
+              </div>
               <div class="modal-footer">
                 <button type="button" class="btn btn-default" data-dismiss="modal" translate="shared.Cancel"></button>
                 <button type="button" class="btn btn-primary" ng-click="vm.deleteSelectedSvcSource()" translate="shared.Delete"></button>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasourceSummaryController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasourceSummaryController.js
@@ -8,11 +8,11 @@
         .module(pluginName)
         .controller('DatasourceSummaryController', DatasourceSummaryController);
 
-    DatasourceSummaryController.$inject = ['$scope', '$rootScope', '$translate', 'RepoRestService', 'REST_URI', 'SYNTAX', 'DSPageService', 
+    DatasourceSummaryController.$inject = ['$scope', '$rootScope', '$translate', 'RepoRestService', 'REST_URI', 'SYNTAX', 'DSPageService', 'DSSelectionService',
                                            'SvcSourceSelectionService', 'TranslatorSelectionService', 'DatasourceWizardService', 
                                            'ConnectionSelectionService', 'DownloadService', 'CredentialService', 'pfViewUtils'];
 
-    function DatasourceSummaryController($scope, $rootScope, $translate, RepoRestService, REST_URI, SYNTAX, DSPageService, 
+    function DatasourceSummaryController($scope, $rootScope, $translate, RepoRestService, REST_URI, SYNTAX, DSPageService, DSSelectionService,
                                           SvcSourceSelectionService, TranslatorSelectionService, DatasourceWizardService, 
                                           ConnectionSelectionService, DownloadService, CredentialService, pfViewUtils) {
         var vm = this;
@@ -345,8 +345,15 @@
             // Need to select the item first
             SvcSourceSelectionService.selectServiceSource(item);
 
-            // show the delete confirmation modal
-            vm.confirmDeleteMsg = $translate.instant('datasourceSummaryController.confirmDeleteMsg', {sourceName: item.keng__id});
+            // Determine if any dataservices use this source.  List them in the confirmation message
+            var dsList = DSSelectionService.getDataservicesUsingSource(item.keng__id);
+            if( dsList.length > 0 ) {
+                vm.confirmDeleteMsg = $translate.instant('datasourceSummaryController.confirmDeleteDataservicesAffectedMsg', {sourceName: item.keng__id, dsList: dsList.toString()});
+            } else {
+                // show the delete confirmation modal
+                vm.confirmDeleteMsg = $translate.instant('datasourceSummaryController.confirmDeleteMsg', {sourceName: item.keng__id});
+            }
+
             $('#confirmDeleteModal').modal('show');
         };
  

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsSummaryController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsSummaryController.js
@@ -22,6 +22,7 @@
         vm.allItems = DSSelectionService.getDataServices();
         vm.items = vm.allItems;
         vm.confirmDeleteMsg = "";
+        vm.cannotEditMsg = "";
 
         function setHelpId() {
             var page = DSPageService.page(DSPageService.DATASERVICE_SUMMARY_PAGE);
@@ -300,7 +301,26 @@
          * Handle edit dataservice menu select
          */
         var editDataServiceMenuAction = function(action, item) {
-            vm.editDataService(item);
+            // Check the data service sources - to see if they exist.
+            var missingSources = [];
+            if( item.serviceViewTables ) {
+                for(var i = 0; i < item.serviceViewTables.length; ++i) {
+                    var tableName = item.serviceViewTables[i];
+                    var dotIndex = tableName.indexOf('.');
+                    var sourceName = tableName.substring(0,dotIndex);
+                    var hasSource = SvcSourceSelectionService.hasServiceSource(sourceName);
+                    if(!hasSource) {
+                        missingSources.push(sourceName);
+                    }
+                }
+            }
+            // If any data service sources are missing, disallow edit.
+            if( missingSources.length > 0 ) {
+                vm.cannotEditMsg = $translate.instant('dsSummaryController.cannotEditMissingSourcesMsg', {dsName: item.keng__id, srcList: missingSources.toString()});
+                $('#cannotEditModal').modal('show');
+            } else {
+                vm.editDataService(item);
+            }
         };
 
         /**


### PR DESCRIPTION
When the user deletes a data source which is used by a data service, a warning dialog is displayed.  Also, when the user attempts to edit a data service - the edit will be disallowed if any of the needed sources are missing.
- added functions in DSSelectionService and SvcSourceSelectionService.
- added dialogs / messages on service summary and source summary pages.