### PR TITLE
TEIIDTOOLS-209 Resolve issue with edit of join service

### DIFF
--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -8,6 +8,7 @@
         "changedConnectionFailedMsg" : "Failed to get connection: {{errorMsg}}",
         "CheckAll" : "Check All",
         "Close" : "Close",
+        "Confirm" : "Confirm",
         "Connection" : "Connection",
         "Connections" : "Connections",
         "Copy" : "Copy",
@@ -67,6 +68,7 @@
     },
 
     "dataservice-edit" : {
+        "confirmExpertTitle" : "Confirm Switch to Expert",
         "instructionsMsg" : "Change the definition of your Data Service by choosing a different data source and table",
         "enableTextEditLbl" : "Enable Text Edit",
         "expertTab" : "Expert",
@@ -203,6 +205,7 @@
         "getVdbModelTablesFailedMsg" : "Failed to get Vdb model tables",
         "createDataserviceFailedMsg" : "Failed to create the data service",
         "updateDataserviceFailedMsg" : "Failed to update the data service",
+        "noTreeContent" : "No Active Data Sources!",
         "selectedTables" : "Selected Tables",
         "stepTitle" : "Choose Data Sources",
         "updateVdbFromDdlFailedMsg" : "Failed to construct temp Vdb from DDL",
@@ -218,6 +221,7 @@
     },
 
     "dsEditController" : {
+        "confirmExpertMsg" : "Switching to Expert mode requires you to finish your edits in expert mode.  Please confirm.",
         "enterViewDefnMsg" : "Enter a View Definition",
         "updateDataserviceFailedMsg" : "Failed to update the data service",
         "saveFailedMsg" : "Failed to update the data service: {{response}}"

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-edit.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-edit.html
@@ -1,9 +1,27 @@
 <div id="outer" class="outer-wrapper">
-	<div id="dataservice-edit-container" class="container-fluid" ng-controller="DSEditController as vm">
-	
-	    <div id="dsEdit-edit-controls" ng-show="vm.svcSourcesLoading==false" class="col-md-12 row">
+    <div id="dataservice-edit-container" class="container-fluid" ng-controller="DSEditController as vm">
+
+        <!-- Modal Dialog for user to confirm moving to expert tab -->
+        <div class="modal fade dsb-modal" id="confirmExpertModal" tabindex="-1" role="dialog" aria-labelledby="confirmExpertModalLabel" aria-hidden="true">
+          <div class="modal-dialog">
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal" aria-hidden="true">
+                  <span class="pficon pficon-close"></span>
+                </button>
+                <h4 class="modal-title" id="confirmExpertModalLabel" translate="dataservice-edit.confirmExpertTitle"></h4>
+              </div>
+              <div class="modal-body">{{vm.confirmExpertMsg}}</div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-default" ng-click="vm.stayOnWizardTab()" translate="shared.Cancel"></button>
+                <button type="button" class="btn btn-primary" ng-click="vm.switchToExpertTab()" translate="shared.Confirm"></button>
+              </div>
+            </div>
+          </div>
+        </div>
+        <div id="dsEdit-edit-controls" ng-show="vm.svcSourcesLoading==false" class="col-md-12 row">
             <uib-tabset>
-                <uib-tab heading="{{:: 'dataservice-edit.wizardTab' | translate}}" active="vm.wizardTabActive">
+                <uib-tab heading="{{:: 'dataservice-edit.wizardTab' | translate}}" active="vm.wizardTabActive" disable="vm.disableWizardTab">
                     <dataservice-edit-wizard></dataservice-edit-wizard>
                 </uib-tab>
                 <uib-tab heading="{{:: 'dataservice-edit.expertTab' | translate}}" active="vm.expertTabActive" disable="vm.disableExpertTab" ng-click="vm.onExpertTabSelected()">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsEditController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsEditController.js
@@ -20,6 +20,8 @@
         vm.wizardTabActive = true;
         vm.expertTabActive = false;
         vm.disableExpertTab = EditWizardService.sourceTables().length === 0;
+        vm.disableWizardTab = false;
+        vm.confirmExpertMsg = "";
         vm.sourceNames = [];
         vm.tableNames = [];
         vm.disableFinish = false;
@@ -73,6 +75,7 @@
                 vm.expertTabActive = false;
             } else {
                 vm.wizardTabActive = false;
+                vm.disableWizardTab = true;
                 vm.expertTabActive = true;
             }
         }
@@ -81,8 +84,29 @@
          * Expert tab selected.  Get selections from EditWizardService to populate text view.
          */
         vm.onExpertTabSelected = function() {
+            // Show the expert mode confirmation modal
+            vm.confirmExpertMsg = $translate.instant('dsEditController.confirmExpertMsg');
+            $('#confirmExpertModal').modal('show');
+        };
+        
+        /**
+         * Switch to the Expert Tab after confirming
+         */
+        vm.switchToExpertTab = function( ) {
             setViewDdlFromEditor(false);
             loadTableColumnTree();
+            vm.disableWizardTab = true;
+            // dismiss the confirmation modal
+            $('#confirmExpertModal').modal('hide');
+        };
+
+        /**
+         * Stay on Wizard tab after confirm cancelled
+         */
+        vm.stayOnWizardTab = function( ) {
+            vm.wizardTabActive = true;
+            // dismiss the confirmation modal
+            $('#confirmExpertModal').modal('hide');
         };
 
         /**

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/EditWizardService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/EditWizardService.js
@@ -266,8 +266,10 @@
             } else if ( wiz.sourceTables.length===1 && ( source !== wiz.sources[0] || sourceTable !== wiz.sourceTables[0] ) ) {
                 wiz.sources.push(source);
                 wiz.sourceTables.push(sourceTable);
-                // Set the criteria predicates based on the table selections
-                setCriteriaPredicatesFromTables(wiz.sourceTables[0],wiz.sourceTables[1]);
+                // If no criteria predicates have been set, attempt to set based on the table selections
+                if(!service.criteriaComplete()) {
+                  setCriteriaPredicatesFromTables(wiz.sourceTables[0],wiz.sourceTables[1]);
+                }
                 // Broadcast table change
                 $rootScope.$broadcast("editWizardTablesChanged");
             }

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.html
@@ -81,7 +81,7 @@
                     </div>
                     <!-- No Content Message -->
                     <div ng-show="vm.treeLoading==false && vm.treedata.length == 0 && !vm.hasTreeFetchError">
-                        <h4 translate="dataserviceEditWizard.noTreeContent"></h4>
+                        <h5 style="color:red" translate="dataserviceEditWizard.noTreeContent"></h5>
                     </div>
                     <!-- Fetch Content Error Message -->
                     <div ng-show="vm.treeLoading==false && vm.hasTreeFetchError">

--- a/vdb-bench-assembly/plugins/vdb-bench-widgets/criteriaBuilder.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-widgets/criteriaBuilder.html
@@ -41,7 +41,7 @@
             <div class="col-md-3">
                 <select ng-model="criteriaPredicate.lhColName" ng-change="vm.lhColumnChanged( )">
                     <option value="" translate="criteriaBuilder.chooseCriteriaCol"></option>
-                    <option ng-selected="{{lhCol.keng__id == criteriaPredicate.lhColName}}"
+                    <option ng-selected="{{lhCol.keng__id === criteriaPredicate.lhColName}}"
                             ng-repeat="lhCol in vm.lhSourceCols"
                             value="{{lhCol.keng__id}}">
                             {{lhCol.keng__id}}
@@ -52,7 +52,7 @@
             <div class="col-md-2">
                 <select ng-model="criteriaPredicate.operatorName" ng-change="vm.operatorChanged( )">
                     <option value="" translate="criteriaBuilder.chooseOperator"></option>
-                    <option ng-selected="{{operator.name == criteriaPredicate.operatorName}}"
+                    <option ng-selected="{{operator.name === criteriaPredicate.operatorName}}"
                             ng-repeat="operator in vm.operatorOptions"
                             value="{{operator.name}}">
                             {{operator.name}}
@@ -63,7 +63,7 @@
             <div class="col-md-3">
                 <select ng-model="criteriaPredicate.rhColName" ng-change="vm.rhColumnChanged( )">
                     <option value="" translate="criteriaBuilder.chooseCriteriaCol"></option>
-                    <option ng-selected="{{rhCol.keng__id == criteriaPredicate.rhColName}}"
+                    <option ng-selected="{{rhCol.keng__id === criteriaPredicate.rhColName}}"
                             ng-repeat="rhCol in vm.rhSourceCols"
                             value="{{rhCol.keng__id}}">
                             {{rhCol.keng__id}}


### PR DESCRIPTION
- TEIIDTOOLS-199 - fix missing message issue for empty tree content
- TEIIDTOOLS-209 - fix issue with join editing.  Also now disables switching from 'Expert' mode to 'Wizard' mode.  Once the user enters expert mode, the edits must be finished there.  Previously allowed switching back and forth which can potentially overwrite the expert edits.