### PR TITLE
TEIIDTOOLS-231 datasource page refresh improvements

### DIFF
--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -386,6 +386,7 @@
         "sourceCreateFailedMsg" : "Failed to create the data source.",
         "sourceUpdateFailedMsg" : "Failed to update the data source.",
         "sourceDeployFailedMsg" : "Failed to deploy the data source.",
+        "sourceDeploymentInProgress" : "Source deployment in progress",
         "sourceModelCreateFailedMsg" : "Failed to create the data source model.",
         "sourceModelConnectionCreateFailedMsg" : "Failed to create the source model connection.",
         "sourceModelConnectionUpdateFailedMsg" : "Failed to update the source model connection.",

--- a/vdb-bench-assembly/plugins/vdb-bench-core/DSSelectionService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/DSSelectionService.js
@@ -274,7 +274,9 @@
                             //
                             // Monitor the service vdb of the dataservice to determine when its active
                             //
-                            RepoRestService.pollForActiveVdb(dsVdbName, successCallback, failCallback);
+                            var pollDurationSec = 120;
+                            var pollIntervalSec = 2;
+                            RepoRestService.pollForActiveVdb(dsVdbName, pollDurationSec, pollIntervalSec, successCallback, failCallback);
                         } else {
                             service.setDeploying(false, selDSName, false, result.Information.ErrorMessage1);
                         }

--- a/vdb-bench-assembly/plugins/vdb-bench-core/SvcSourceSelectionService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/SvcSourceSelectionService.js
@@ -390,6 +390,23 @@
         };
 
         /*
+         * return the serviceSource status message
+         *    (defaults to 'Unknown' if the dsbTeiidStatusMessage property is not found)
+         */
+        service.getServiceSourceStatusMessage = function ( datasource ) {
+            var statusMessage = "Unknown";
+            for(var key in datasource.keng__properties) {
+                var propName = datasource.keng__properties[key].name;
+                var propValue = datasource.keng__properties[key].value;
+                if(propName==='dsbTeiidStatusMessage') {
+                    statusMessage = propValue;
+                    break;
+                }
+            }
+            return statusMessage;
+        };
+
+        /*
          * Determine if a service source with the specified name currently exists
          */
         service.hasServiceSource = function( svcSourceName ) {

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/content/css/styles.less
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/content/css/styles.less
@@ -241,7 +241,7 @@ button[id^='dropdownKebabRight_'] {
 }
 
 .ds-warning {
-    color: yellow;
+    color: rgb(255, 204, 0);
 }
 
 .ds-status {

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasourceSummaryController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/datasources/datasourceSummaryController.js
@@ -8,11 +8,11 @@
         .module(pluginName)
         .controller('DatasourceSummaryController', DatasourceSummaryController);
 
-    DatasourceSummaryController.$inject = ['$scope', '$rootScope', '$translate', 'RepoRestService', 'REST_URI', 'SYNTAX', 'DSPageService', 'DSSelectionService',
+    DatasourceSummaryController.$inject = ['$scope', '$rootScope', '$translate', '$interval', 'RepoRestService', 'REST_URI', 'SYNTAX', 'DSPageService', 'DSSelectionService',
                                            'SvcSourceSelectionService', 'TranslatorSelectionService', 'DatasourceWizardService', 
                                            'ConnectionSelectionService', 'DownloadService', 'CredentialService', 'pfViewUtils'];
 
-    function DatasourceSummaryController($scope, $rootScope, $translate, RepoRestService, REST_URI, SYNTAX, DSPageService, DSSelectionService,
+    function DatasourceSummaryController($scope, $rootScope, $translate, $interval, RepoRestService, REST_URI, SYNTAX, DSPageService, DSSelectionService,
                                           SvcSourceSelectionService, TranslatorSelectionService, DatasourceWizardService, 
                                           ConnectionSelectionService, DownloadService, CredentialService, pfViewUtils) {
         var vm = this;
@@ -138,6 +138,72 @@
             setDDL();
         });
 
+        /**
+         * Background function that updates datasource status
+         * The check is performed every 45 seconds
+         */
+        function backgroundCheckSourceStatus() {
+            var statusChecker = $interval(function() {
+
+                try {
+                    // Update workspace VDBs from teiid, then update row statuses
+                    RepoRestService.updateWorkspaceVdbStatusFromTeiid().then(
+                        function (result) {
+                            updateRowStatuses();
+                        },
+                        function (response) {
+                            // Some kind of error has occurred
+                            throw RepoRestService.newRestException("Failed to update workspace sources.\n" + response.message);
+                        });
+                } catch (error) {
+                    alert("An error occurred:\n" + error.message);
+                }
+
+            }, 45000);
+        }
+
+        /**
+         * Update row status from workspace VDB status, if the status has changed
+         */
+        function updateRowStatuses() {
+            try {
+                RepoRestService.getVdbs(REST_URI.WKSP_SERVICE).then(
+                    // Get workspace VDBs
+                    function (wkspVdbs) {
+                        // Determine if any status have changed.  If so, update the status and message of the changed row
+                        for(var i = 0; i < wkspVdbs.length; i++) {
+                            if( SvcSourceSelectionService.isServiceSource(wkspVdbs[i]) ) {
+                                var srcName = wkspVdbs[i].keng__id;
+                                for(var iRow = 0; iRow < vm.items.length; iRow++) {
+                                    if(vm.items[iRow].keng__id === srcName) {
+                                        var teiidStatus = SvcSourceSelectionService.getServiceSourceStatus(wkspVdbs[i]);
+                                        var rowItemStatus = SvcSourceSelectionService.getServiceSourceStatus(vm.items[iRow]);
+                                        // If the teiid status is different than current row, update the row item to match
+                                        if(rowItemStatus !== teiidStatus) {
+                                            var teiidStatusMessage = SvcSourceSelectionService.getServiceSourceStatusMessage(wkspVdbs[i]);
+                                            for(var key in vm.items[iRow].keng__properties) {
+                                                var propName = vm.items[iRow].keng__properties[key].name;
+                                                if(propName=='dsbTeiidStatus') {
+                                                    vm.items[iRow].keng__properties[key].value = teiidStatus;
+                                                } else if(propName=='dsbTeiidStatusMessage') {
+                                                    vm.items[iRow].keng__properties[key].value = teiidStatusMessage;
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    function (response) {
+                        // Some kind of error has occurred
+                        throw RepoRestService.newRestException("Failed to get sources for status update.\n" + response.message);
+                    });
+            } catch (error) {
+                alert("An error occurred:\n" + error.message);
+            }
+        }
+            
         /**
          * Delete the specified VDB from the server, then remove the repo VDB
          */
@@ -599,6 +665,8 @@
             vm.items = vm.allItems;
             vm.filterConfig.resultsCount = vm.items.length;
             vm.hasSources = vm.allItems.length>0;
+            // Starts background polling to check
+            backgroundCheckSourceStatus();
         };
 
         vm.refresh();

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/datasource-wizard/datasourceEditWizard.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/datasource-wizard/datasourceEditWizard.html
@@ -1,6 +1,10 @@
-<div ng-show="vm.deployInProgress==true || vm.wizardServiceReady==false" class="row">
+<div ng-show="vm.wizardServiceReady==false" class="row">
     <div class="spinner spinner-lg spinner-inline" />
     {{:: 'datasourceEditWizard.initializingWizard' | translate}}
+</div>
+<div ng-show="vm.deployInProgress==true" class="row">
+    <div class="spinner spinner-lg spinner-inline" />
+    {{:: 'datasourceEditWizard.sourceDeploymentInProgress' | translate}}
 </div>
 
 <div ng-show="vm.deployInProgress==false && vm.wizardServiceReady==true">

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/datasource-wizard/datasourceEditWizard.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/datasource-wizard/datasourceEditWizard.js
@@ -449,9 +449,11 @@
                                 SvcSourceSelectionService.refresh('datasource-summary');
                             };
                             //
-                            // Monitors the source vdb to determine when its active
+                            // Monitor the source every second for 5 seconds, checking for active state
                             //
-                            RepoRestService.pollForActiveVdb(vdbName, successCallback, failCallback);
+                            var pollingDurationSec = 5;
+                            var pollingIntervalSec = 1;
+                            RepoRestService.pollForActiveVdb(vdbName, pollingDurationSec, pollingIntervalSec, successCallback, failCallback);
                         } else {
                             SvcSourceSelectionService.setDeploying(false, vdbName, false, result.Information.ErrorMessage1);
                         }


### PR DESCRIPTION
The jira pointed out an issue when datasource metadata takes a long time (over a minute to load).  Was not redirecting to the summary page.
- RepositoryRestService.pollForActiveVdb - added args so user can adjust polling duration and interval.  At end of polling, the fail callback is now called with a 'Time out' message.  
- datasourceEditWizard only polls for 5 seconds now, instead of waiting a full minute.  Redirects to the summary page more quickly now.  Longer loading sources may have an initial status of "Loading"
- Added a background function in datasourceSummaryController.  The background function will update the workspace vdb statuses of the displayed sources every 45secs.  The row status is changed without doing a full page refresh.  The "Loading" status will change to "Active" for example when the vdb finishes loading
- changed warning color of "Loading" status to a darker yellow for better visibility
  