### PR TITLE
TEIIDTOOLS-229 Resolve issue with empty repo URL

### DIFF
--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/export/dsExportGitWizard.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/export/dsExportGitWizard.js
@@ -154,6 +154,9 @@
         vm.repoTargetUrl = function() {
             // git path propery (ends with .git)
             var gitUrl = vm.repo.parameters['repo-path-property'];
+            if(!angular.isDefined(gitUrl)) {
+                gitUrl = "";
+            }
 
             // if path ends with .git, it is removed.  Then /tree/ is appended.
             var baseUrl = gitUrl.replace(".git","").concat("/tree/");

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/import/dsImportGitWizard.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/import/dsImportGitWizard.js
@@ -158,6 +158,9 @@
         vm.repoTargetUrl = function() {
             // git path propery (ends with .git)
             var gitUrl = vm.repo.parameters['repo-path-property'];
+            if(!angular.isDefined(gitUrl)) {
+                gitUrl = "";
+            }
 
             // if path ends with .git, it is removed.  Then /tree/ is appended.
             var baseUrl = gitUrl.replace(".git","").concat("/tree/");


### PR DESCRIPTION
Now handling undefined gitUrl in the repoTargetUrl functions.