### PR TITLE
TEIIDTOOLS-237-238 Corrects connection download name and delete confirmation

### DIFF
--- a/vdb-bench-assembly/plugins/vdb-bench-core/DownloadService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/DownloadService.js
@@ -97,7 +97,7 @@
                         var contentType = fileType === "zip" ? 'application/zip' : 'text/plain;charset=utf-8';                        
                         var dataBlob = b64toBlob(enc, contentType);
                         
-                        var fileExt = ( fileType == "-vdb.xml" ) ? fileType : SYNTAX.DOT + fileType;
+                        var fileExt = ( fileType == "-vdb.xml" || fileType == "-connection.xml" ) ? fileType : SYNTAX.DOT + fileType;
 
                         FileSaver.saveAs(dataBlob, name + fileExt);
                     },

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/connections/connectionSummaryController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/connections/connectionSummaryController.js
@@ -281,14 +281,18 @@
             // Need to select the item first
             ConnectionSelectionService.selectConnection(item);
 
+            // TODO : New function is required to check whether the dataservice needs the connection
             // Determine if any dataservices use this connection.  List them in the confirmation message
-            var dsList = DSSelectionService.getDataservicesUsingSource(item.keng__id);
-            if( dsList.length > 0 ) {
-                vm.confirmDeleteMsg = $translate.instant('datasourceSummaryController.confirmDeleteDataservicesAffectedMsg', {sourceName: item.keng__id, dsList: dsList.toString()});
-            } else {
-                // show the delete confirmation modal
-                vm.confirmDeleteMsg = $translate.instant('datasourceSummaryController.confirmDeleteMsg', {sourceName: item.keng__id});
-            }
+            //var dsList = DSSelectionService.getDataservicesUsingSource(item.keng__id);
+            //if( dsList.length > 0 ) {
+            //    vm.confirmDeleteMsg = $translate.instant('connectionSummaryController.confirmDeleteDataservicesAffectedMsg', {connectionName: item.keng__id, dsList: dsList.toString()});
+            //} else {
+            //   // show the delete confirmation modal
+            //   vm.confirmDeleteMsg = $translate.instant('connectionSummaryController.confirmDeleteMsg', {connectionName: item.keng__id});
+            //}
+
+            // show the delete confirmation modal
+            vm.confirmDeleteMsg = $translate.instant('connectionSummaryController.confirmDeleteMsg', {connectionName: item.keng__id});
 
             $('#confirmDeleteModal').modal('show');
         };


### PR DESCRIPTION
TTOOLS 237 : Fix confirmation dialog to use the correct i18n message.  Commented out the block where a dataservice is checked if it uses a connection.  The incorrect function was being used; we'll need to add a new one to check for connections used by a dataservice.  Will create a jira for that

TTOOLS 238 : Minor fix in DownloadService to account for -connection.xml type same way as -vdb.xml was being handled.