### PR TITLE
TeidTools-224 Add minimal data role options for single data service view in DSB

### DIFF
--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -200,6 +200,7 @@
         "clickSourceTableInstructionMsg" : "Click on a source table to add it to your selections",
         "dataSources" : "Data Sources",
         "enterNameInstructionMsg" : "Enter a name for your data service",
+        "IncludeAllColumns" : "Include All Columns",
         "invalidNameInstructionMsg" : "Data service name has invalid characters or already exists",
         "getVdbModelsFailedMsg" : "Failed to get Vdb models",
         "getVdbModelTablesFailedMsg" : "Failed to get Vdb model tables",
@@ -493,10 +494,15 @@
     },
 
     "editWizardService" : {
+        "dataSourcesUpdatableMsg" : "When <strong>Read-only Access</strong> is unchecked, this data service has update and delete access to your source data.",
         "initTableSelectionsFailedMsg" : "Error initializing data service source table selections.",
         "getJoinCriteriaFailedMsg" : "Error retrieving join criteria.",
         "nameRequired" : "@:shared.nameRequired",
-        "validateDataServiceNameError" : "Error validating data service name."
+         "ReadOnlyAccess" : "Read-only Access",
+        "validateDataServiceNameError" : "Error validating data service name.",
+        "help" : {
+            "readOnlyAccess" : "When checked, data sources have read-only access and cannot be updated."
+        }
     },
 
     "fileImportControl" : {
@@ -631,6 +637,8 @@
     },
 
     "RepositoryRestService" : {
+        "createDefaultDataRoleMissingArgs" : "Then data service name and at least one model name must be defined when creating the default read-only access data role.",
+        "deleteDataRoleMissingArgs" : "The data service name and the data role name must be defined for delete.",
         "emptyDataServiceName" : "The data service name cannot be empty.",
         "emptyDataSourceName" : "The data source name cannot be empty.",
         "emptyConnectionName" : "The connection name cannot be empty.",

--- a/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
@@ -486,6 +486,9 @@
                     "keng__dataPath": getUserWorkspacePath() + "/" + vdbName + "/vdb:dataRoles/" + READ_ONLY_DATA_ROLE_NAME,
                     "vdb__dataRole": READ_ONLY_DATA_ROLE_NAME,
                     "vdb__description": "The default read-only access data role.",
+                    "vdb__grantAll": false,
+                    "vdb__anyAuthenticated": true,
+                    "vdb__allowCreateTemporaryTables": false,
                     "vdb__permissions": [
                         {
                             "keng__id": VIEW_MODEL,
@@ -496,7 +499,6 @@
                             "vdb__allowCreate": false,
                             "vdb__allowDelete": false,
                             "vdb__allowExecute": false,
-                            "vdb__allowLanguage": false,
                             "vdb__allowRead": true,
                             "vdb__allowUpdate": false
                         },
@@ -509,7 +511,6 @@
                             "vdb__allowCreate": false,
                             "vdb__allowDelete": false,
                             "vdb__allowExecute": false,
-                            "vdb__allowLanguage": false,
                             "vdb__allowRead": true,
                             "vdb__allowUpdate": false
                         }
@@ -527,7 +528,6 @@
 	                        "vdb__allowCreate": false,
 	                        "vdb__allowDelete": false,
 	                        "vdb__allowExecute": false,
-	                        "vdb__allowLanguage": false,
 	                        "vdb__allowRead": true,
 	                        "vdb__allowUpdate": false
                         }

--- a/vdb-bench-assembly/plugins/vdb-bench-core/constants.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/constants.js
@@ -98,6 +98,7 @@
             MODEL: '/Model',
             MODELS: '/Models',
             MODEL_SOURCES: '/VdbModelSources',
+            DATA_ROLES: '/VdbDataRoles',
             SAVE_SEARCH: 'saveSearch',
             SAVED_SEARCHES: '/savedSearches',
             SEARCH_CONTAINS: 'contains',

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/content/css/styles.less
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/content/css/styles.less
@@ -707,7 +707,10 @@ button[id^='dropdownKebabRight_'] {
     border: 3px dashed #AAAAAA;
     height: 75px;
     min-height: 75px;
-    margin: 10px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    margin-left: 0px;
+    margin-right: 0px;
     padding-left: 0.5em;
     padding-right: 0.5em;
 }
@@ -716,7 +719,10 @@ button[id^='dropdownKebabRight_'] {
     border: 3px dashed #111111;
     height: 75px;
     min-height: 75px;
-    margin: 10px;
+    margin-top: 10px;
+    margin-bottom: 10px;
+    margin-left: 0px;
+    margin-right: 0px;
     padding-left: 0.5em;
     padding-right: 0.5em;
     background-color: #def3ff;
@@ -771,6 +777,13 @@ button[id^='dropdownKebabRight_'] {
 
 .dsb-wizard-container .wizard-pf-main {
     padding: 0em 2em 0em 2em !important;
+}
+
+.dsb-wizard-sources-container {
+    margin-left: 0px;
+    margin-right: 0px;
+    padding-left: 0px;
+    padding-right: 0px;
 }
 
 .dsb-modal {

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-edit.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-edit.html
@@ -25,7 +25,7 @@
                     <dataservice-edit-wizard></dataservice-edit-wizard>
                 </uib-tab>
                 <uib-tab heading="{{:: 'dataservice-edit.expertTab' | translate}}" active="vm.expertTabActive" disable="vm.disableExpertTab" ng-click="vm.onExpertTabSelected()">
-                    <div class="col-md-12">
+                    <div class="row">
                         <h4 class="pull-left">{{'dataservice-edit.viewDdlTitle' | translate}}</h4>
                     </div>
                     <div class="col-md-8">
@@ -35,10 +35,40 @@
                             <span class="help-block">{{vm.ddlErrorMsg}}</span>
                         </div>
                     </div>
-                    <div class="col-md-4">
-                        <h5>{{'dataservice-edit.viewTablesTitle' | translate}}</h5>
+                    <div class = "col-md-4 dsb-wizard-sources-container">
+                        <div class = "row dsb-wizard-sources-container">
+	                        <h5 class = "pull-left">{{'dataservice-edit.viewTablesTitle' | translate}}</h5>
+	
+		                    <!-- checkbox indicating if the data sources are read-only -->
+		                	<div class = "pull-right">
+			                    <div class = "checkbox checkbox-primary">
+				                    <input type = "checkbox"
+				                           ng-model = "vm.readOnlyAccess"
+				                           ng-init = "vm.readOnlyAccess">
+			                        <h4 style = "display:inline">
+			                            <strong translate = "editWizardService.ReadOnlyAccess" />
+		                                <label class = "help-label"
+		                                       style = "padding-left: 5px;">
+		                                    <span class = "fa fa-info-circle"
+		                                          uib-tooltip = "{{ 'editWizardService.help.readOnlyAccess' | translate }}"
+		                                          tooltip-class = "custom-tooltip"
+		                                          tooltip-append-to-body = "true">
+		                                    </span>
+		                                </label>
+			                        </h4>
+			                    </div>
+			                </div>
+			            </div>
+
+		                <!-- Warning message when the data sources are updatable -->
+                        <div class = "row toast-pf alert alert-warning"
+                             ng-show = "!vm.readOnlyAccess">
+                            <span class = "pficon pficon-warning-triangle-o" />
+                            <span translate = "editWizardService.dataSourcesUpdatableMsg" />
+                        </div>
+
                         <!-- Tree control to display tables / columns -->
-                        <div class="tree-control-container">
+                        <div class="row tree-control-container">
                             <!-- No Content Message -->
                             <div ng-show="vm.treedata.length == 0">
                                 <h4 translate="dataservice-edit.noContent"></h4>
@@ -54,7 +84,8 @@
                                 </div>
                             </div>
                         </div>
-                    </div>
+		            </div>
+                    
                     <div class="col-md-12">
                         <p>&nbsp;</p>
                         <input type="submit" class="btn btn-primary" value="{{:: 'shared.Finish' | translate}}" ng-click="vm.finishClicked()" ng-disabled="vm.disableFinish" />

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-new.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-new.html
@@ -33,8 +33,38 @@
                             <span class="help-block">{{vm.ddlErrorMsg}}</span>
                         </div>
                     </div>
-                    <div class="col-md-4">
-                        <h5>{{'dataservice-new.viewTablesTitle' | translate}}</h5>
+                    <div class="col-md-4 dsb-wizard-sources-container">
+                        <div class = "row dsb-wizard-sources-container">
+                            <h5 class = "pull-left">{{'dataservice-new.viewTablesTitle' | translate}}</h5>
+	
+		                    <!-- checkbox indicating if the data sources are read-only -->
+		                	<div class = "pull-right">
+			                    <div class = "checkbox checkbox-primary">
+				                    <input type = "checkbox"
+				                           ng-model = "vm.readOnlyAccess"
+				                           ng-init = "vm.readOnlyAccess">
+			                        <h4 style = "display:inline">
+			                            <strong translate = "editWizardService.ReadOnlyAccess" />
+		                                <label class = "help-label"
+		                                       style = "padding-left: 5px;">
+		                                    <span class = "fa fa-info-circle"
+		                                          uib-tooltip = "{{ 'editWizardService.help.readOnlyAccess' | translate }}"
+		                                          tooltip-class = "custom-tooltip"
+		                                          tooltip-append-to-body = "true">
+		                                    </span>
+		                                </label>
+			                        </h4>
+			                    </div>
+			                </div>
+			            </div>
+
+		                <!-- Warning message when the data sources are updatable -->
+                        <div class = "row toast-pf alert alert-warning"
+                             ng-show = "!vm.readOnlyAccess">
+                            <span class = "pficon pficon-warning-triangle-o" />
+                            <span translate = "editWizardService.dataSourcesUpdatableMsg" />
+                        </div>
+
                         <!-- Tree control to display tables / columns -->
                         <div class="tree-control-container">
                             <!-- No Content Message -->

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsEditController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsEditController.js
@@ -346,7 +346,7 @@
                     var relativeModelSourcePath = vm.sourceNames[0]+"/"+selSvcSourceModelName+"/vdb:sources/"+selSvcSourceModelName;
                     var relativeTablePath = vm.sourceNames[0]+"/"+selSvcSourceModelName+"/"+vm.tableNames[0];
 
-                    setDataServiceVdbForSingleTable(dataserviceName, selSvcSourceModelName, relativeModelSourcePath, vm.viewDdl, relativeTablePath);
+                    setDataServiceVdbForSingleTable(dataserviceName, vm.sourceNames[0], relativeModelSourcePath, vm.viewDdl, relativeTablePath);
                 };
 
                 // Failure callback
@@ -379,7 +379,7 @@
                     // Join type
                     var joinType = EditWizardService.joinType();
 
-                    setDataServiceVdbForJoinTables(dataserviceName, lhSourceModelName, lhRelativeModelSourcePath, rhSourceModelName, rhRelativeModelSourcePath, vm.viewDdl,
+                    setDataServiceVdbForJoinTables(dataserviceName, vm.sourceNames[0], lhRelativeModelSourcePath, vm.sourceNames[1], rhRelativeModelSourcePath, vm.viewDdl,
                             lhRelativeTablePath, rhRelativeTablePath);
                 };
 

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsEditController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsEditController.js
@@ -29,6 +29,7 @@
         vm.ddlErrorMsg = "";
         vm.treedata = [];
         vm.initialExpandedNodes = [];
+        vm.readOnlyAccess = EditWizardService.isReadOnlyAccess();
 
         /*
          * Set a custom title to the page including the data service's id
@@ -345,7 +346,7 @@
                     var relativeModelSourcePath = vm.sourceNames[0]+"/"+selSvcSourceModelName+"/vdb:sources/"+selSvcSourceModelName;
                     var relativeTablePath = vm.sourceNames[0]+"/"+selSvcSourceModelName+"/"+vm.tableNames[0];
 
-                    setDataServiceVdbForSingleTable(dataserviceName, relativeModelSourcePath, vm.viewDdl, relativeTablePath);
+                    setDataServiceVdbForSingleTable(dataserviceName, selSvcSourceModelName, relativeModelSourcePath, vm.viewDdl, relativeTablePath);
                 };
 
                 // Failure callback
@@ -378,7 +379,7 @@
                     // Join type
                     var joinType = EditWizardService.joinType();
 
-                    setDataServiceVdbForJoinTables(dataserviceName, lhRelativeModelSourcePath, rhRelativeModelSourcePath, vm.viewDdl,
+                    setDataServiceVdbForJoinTables(dataserviceName, lhSourceModelName, lhRelativeModelSourcePath, rhSourceModelName, rhRelativeModelSourcePath, vm.viewDdl,
                             lhRelativeTablePath, rhRelativeTablePath);
                 };
 
@@ -420,15 +421,50 @@
             mode: 'text/x-sql'
         };
 
+        function setDefaultReadOnlyDataRole( dataServiceName, readOnly, model1Name, model2Name ) {
+            try {
+        		if ( readOnly ) {
+                	// always delete since if readOnly it is not needed or if !readOnly the models may have changed
+//            		RepoRestService.deleteDefaultReadOnlyDataRole( dataServiceName );
+
+            		RepoRestService.createDefaultReadOnlyDataRole( dataServiceName, model1Name, model2Name ).then(
+                        function () {
+                            // Reinitialise the list of data services
+                            DSSelectionService.refresh( 'dataservice-summary' );
+                        },
+                        function ( response ) {
+                            vm.showDdlError = true;
+                            vm.ddlErrorMsg = RepoRestService.responseMessage( response );
+                            RepoRestService.deleteDataService( dataServiceName );
+                        }
+                    );
+            	} else {
+            		RepoRestService.deleteDefaultReadOnlyDataRole( dataServiceName ).then(
+                        function () {
+                            DSSelectionService.refresh( 'dataservice-summary' );
+                        },
+                        function ( response ) {
+                            vm.showDdlError = true;
+                            vm.ddlErrorMsg = RepoRestService.responseMessage( response );
+                            RepoRestService.deleteDataService( dataServiceName );
+                        }
+                    );
+            	}
+            } catch ( error ) {
+                vm.showDdlError = true;
+                vm.ddlErrorMsg = RepoRestService.responseMessage(response);
+                RepoRestService.deleteDataService( dataServiceName );
+            }
+        }
+
         /**
          * Set the dataservice VDB.  If fails, delete the dataservice
          */
-        function setDataServiceVdbForSingleTable( dataserviceName, relativeModelSourcePath, ddl, relativeTablePath ) {
+        function setDataServiceVdbForSingleTable( dataserviceName, modelName, relativeModelSourcePath, ddl, relativeTablePath ) {
             try {
                 RepoRestService.setDataServiceVdbForSingleTable( dataserviceName, relativeModelSourcePath, ddl, relativeTablePath, null ).then(
                     function () {
-                        // Reinitialise the list of data services
-                        DSSelectionService.refresh('dataservice-summary');
+                        setDefaultReadOnlyDataRole( dataserviceName, vm.readOnlyAccess, modelName, null );
                     },
                     function (response) {
                         vm.showDdlError = true;
@@ -443,14 +479,13 @@
         /**
          * Set the dataservice VDB.  If fails, delete the dataservice
          */
-        function setDataServiceVdbForJoinTables(dataserviceName, lhRelativeModelSourcePath, rhRelativeModelSourcePath, ddl,
+        function setDataServiceVdbForJoinTables(dataserviceName, lhModelName, lhRelativeModelSourcePath, rhModelName, rhRelativeModelSourcePath, ddl,
                 lhRelativeTablePath, rhRelativeTablePath) {
             try {
                 RepoRestService.setDataServiceVdbForJoinTables( dataserviceName, lhRelativeModelSourcePath, rhRelativeModelSourcePath, ddl,
                                                                 lhRelativeTablePath, null, rhRelativeTablePath, null, null, null, null).then(
                     function () {
-                        // Reinitialise the list of data services
-                        DSSelectionService.refresh('dataservice-summary');
+                        setDefaultReadOnlyDataRole( dataserviceName, vm.readOnlyAccess, lhModelName, rhModelName );
                     },
                     function (response) {
                         vm.showDdlError = true;
@@ -461,6 +496,10 @@
                 vm.ddlErrorMsg = RepoRestService.responseMessage(response);
             }
         }
+
+        $scope.$watch( 'vm.readOnlyAccess', function( newValue, oldValue ) {
+            EditWizardService.setReadOnlyAccess( newValue );
+        });
 
     }
     

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsNewController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsNewController.js
@@ -292,7 +292,7 @@
                     var relativeModelSourcePath = sourceName+"/"+selSvcSourceModelName+"/vdb:sources/"+selSvcSourceModelName;
                     var relativeTablePath = sourceName+"/"+selSvcSourceModelName+"/"+tableName;
 
-                    setDataServiceVdbForSingleTable(dataserviceName, selSvcSourceModelName, relativeModelSourcePath, vm.viewDdl, relativeTablePath);
+                    setDataServiceVdbForSingleTable(dataserviceName, sourceName, relativeModelSourcePath, vm.viewDdl, relativeTablePath);
                 };
 
                 // Failure callback
@@ -322,7 +322,7 @@
                     var rhRelativeModelSourcePath = vm.sourceNames[1]+"/"+rhSourceModelName+"/vdb:sources/"+rhSourceModelName;
                     var rhRelativeTablePath = vm.sourceNames[1]+"/"+rhSourceModelName+"/"+vm.tableNames[1];
 
-                    setDataServiceVdbForJoinTables(dataserviceName, lhSourceModelName, lhRelativeModelSourcePath, rhSourceModelName, rhRelativeModelSourcePath, vm.viewDdl,
+                    setDataServiceVdbForJoinTables(dataserviceName, vm.sourceNames[0], lhRelativeModelSourcePath, vm.sourceNames[1], rhRelativeModelSourcePath, vm.viewDdl,
                                                                     lhRelativeTablePath, rhRelativeTablePath);
                 };
 

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsNewController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsNewController.js
@@ -26,6 +26,7 @@
         vm.ddlErrorMsg = "";
         vm.treedata = [];
         vm.initialExpandedNodes = [];
+        vm.readOnlyAccess = EditWizardService.isReadOnlyAccess();
 
         vm.editorLoaded = function(_editor) {
             if (! _editor)
@@ -291,7 +292,7 @@
                     var relativeModelSourcePath = sourceName+"/"+selSvcSourceModelName+"/vdb:sources/"+selSvcSourceModelName;
                     var relativeTablePath = sourceName+"/"+selSvcSourceModelName+"/"+tableName;
 
-                    setDataServiceVdbForSingleTable(dataserviceName, relativeModelSourcePath, vm.viewDdl, relativeTablePath);
+                    setDataServiceVdbForSingleTable(dataserviceName, selSvcSourceModelName, relativeModelSourcePath, vm.viewDdl, relativeTablePath);
                 };
 
                 // Failure callback
@@ -321,7 +322,7 @@
                     var rhRelativeModelSourcePath = vm.sourceNames[1]+"/"+rhSourceModelName+"/vdb:sources/"+rhSourceModelName;
                     var rhRelativeTablePath = vm.sourceNames[1]+"/"+rhSourceModelName+"/"+vm.tableNames[1];
 
-                    setDataServiceVdbForJoinTables(dataserviceName, lhRelativeModelSourcePath, rhRelativeModelSourcePath, vm.viewDdl,
+                    setDataServiceVdbForJoinTables(dataserviceName, lhSourceModelName, lhRelativeModelSourcePath, rhSourceModelName, rhRelativeModelSourcePath, vm.viewDdl,
                                                                     lhRelativeTablePath, rhRelativeTablePath);
                 };
 
@@ -363,15 +364,50 @@
             mode: 'text/x-sql'
         };
 
+        function setDefaultReadOnlyDataRole( dataServiceName, readOnly, model1Name, model2Name ) {
+            try {
+        		if ( readOnly ) {
+                	// always delete since if readOnly it is not needed or if !readOnly the models may have changed
+//            		RepoRestService.deleteDefaultReadOnlyDataRole( dataServiceName );
+
+            		RepoRestService.createDefaultReadOnlyDataRole( dataServiceName, model1Name, model2Name ).then(
+                        function () {
+                            // Reinitialise the list of data services
+                            DSSelectionService.refresh( 'dataservice-summary' );
+                        },
+                        function ( response ) {
+                            vm.showDdlError = true;
+                            vm.ddlErrorMsg = RepoRestService.responseMessage( response );
+                            RepoRestService.deleteDataService( dataServiceName );
+                        }
+                    );
+            	} else {
+            		RepoRestService.deleteDefaultReadOnlyDataRole( dataServiceName ).then(
+                        function () {
+                            DSSelectionService.refresh( 'dataservice-summary' );
+                        },
+                        function ( response ) {
+                            vm.showDdlError = true;
+                            vm.ddlErrorMsg = RepoRestService.responseMessage( response );
+                            RepoRestService.deleteDataService( dataServiceName );
+                        }
+                    );
+            	}
+            } catch ( error ) {
+                vm.showDdlError = true;
+                vm.ddlErrorMsg = RepoRestService.responseMessage(response);
+                RepoRestService.deleteDataService( dataServiceName );
+            }
+        }
+
         /**
          * Set the dataservice VDB.  If fails, delete the dataservice
          */
-        function setDataServiceVdbForSingleTable( dataserviceName, relativeModelSourcePath, ddl, relativeTablePath ) {
+        function setDataServiceVdbForSingleTable( dataserviceName, modelName, relativeModelSourcePath, ddl, relativeTablePath ) {
             try {
                 RepoRestService.setDataServiceVdbForSingleTable( dataserviceName, relativeModelSourcePath, ddl, relativeTablePath, null ).then(
                     function () {
-                        // Reinitialise the list of data services
-                        DSSelectionService.refresh('dataservice-summary');
+                        setDefaultReadOnlyDataRole( dataserviceName, vm.readOnlyAccess, modelName, null );
                     },
                     function (response) {
                         vm.showDdlError = true;
@@ -388,14 +424,13 @@
         /**
          * Set the dataservice VDB.  If fails, delete the dataservice
          */
-        function setDataServiceVdbForJoinTables(dataserviceName, lhRelativeModelSourcePath, rhRelativeModelSourcePath, ddl,
+        function setDataServiceVdbForJoinTables(dataserviceName, lhModelName, lhRelativeModelSourcePath, rhModelName, rhRelativeModelSourcePath, ddl,
                 lhRelativeTablePath, rhRelativeTablePath) {
             try {
                 RepoRestService.setDataServiceVdbForJoinTables( dataserviceName, lhRelativeModelSourcePath, rhRelativeModelSourcePath, ddl,
                                                                 lhRelativeTablePath, null, rhRelativeTablePath, null, null, null, null).then(
                     function () {
-                        // Reinitialise the list of data services
-                        DSSelectionService.refresh('dataservice-summary');
+                        setDefaultReadOnlyDataRole( dataserviceName, vm.readOnlyAccess, lhModelName, rhModelName );
                     },
                     function (response) {
                         vm.showDdlError = true;
@@ -408,6 +443,10 @@
                 RepoRestService.deleteDataService( dataserviceName );
             }
         }
+
+        $scope.$watch( 'vm.readOnlyAccess', function( newValue, oldValue ) {
+            EditWizardService.setReadOnlyAccess( newValue );
+        });
 
     }
 

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.html
@@ -55,76 +55,104 @@
                         </div>
                     </form>
                 </div>
-                <div class="col-md-4">
-                    <h3><strong translate="dataserviceEditWizard.dataSources" />
-                        <label class="help-label">
-                            <span class="fa fa-info-circle" uib-tooltip="{{ 'dataserviceEditWizard.help.dataSources' | translate }}"
-                                  tooltip-class="custom-tooltip" tooltip-append-to-body="true"></span>
-                        </label>
-                    </h3>
-                </div>
-                <div class="col-md-6">
-                    <h3><strong translate="dataserviceEditWizard.selectedTables" />
-                        <label class="help-label">
-                            <span class="fa fa-info-circle" uib-tooltip-html="{{ 'dataserviceEditWizard.help.selectedTables' | translate }}"
-                                  tooltip-class="custom-tooltip" tooltip-append-to-body="true"></span>
-                        </label>
-                    </h3>
-                </div>
-                <div class="col-md-2">
-                </div>
-                <!-- Source-Table Tree Control -->
-                <div class="tree-control-container col-md-4">
-                    <!-- Spinner when loading -->
-                    <div ng-show="vm.treeLoading==true">
-                        <div class="spinner spinner-lg" />
-                    </div>
-                    <!-- No Content Message -->
-                    <div ng-show="vm.treeLoading==false && vm.treedata.length == 0 && !vm.hasTreeFetchError">
-                        <h5 style="color:red" translate="dataserviceEditWizard.noTreeContent"></h5>
-                    </div>
-                    <!-- Fetch Content Error Message -->
-                    <div ng-show="vm.treeLoading==false && vm.hasTreeFetchError">
-                        <h4>{{vm.treeFetchErrorMsg}}</h4>
-                    </div>
-                    <div class="tree-control-inner-container" ng-show="vm.treeLoading==false">
-                        <!-- tree control for catalog and schema -->
-                        <treecontrol class="tree-light tree-control-results" 
-                             tree-model="vm.treedata" 
-                             selected-node="vm.initialTreeNodeSelection" 
-                             on-selection="vm.treeSelectionChanged(node,selected,$parentNode)" 
-                             expanded-nodes="vm.initialTreeExpandedNodes" 
-                             on-node-toggle="vm.treeExpansionChanged(node,expanded)">
-                             <span ng-switch="" on="node.type">
-                                 <span ng-switch-when="source" class="fa fa-database" aria-hidden="true"></span>
-                                 <span ng-switch-when="table" class="fa fa-table" aria-hidden="true"></span>
-                                 <span ng-switch-when="loading" class="spinner spinner-lg" aria-hidden="true"></span>
-                             </span>
-                            {{node.name}}
-                        </treecontrol>
-                    </div>
-                </div>
-                <div class="col-md-4">
-                    <div class="{{vm.table1Style}}">
-                        <div class="col-md-1 pull-right">
-                            <button id="btn-remove-table1-selection" class="btn btn-xs pficon pficon-close" ng-click="vm.removeTable1Selection()"></button>
+                <div class = "row">
+	                <div class="col-md-5 dsb-wizard-sources-container">
+	                    <h3><strong translate="dataserviceEditWizard.dataSources" />
+	                        <label class="help-label">
+	                            <span class="fa fa-info-circle" uib-tooltip="{{ 'dataserviceEditWizard.help.dataSources' | translate }}"
+	                                  tooltip-class="custom-tooltip" tooltip-append-to-body="true"></span>
+	                        </label>
+	                    </h3>
+		                <!-- Source-Table Tree Control -->
+		                <div class="tree-control-container">
+		                    <!-- Spinner when loading -->
+		                    <div ng-show="vm.treeLoading==true">
+		                        <div class="spinner spinner-lg" />
+		                    </div>
+		                    <!-- No Content Message -->
+		                    <div ng-show="vm.treeLoading==false && vm.treedata.length == 0 && !vm.hasTreeFetchError">
+		                        <h5 style="color:red" translate="dataserviceEditWizard.noTreeContent"></h5>
+		                    </div>
+		                    <!-- Fetch Content Error Message -->
+		                    <div ng-show="vm.treeLoading==false && vm.hasTreeFetchError">
+		                        <h4>{{vm.treeFetchErrorMsg}}</h4>
+		                    </div>
+		                    <div class="tree-control-inner-container" ng-show="vm.treeLoading==false">
+		                        <!-- tree control for catalog and schema -->
+		                        <treecontrol class="tree-light tree-control-results" 
+		                             tree-model="vm.treedata" 
+		                             selected-node="vm.initialTreeNodeSelection" 
+		                             on-selection="vm.treeSelectionChanged(node,selected,$parentNode)" 
+		                             expanded-nodes="vm.initialTreeExpandedNodes" 
+		                             on-node-toggle="vm.treeExpansionChanged(node,expanded)">
+		                             <span ng-switch="" on="node.type">
+		                                 <span ng-switch-when="source" class="fa fa-database" aria-hidden="true"></span>
+		                                 <span ng-switch-when="table" class="fa fa-table" aria-hidden="true"></span>
+		                                 <span ng-switch-when="loading" class="spinner spinner-lg" aria-hidden="true"></span>
+		                             </span>
+		                            {{node.name}}
+		                        </treecontrol>
+		                    </div>
+		                </div>
+	                </div>
+	                <div class="col-md-7 dsb-wizard-sources-container">
+	                    <h3><strong translate="dataserviceEditWizard.selectedTables" />
+	                        <label class="help-label">
+	                            <span class="fa fa-info-circle" uib-tooltip-html="{{:: 'dataserviceEditWizard.help.selectedTables' | translate }}"
+	                                  tooltip-class="custom-tooltip" tooltip-append-to-body="true"></span>
+	                        </label>
+	                    </h3>
+		                
+		                <!-- Warning message when the data sources are updatable -->
+                        <div class = "row toast-pf alert alert-warning"
+                             ng-show = "!vm.readOnlyAccess">
+                            <span class = "pficon pficon-warning-triangle-o" />
+                            <span translate = "editWizardService.dataSourcesUpdatableMsg" />
                         </div>
-                        <h4><strong>{{vm.selectedSources[0]}}</strong></h4>
-                        <h3>&nbsp;&nbsp;{{vm.selectedTables[0]}}</h4>
+	
+		                <div class = "col-md-8">
+		                    <div class="{{vm.table1Style}}">
+		                        <div class="col-md-1 pull-right">
+		                            <button id="btn-remove-table1-selection" class="btn btn-xs pficon pficon-close" ng-click="vm.removeTable1Selection()"></button>
+		                        </div>
+		                        <h4><strong>{{vm.selectedSources[0]}}</strong></h4>
+		                        <h3>&nbsp;&nbsp;{{vm.selectedTables[0]}}</h4>
+		                    </div>
+		                    <div class="{{vm.table2Style}}">
+		                        <div class="col-md-1 pull-right">
+		                            <button id="btn-remove-table2-selection" class="btn btn-xs pficon pficon-close" ng-click="vm.removeTable2Selection()"></button>
+		                        </div>
+		                        <h4><strong>{{vm.selectedSources[1]}}</strong></h4>
+		                        <h3>&nbsp;&nbsp;{{vm.selectedTables[1]}}</h4>
+		                    </div>
+		                </div>
+      
+	                    <div class = "col-md-4">
+		                    <div class = "checkbox checkbox-primary"
+		                         ng-show = "vm.selectedTables != 0">
+			                    <input type = "checkbox"
+			                           ng-model = "vm.readOnlyAccess"
+			                           ng-init = "vm.readOnlyAccess">
+		                        <h4 style = "display:inline">
+		                            <strong translate = "editWizardService.ReadOnlyAccess" />
+	                                <label class = "help-label"
+	                                       style = "padding-left: 5px;">
+	                                    <span class = "fa fa-info-circle"
+	                                          uib-tooltip = "{{ 'editWizardService.help.readOnlyAccess' | translate }}"
+	                                          tooltip-class = "custom-tooltip"
+	                                          tooltip-append-to-body = "true">
+	                                    </span>
+	                                </label>
+		                        </h4>
+		                    </div>
+		                    <div class = "checkbox checkbox-primary" ng-show="vm.selectedTables.length==1">
+		                        <input type="checkbox" ng-model="vm.includeAllColumns" ng-true-value=true ng-false-value=false ng-change="vm.includeAllColumnsCheckboxChanged()">
+		                        <h4 style="display:inline">
+		                            <strong translate = "dataserviceEditWizard.IncludeAllColumns" />
+		                        </h4>
+		                    </div>
+		                </div>
                     </div>
-                    <div class="{{vm.table2Style}}">
-                        <div class="col-md-1 pull-right">
-                            <button id="btn-remove-table2-selection" class="btn btn-xs pficon pficon-close" ng-click="vm.removeTable2Selection()"></button>
-                        </div>
-                        <h4><strong>{{vm.selectedSources[1]}}</strong></h4>
-                        <h3>&nbsp;&nbsp;{{vm.selectedTables[1]}}</h4>
-                    </div>
-                </div>
-                <div class="col-md-2">
-                    <form ng-show="vm.selectedTables.length==1">
-                        <input type="checkbox" ng-model="vm.includeAllColumns" ng-true-value=true ng-false-value=false ng-change="vm.includeAllColumnsCheckboxChanged()">
-                        <h4 style="display:inline"><strong>Include All Columns</strong></h4><h4>
-                    </form>
                 </div>
             </div>
 

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.js
@@ -633,7 +633,7 @@
                     try {
                         RepoRestService.setDataServiceVdbForSingleTable( dataserviceName, relativeModelSourcePath, null, relativeTablePath, columnNames ).then(
                             function () {
-                            	setDefaultReadOnlyDataRole( dataserviceName, vm.readOnlyAccess, selSvcSourceModelName, null );
+                            	setDefaultReadOnlyDataRole( dataserviceName, vm.readOnlyAccess, sourceNames[0], null );
                             },
                             function (response) {
                                 throw RepoRestService.newRestException($translate.instant('dsNewController.saveFailedMsg', 
@@ -689,7 +689,7 @@
                                                                                          rhRelativeTablePath, rhColumnNames, 
                                                                                          joinType, criteriaPredicates).then(
                             function () {
-                            	setDefaultReadOnlyDataRole( dataserviceName, vm.readOnlyAccess, lhSourceModelName, rhSourceModelName );
+                            	setDefaultReadOnlyDataRole( dataserviceName, vm.readOnlyAccess, sourceNames[0], sourceNames[1] );
                             },
                             function (response) {
                                 throw RepoRestService.newRestException($translate.instant('dsNewController.saveFailedMsg', 

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/dataserviceEditWizard.js
@@ -51,6 +51,8 @@
         vm.buildVdbIndex = 0;
         vm.table1Style = STYLES.DSWIZARD_TABLE_NOT_SELECTED;
         vm.table2Style = STYLES.DSWIZARD_TABLE_NOT_SELECTED;
+        
+        vm.readOnlyAccess = EditWizardService.isReadOnlyAccess();
 
         /*
          * page init here
@@ -631,8 +633,7 @@
                     try {
                         RepoRestService.setDataServiceVdbForSingleTable( dataserviceName, relativeModelSourcePath, null, relativeTablePath, columnNames ).then(
                             function () {
-                                // Reinitialise the list of data services
-                                DSSelectionService.refresh('dataservice-summary');
+                            	setDefaultReadOnlyDataRole( dataserviceName, vm.readOnlyAccess, selSvcSourceModelName, null );
                             },
                             function (response) {
                                 throw RepoRestService.newRestException($translate.instant('dsNewController.saveFailedMsg', 
@@ -688,8 +689,7 @@
                                                                                          rhRelativeTablePath, rhColumnNames, 
                                                                                          joinType, criteriaPredicates).then(
                             function () {
-                                // Reinitialise the list of data services
-                                DSSelectionService.refresh('dataservice-summary');
+                            	setDefaultReadOnlyDataRole( dataserviceName, vm.readOnlyAccess, lhSourceModelName, rhSourceModelName );
                             },
                             function (response) {
                                 throw RepoRestService.newRestException($translate.instant('dsNewController.saveFailedMsg', 
@@ -706,6 +706,51 @@
 
                 // get models for sources
                 EditWizardService.getModelsForSourceVdbs(EditWizardService.sources(), joinSuccessCallback, joinFailureCallback);
+            }
+        }
+
+        function setDefaultReadOnlyDataRole( dataServiceName, readOnly, model1Name, model2Name ) {
+            try {
+        		if ( readOnly ) {
+                	// always delete since when readOnly it is not needed or when !readOnly the models may have changed
+            		RepoRestService.deleteDefaultReadOnlyDataRole( dataServiceName ).then(
+                        function () {
+                    		RepoRestService.createDefaultReadOnlyDataRole( dataServiceName, model1Name, model2Name ).then(
+                                function () {
+                                    // Reinitialise the list of data services
+                                    DSSelectionService.refresh( 'dataservice-summary' );
+                                },
+                                function ( response ) {
+                                    vm.showDdlError = true;
+                                    vm.ddlErrorMsg = RepoRestService.responseMessage( response );
+                                    RepoRestService.deleteDataService( dataServiceName );
+                                }
+                            );
+                        },
+                        function ( response ) {
+                            vm.showDdlError = true;
+                            vm.ddlErrorMsg = RepoRestService.responseMessage( response );
+                            RepoRestService.deleteDataService( dataServiceName );
+                        }
+            		);
+            	} else {
+            		RepoRestService.deleteDefaultReadOnlyDataRole( dataServiceName ).then(
+                        function () {
+                            DSSelectionService.refresh( 'dataservice-summary' );
+                        },
+                        function ( response ) {
+                        	if ( response.status != 404 ) {
+	                            vm.showDdlError = true;
+	                            vm.ddlErrorMsg = RepoRestService.responseMessage( response );
+	                            RepoRestService.deleteDataService( dataServiceName );
+                        	}
+                        }
+                    );
+            	}
+            } catch ( error ) {
+                vm.showDdlError = true;
+                vm.ddlErrorMsg = RepoRestService.responseMessage(response);
+                RepoRestService.deleteDataService( dataServiceName );
             }
         }
 
@@ -741,6 +786,10 @@
 
             updateInstructionMessage();
         }
+
+        $scope.$watch( 'vm.readOnlyAccess', function( newValue, oldValue ) {
+            EditWizardService.setReadOnlyAccess( newValue );
+        });
 
         /**
          * Handles next button enablement and text whenever the service name changes.


### PR DESCRIPTION
- Added checkbox to data service wizard to indicate if service should have read-only access or be updatable
- Added data role related methods to the RepositoryRestService
- Creates a read-only access data role and permission on the models of the service
- Minor tweaks to the wizard layout
- Displays an inline notification when read-only access is unchecked.