### PR TITLE
TEIIDTOOLS-209 Switch to expert tab modifications

### DIFF
--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -221,6 +221,7 @@
     },
 
     "dsEditController" : {
+        "incompleteSelectionsMsg" : "Please complete all wizard selections before switching to expert tab.",
         "confirmExpertMsg" : "Switching to Expert mode requires you to finish your edits in expert mode.  Please confirm.",
         "enterViewDefnMsg" : "Enter a View Definition",
         "updateDataserviceFailedMsg" : "Failed to update the data service",
@@ -257,6 +258,7 @@
     },
 
     "dsNewController" : {
+        "incompleteSelectionsMsg" : "Please complete all wizard selections before switching to expert tab.",
         "createDataserviceFailedMsg" : "Failed to create the data service",
         "enterViewDefnMsg" : "Enter a View Definition",
         "saveFailedMsg" : "Failed to update the data service: {{response}}"

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-new.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-new.html
@@ -19,10 +19,10 @@
                 <span>{{vmmain.page('svcsource-new').title}}</span></a>
             </h4>
             <uib-tabset>
-                <uib-tab heading="{{:: 'dataservice-new.wizardTab' | translate}}">
+                <uib-tab heading="{{:: 'dataservice-new.wizardTab' | translate}}" active="vm.wizardTabActive">
                     <dataservice-edit-wizard></dataservice-edit-wizard>
                 </uib-tab>
-                <uib-tab heading="{{:: 'dataservice-new.expertTab' | translate}}" disable="vm.disableExpertTab" ng-click="vm.onExpertTabSelected()">
+                <uib-tab heading="{{:: 'dataservice-new.expertTab' | translate}}" active="vm.expertTabActive" disable="vm.disableExpertTab" ng-click="vm.onExpertTabSelected()">
                     <div class="col-md-12">
                         <h4 class="pull-left">{{'dataservice-new.viewDdlTitle' | translate}}</h4>
                     </div>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsEditController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsEditController.js
@@ -84,11 +84,20 @@
          * Expert tab selected.  Get selections from EditWizardService to populate text view.
          */
         vm.onExpertTabSelected = function() {
-            // Show the expert mode confirmation modal
-            vm.confirmExpertMsg = $translate.instant('dsEditController.confirmExpertMsg');
-            $('#confirmExpertModal').modal('show');
+            if(!vm.disableExpertTab) {
+                if(!EditWizardService.selectionsComplete()) {
+                    var incompleteSelectionsMsg = $translate.instant('dsEditController.incompleteSelectionsMsg');
+                    alert(incompleteSelectionsMsg);
+                    vm.wizardTabActive = true;
+                    vm.expertTabActive = false;
+                } else {
+                // Show the expert mode confirmation modal
+                    vm.confirmExpertMsg = $translate.instant('dsEditController.confirmExpertMsg');
+                    $('#confirmExpertModal').modal('show');
+                }
+            }
         };
-        
+
         /**
          * Switch to the Expert Tab after confirming
          */

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsNewController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsNewController.js
@@ -67,8 +67,19 @@
          * Expert tab selected.  Get selections from EditWizardService to populate text view.
          */
         vm.onExpertTabSelected = function() {
-            setViewDdlFromEditor();
-            loadTableColumnTree();
+            if(!vm.disableExpertTab) {
+                if(!EditWizardService.selectionsComplete()) {
+                    var incompleteSelectionsMsg = $translate.instant('dsNewController.incompleteSelectionsMsg');
+                    alert(incompleteSelectionsMsg);
+                    vm.wizardTabActive = true;
+                    vm.expertTabActive = false;
+                } else {
+                    vm.wizardTabActive = false;
+                    vm.expertTabActive = true;
+                    setViewDdlFromEditor();
+                    loadTableColumnTree();
+                }
+            }
         };
 
         /**

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/EditWizardService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/widgets/dataservice-wizard/EditWizardService.js
@@ -541,6 +541,63 @@
             return true;
         };
 
+        /*
+         * 'true' if wizard selections are complete.  'complete' means the selections are defined enough to generate valid DDL.
+         */
+        service.selectionsComplete = function( ) {
+            // Service Name must be defined
+            if(wiz.serviceName.length===0) return false;
+
+            // Must have at least one table selection
+            if(!wiz.sourceTables || wiz.sourceTables.length===0) return false;
+
+            // One source, must have at least one selected Column
+            if(wiz.sourceTables.length===1) {
+                if (!wiz.includeAllSource1Columns) {
+                    if(!hasSrc1ColumnSelection()) {
+                        return false;
+                    }
+                } 
+            // If two source table selections, must be 
+            //   - columns selected from source 1 or source 2
+            //   - a completed join criteria
+            } else {
+                if( ( !hasSrc1ColumnSelection() && !hasSrc2ColumnSelection() ) || !service.criteriaComplete() ) {
+                    return false;
+                }
+            }
+
+            return true;
+        };
+
+        /**
+         * Determine if at least one src1 column is selected
+         */
+        function hasSrc1ColumnSelection() {
+            var hasOne = false;
+            for(var i=0; i<wiz.src1AvailableColumns.length; i++) {
+                if(wiz.src1AvailableColumns[i].selected) {
+                    hasOne = true;
+                    break;
+                }
+            }
+            return hasOne;
+        }
+
+        /**
+         * Determine if at least one src1 column is selected
+         */
+        function hasSrc2ColumnSelection() {
+            var hasOne = false;
+            for(var i=0; i<wiz.src2AvailableColumns.length; i++) {
+                if(wiz.src2AvailableColumns[i].selected) {
+                    hasOne = true;
+                    break;
+                }
+            }
+            return hasOne;
+        }
+
         /**
          * Sets the predicate criteria based on the currently selected tables.
          * This will make a REST call to use the PK - FK relationships on the tables to determine the join criteria.


### PR DESCRIPTION
When switching from the wizard to expert tabs, the wizard state is now being checked.  If the wizard selections are not fully defined, the user is prevented from moving to the expert tab.  The user is shown a message dialog telling them to finish the wizard selections.  This should prevent invalid DDL from being generated and put into the expert tab for incomplete wizard states.