### PR TITLE
TEIIDTOOLS-243 Now displaying notification on test page for activation problems

### DIFF
--- a/vdb-bench-assembly/app/i18n/messages-en.json
+++ b/vdb-bench-assembly/app/i18n/messages-en.json
@@ -159,6 +159,7 @@
         "columnPlaceholder" : "column",
         "Columns" : "Columns",
         "conditionPlaceholder" : "condition",
+        "dataServiceDeploymentFailedMessage" : "The Data Service failed to activate.  Please correct the problem and retry",
         "deployingDataService" : "Deploying data service",
         "DescendingChoice" : "Desc",
         "endpointNotAvailableMsg" : "The endpoint is not available",

--- a/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-core/RepositoryRestService.js
@@ -1394,7 +1394,12 @@
                                 return;
                             } else if (vdb.failed) {
                                 if (failCallback) {
-                                    failCallback("Failed");
+                                    // If specific errors are available, use the first one
+                                    var msg = "Please consult the server log.";
+                                    if(vdb.errors && vdb.errors.length>0) {
+                                        msg = vdb.errors[0];
+                                    }
+                                    failCallback(msg);
                                 }
                                 $interval.cancel(promise);
                             }

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-test.html
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dataservice-test.html
@@ -1,15 +1,25 @@
 <div id="outer" class="outer-wrapper">
 	<div id="dataservice-test-container" class="container-fluid" ng-controller="DSTestController as vm">
 
-	    <!--
-	      -- Deployment
-	      -->
-	    <!-- Show spinner while deploying -->
-	    <div id="deployment-spinner" ng-show="vm.dsDeploymentInProgress==true" class="col-md-10 row">
+        <!--
+          -- Deployment
+          -->
+        <!-- Show spinner while deploying -->
+        <div id="deployment-spinner" ng-show="vm.dsDeploymentInProgress==true" class="col-md-10 row">
             <div class="spinner spinner-lg spinner-inline" />
             {{:: 'dataservice-test.deployingDataService' | translate}}
-	    </div>
-	    
+        </div>
+        
+        <!-- Deployment failure -->
+        <div id="deployment-failure" ng-show="vm.dsDeploymentInProgress==false && vm.dsDeploymentSuccess==false">
+            <!-- Error message when the vdb fails to activate -->
+            <div class = "row toast-pf alert alert-danger">
+                <span class = "pficon pficon-error-circle-o" />
+                <span translate = "dataservice-test.dataServiceDeploymentFailedMessage" />
+            </div>
+            <h4><strong>ERROR : <em>{{vm.dsDeploymentMessage}}</em></strong></h4>
+        </div>
+        
 
 	    <div id="deployed-test-search-tabs" ng-show="vm.dsDeploymentInProgress==false && vm.dsDeploymentSuccess==true">
 	        <uib-tabset>

--- a/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsTestController.js
+++ b/vdb-bench-assembly/plugins/vdb-bench-dataservice/dsTestController.js
@@ -493,9 +493,9 @@
          * When a data service is currently being deployed
          */
         $scope.$on('deployDataServiceChanged', function (event, dsDeployInProgress) {
+            vm.dsDeploymentMessage = DSSelectionService.deploymentMessage();
             vm.dsDeploymentInProgress = dsDeployInProgress;
             vm.dsDeploymentSuccess = DSSelectionService.deploymentSuccess();
-            vm.dsDeploymentMessage = DSSelectionService.deploymentMessage();
         });
 
         /**


### PR DESCRIPTION
- use specific vdb error message if available, instead of generic 'Failed' message
- adds toast notification to test page when a problem is encountered.  The specific message is shown when available, otherwise a message to consult the server log